### PR TITLE
No need to explicitly `npm install` React

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ for the web, backed by a precomputed CSS library. ~19KB minified and gzipped.
 ## Install
 
 ```
-npm install --save react react-native-web
+npm install --save react-native-web
 ```
 
 ## Use


### PR DESCRIPTION
I might be missing something, but `react` is a dependency for `react-native-web` as per `package.json`, so there is no need to explicitly `npm install` it since it will get installed anyway.