### PR TITLE
Image: 'backgroundColor' default should be 'transparent'

### DIFF
--- a/docs/components/Image.md
+++ b/docs/components/Image.md
@@ -64,7 +64,7 @@ Defaults:
 ```js
 {
   alignSelf: 'flex-start',
-  backgroundColor: 'lightGray'
+  backgroundColor: 'transparent'
 }
 ```
 

--- a/src/components/Image/index.js
+++ b/src/components/Image/index.js
@@ -17,7 +17,7 @@ const imageStyleKeys = Object.keys(ImageStylePropTypes)
 const styles = StyleSheet.create({
   initial: {
     alignSelf: 'flex-start',
-    backgroundColor: 'lightgray',
+    backgroundColor: 'transparent',
     backgroundPosition: 'center',
     backgroundRepeat: 'no-repeat',
     backgroundSize: 'cover'


### PR DESCRIPTION
Trying to render an image with transparent pixels results in a nasty background.
This doesn't happen in React Native — transparent pixels are rendered correctly.