### PR TITLE
Include react-dom package

### DIFF
--- a/config/webpack.config.publish.js
+++ b/config/webpack.config.publish.js
@@ -8,12 +8,13 @@ module.exports = assign({}, base, {
   },
   externals: [{
     'react': true,
-    'react-dom': true
+    'react-dom': true,
+    'react-dom/server': true
   }],
   output: {
     filename: 'react-native-web.js',
     library: 'ReactNativeWeb',
-    libraryTarget: 'commonjs2',
+    libraryTarget: 'umd',
     path: constants.DIST_DIRECTORY
   }
 })

--- a/examples/index.html
+++ b/examples/index.html
@@ -2,7 +2,5 @@
 <meta charset="utf-8">
 <title>React Native for Web</title>
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<meta name="description" content="The core React Native components adapted and expanded upon for the web">
-<style id="react-stylesheet"></style>
 <div id="react-root"></div>
 <script src="/examples.js"></script>

--- a/examples/index.js
+++ b/examples/index.js
@@ -2,8 +2,7 @@ import { MediaProvider, matchMedia } from 'react-media-queries'
 import App from './components/App'
 import createGetter from 'react-media-queries/lib/createMediaQueryGetter'
 import createListener from 'react-media-queries/lib/createMediaQueryListener'
-import React, { StyleSheet } from '../src'
-import ReactDOM from 'react-dom'
+import React from '../src'
 
 const mediaQueries = {
   small: '(min-width: 300px)',
@@ -12,11 +11,9 @@ const mediaQueries = {
 }
 const ResponsiveApp = matchMedia()(App)
 
-ReactDOM.render(
+React.render(
   <MediaProvider getMedia={createGetter(mediaQueries)} listener={createListener(mediaQueries)}>
     <ResponsiveApp />
   </MediaProvider>,
   document.getElementById('react-root')
 )
-
-document.getElementById('react-stylesheet').textContent = StyleSheet.renderToString()

--- a/src/components/Touchable/index.js
+++ b/src/components/Touchable/index.js
@@ -43,11 +43,11 @@ class Touchable extends React.Component {
 
   static defaultProps = {
     accessibilityRole: 'button',
-    activeOpacity: 1,
-    activeUnderlayColor: 'transparent',
-    delayLongPress: 1000,
+    activeOpacity: 0.8,
+    activeUnderlayColor: 'black',
+    delayLongPress: 500,
     delayPressIn: 0,
-    delayPressOut: 0,
+    delayPressOut: 100,
     style: styles.initial
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,8 @@
 import React from 'react'
+import ReactDOM from 'react-dom'
+import ReactDOMServer from 'react-dom/server'
 
+// api
 import StyleSheet from './modules/StyleSheet'
 
 // components
@@ -11,7 +14,25 @@ import TextInput from './components/TextInput'
 import Touchable from './components/Touchable'
 import View from './components/View'
 
+const render = (element, container, callback) => {
+  const styleElement = document.getElementById('react-stylesheet')
+  if (!styleElement) {
+    const style = `<style id='react-stylesheet'>${StyleSheet.renderToString()}</style>`
+    container.insertAdjacentHTML('beforebegin', style)
+  }
+  return ReactDOM.render(element, container, callback)
+}
+
+const renderToString = (element) => {
+  const style = `<style id='react-stylesheet'>${StyleSheet.renderToString()}</style>`
+  const html = ReactDOMServer.renderToString(element)
+  return `${style}\n${html}`
+}
+
 const ReactNative = {
+  // apis
+  StyleSheet,
+
   // components
   Image,
   ListView,
@@ -21,11 +42,10 @@ const ReactNative = {
   Touchable,
   View,
 
-  // apis
-  StyleSheet,
-
   // React
-  ...React
+  ...React,
+  render,
+  renderToString
 }
 
 module.exports = ReactNative


### PR DESCRIPTION
Example of including react-dom in react-native-web, and moving the stylesheet management into the library (no longer responsibility of app developer). Other methods on react-dom could also be included much like React Native's environment-specific additions.

Relates to #52