### PR TITLE
Add semicolons to property initializers

### DIFF
--- a/src/components/CoreComponent/index.js
+++ b/src/components/CoreComponent/index.js
@@ -29,12 +29,12 @@ class CoreComponent extends React.Component {
     style: PropTypes.object,
     testID: PropTypes.string,
     type: PropTypes.string
-  }
+  };
 
   static defaultProps = {
     accessible: true,
     component: 'div'
-  }
+  };
 
   static stylePropTypes = StylePropTypes;
 

--- a/src/components/Image/index.js
+++ b/src/components/Image/index.js
@@ -76,9 +76,9 @@ class Image extends React.Component {
     source: PropTypes.object,
     style: PropTypes.shape(ImageStylePropTypes),
     testID: CoreComponent.propTypes.testID
-  }
+  };
 
-  static stylePropTypes = ImageStylePropTypes
+  static stylePropTypes = ImageStylePropTypes;
 
   static defaultProps = {
     accessible: true,
@@ -86,7 +86,7 @@ class Image extends React.Component {
     resizeMode: 'cover',
     source: {},
     style: styles.initial
-  }
+  };
 
   _createImageLoader() {
     const { source } = this.props

--- a/src/components/ListView/index.js
+++ b/src/components/ListView/index.js
@@ -5,11 +5,11 @@ class ListView extends React.Component {
   static propTypes = {
     children: PropTypes.any,
     style: PropTypes.style
-  }
+  };
 
   static defaultProps = {
     style: {}
-  }
+  };
 
   render() {
     return (

--- a/src/components/ScrollView/index.js
+++ b/src/components/ScrollView/index.js
@@ -31,7 +31,7 @@ class ScrollView extends React.Component {
     scrollEnabled: PropTypes.bool,
     scrollEventThrottle: PropTypes.number,
     style: PropTypes.shape(ScrollViewStylePropTypes)
-  }
+  };
 
   static defaultProps = {
     contentContainerStyle: styles.initialContentContainer,
@@ -39,7 +39,7 @@ class ScrollView extends React.Component {
     scrollEnabled: true,
     scrollEventThrottle: 0,
     style: styles.initial
-  }
+  };
 
   constructor(...args) {
     super(...args)

--- a/src/components/Text/index.js
+++ b/src/components/Text/index.js
@@ -35,15 +35,15 @@ class Text extends React.Component {
     onPress: PropTypes.func,
     style: PropTypes.shape(TextStylePropTypes),
     testID: CoreComponent.propTypes.testID
-  }
+  };
 
-  static stylePropTypes = TextStylePropTypes
+  static stylePropTypes = TextStylePropTypes;
 
   static defaultProps = {
     _className: '',
     accessible: true,
     style: styles.initial
-  }
+  };
 
   _onPress(e) {
     if (this.props.onPress) this.props.onPress(e)

--- a/src/components/TextInput/index.js
+++ b/src/components/TextInput/index.js
@@ -69,9 +69,9 @@ class TextInput extends React.Component {
     style: PropTypes.shape(TextInputStylePropTypes),
     testID: CoreComponent.propTypes.testID,
     value: PropTypes.string
-  }
+  };
 
-  static stylePropTypes = TextInputStylePropTypes
+  static stylePropTypes = TextInputStylePropTypes;
 
   static defaultProps = {
     editable: true,
@@ -80,7 +80,7 @@ class TextInput extends React.Component {
     numberOfLines: 2,
     secureTextEntry: false,
     style: styles.initial
-  }
+  };
 
   _onBlur(e) {
     const { onBlur } = this.props

--- a/src/components/Touchable/index.js
+++ b/src/components/Touchable/index.js
@@ -39,7 +39,7 @@ class Touchable extends React.Component {
     onPressIn: PropTypes.func,
     onPressOut: PropTypes.func,
     style: View.propTypes.style
-  }
+  };
 
   static defaultProps = {
     accessibilityRole: 'button',
@@ -49,7 +49,7 @@ class Touchable extends React.Component {
     delayPressIn: 0,
     delayPressOut: 100,
     style: styles.initial
-  }
+  };
 
   _getChildren() {
     const { activeOpacity, children } = this.props

--- a/src/components/View/index.js
+++ b/src/components/View/index.js
@@ -41,15 +41,15 @@ class View extends React.Component {
     pointerEvents: PropTypes.oneOf(['auto', 'box-none', 'box-only', 'none']),
     style: PropTypes.shape(ViewStylePropTypes),
     testID: CoreComponent.propTypes.testID
-  }
+  };
 
-  static stylePropTypes = ViewStylePropTypes
+  static stylePropTypes = ViewStylePropTypes;
 
   static defaultProps = {
     _className: '',
     accessible: true,
     style: styles.initial
-  }
+  };
 
   render() {
     const {


### PR DESCRIPTION
According to the current proposal, semicolons are required. Babel 6.4 was updated to require them (see https://github.com/babel/babel/pull/3225). This is required in order to fix the build -- master will be red on Travis as soon as the build is rerun because it will pick up the latest Babel parser.