### PR TITLE
Minor: npm run build fails due to deprecated reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "rm -rf ./dist && mkdir dist && babel src -d dist --ignore **/__tests__,src/modules/specHelpers",
+    "build": "rm -rf ./dist && mkdir dist && babel-cli src -d dist --ignore **/__tests__,src/modules/specHelpers",
     "build:umd": "webpack --config config/webpack.config.js --sort-assets-by --progress",
     "examples": "webpack-dev-server --config config/webpack.config.example.js --inline --hot --colors --quiet",
     "lint": "eslint config examples src",


### PR DESCRIPTION
`npm install` / `npm run build` fails because Babel CLI has been moved to the new package called babel-cli.