### PR TITLE
Added support for Image.props.style.resizeMode

### DIFF
--- a/src/components/Image/ImageStylePropTypes.js
+++ b/src/components/Image/ImageStylePropTypes.js
@@ -2,6 +2,7 @@ import { PropTypes } from 'react'
 import ColorPropType from '../../apis/StyleSheet/ColorPropType'
 import LayoutPropTypes from '../../apis/StyleSheet/LayoutPropTypes'
 import TransformPropTypes from '../../apis/StyleSheet/TransformPropTypes'
+import ImageResizeMode from './ImageResizeMode'
 
 const hiddenOrVisible = PropTypes.oneOf([ 'hidden', 'visible' ])
 
@@ -10,6 +11,7 @@ export default {
   ...TransformPropTypes,
   backfaceVisibility: hiddenOrVisible,
   backgroundColor: ColorPropType,
+  resizeMode: PropTypes.oneOf(Object.keys(ImageResizeMode)),
   /**
    * @platform web
    */

--- a/src/components/Image/index.js
+++ b/src/components/Image/index.js
@@ -6,6 +6,7 @@ import ImageResizeMode from './ImageResizeMode'
 import ImageStylePropTypes from './ImageStylePropTypes'
 import React, { Component, PropTypes } from 'react'
 import StyleSheetPropType from '../../apis/StyleSheet/StyleSheetPropType'
+import flattenStyle from '../../apis/StyleSheet/flattenStyle'
 import View from '../View'
 
 const STATUS_ERRORED = 'ERRORED'
@@ -34,7 +35,6 @@ export default class Image extends Component {
   static defaultProps = {
     accessible: true,
     defaultSource: {},
-    resizeMode: 'cover',
     source: {}
   };
 
@@ -130,16 +130,20 @@ export default class Image extends Component {
       accessible,
       children,
       defaultSource,
-      resizeMode,
       source,
-      style,
       testID
     } = this.props
+    const style = flattenStyle(this.props.style)
 
     const isLoaded = this.state.status === STATUS_LOADED
     const defaultImage = defaultSource.uri || null
     const displayImage = !isLoaded ? defaultImage : source.uri
     const backgroundImage = displayImage ? `url("${displayImage}")` : null
+
+    const resizeMode = this.props.resizeMode || (style || {}).resizeMode || 'cover'
+    if (style && style.resizeMode) {
+      delete style.resizeMode // remove resizeMode style, as it is not supported by View
+    }
 
     /**
      * Image is a non-stretching View. The image is displayed as a background


### PR DESCRIPTION
As per the latest react-native API, the resizeMode for an image can also be specified through the style object. This is often more practical as all styling can be done in a style-sheet. The priority of resizeMode is as follows:
- props.resizeMode
- props.style.resizeMode
- 'cover'