### PR TITLE
Added support for directly requiring image assets (rebase, +docs & tests)

### DIFF
--- a/docs/guides/react-native.md
+++ b/docs/guides/react-native.md
@@ -16,6 +16,24 @@ module.exports = {
 }
 ```
 
+## Image assets
+
+In order to require image assets (e.g. `require('assets/myimage.png')`), add an
+url-loader to the webpack config:
+
+```js
+// webpack.config.js
+
+module.exports = {
+  // ...
+  module: {
+    loaders: {
+      // ...
+      {test: /\.(jpe?g|png|gif|svg)$/, loader: 'url?name=[path][name].[ext]'}
+    }
+  }
+```
+
 ## Web-specific code
 
 Minor platform differences can use the `Platform` module.

--- a/src/components/Image/__tests__/index-test.js
+++ b/src/components/Image/__tests__/index-test.js
@@ -36,6 +36,13 @@ suite('components/Image', () => {
     assert(backgroundImage.indexOf(defaultSource.uri) > -1)
   })
 
+  test('prop "defaultSource, no uri"', () => {
+    const defaultSource = 'https://google.com/favicon.ico'
+    const dom = utils.renderToDOM(<Image defaultSource={defaultSource} />)
+    const backgroundImage = dom.style.backgroundImage
+    assert(backgroundImage.indexOf(defaultSource) > -1)
+  })
+
   test('prop "onError"', function (done) {
     this.timeout(5000)
     utils.render(<Image
@@ -91,7 +98,17 @@ suite('components/Image', () => {
     })
   })
 
-  test('prop "source"')
+  test('prop "source", no uri', function (done) {
+    this.timeout(5000)
+    utils.render(<Image
+      onLoad={onLoad}
+      source={'https://google.com/favicon.ico'}
+    />)
+    function onLoad(e) {
+      assert.equal(e.nativeEvent.type, 'load')
+      done()
+    }
+  })
 
   suite('prop "style"', () => {
     test('converts "resizeMode" property', () => {

--- a/src/components/Image/index.js
+++ b/src/components/Image/index.js
@@ -7,6 +7,7 @@ import React, { Component, PropTypes } from 'react'
 import StyleSheet from '../../apis/StyleSheet'
 import StyleSheetPropType from '../../apis/StyleSheet/StyleSheetPropType'
 import View from '../View'
+import resolveAssetSource from './resolveAssetSource'
 
 const STATUS_ERRORED = 'ERRORED'
 const STATUS_LOADED = 'LOADED'
@@ -14,27 +15,32 @@ const STATUS_LOADING = 'LOADING'
 const STATUS_PENDING = 'PENDING'
 const STATUS_IDLE = 'IDLE'
 
+const ImageSourcePropType = PropTypes.oneOfType([
+  PropTypes.shape({
+    uri: PropTypes.string.isRequired
+  }),
+  PropTypes.string
+])
+
 @NativeMethodsDecorator
 export default class Image extends Component {
   static propTypes = {
     accessibilityLabel: CoreComponent.propTypes.accessibilityLabel,
     accessible: CoreComponent.propTypes.accessible,
     children: PropTypes.any,
-    defaultSource: PropTypes.object,
+    defaultSource: ImageSourcePropType,
     onError: PropTypes.func,
     onLoad: PropTypes.func,
     onLoadEnd: PropTypes.func,
     onLoadStart: PropTypes.func,
     resizeMode: PropTypes.oneOf(['contain', 'cover', 'none', 'stretch']),
-    source: PropTypes.object,
+    source: ImageSourcePropType,
     style: StyleSheetPropType(ImageStylePropTypes),
     testID: CoreComponent.propTypes.testID
   };
 
   static defaultProps = {
     accessible: true,
-    defaultSource: {},
-    source: {},
     style: {}
   };
 
@@ -42,7 +48,7 @@ export default class Image extends Component {
 
   constructor(props, context) {
     super(props, context)
-    const { uri } = props.source
+    const uri = resolveAssetSource(props.source)
     // state
     this.state = { status: uri ? STATUS_PENDING : STATUS_IDLE }
     // autobinding
@@ -51,13 +57,13 @@ export default class Image extends Component {
   }
 
   _createImageLoader() {
-    const { source } = this.props
+    const uri = resolveAssetSource(this.props.source)
 
     this._destroyImageLoader()
     this.image = new window.Image()
     this.image.onerror = this._onError
     this.image.onload = this._onLoad
-    this.image.src = source.uri
+    this.image.src = uri
     this._onLoadStart()
   }
 
@@ -113,9 +119,10 @@ export default class Image extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (this.props.source.uri !== nextProps.source.uri) {
+    const nextUri = resolveAssetSource(nextProps.source)
+    if (resolveAssetSource(this.props.source) !== nextUri) {
       this.setState({
-        status: nextProps.source.uri ? STATUS_PENDING : STATUS_IDLE
+        status: nextUri ? STATUS_PENDING : STATUS_IDLE
       })
     }
   }
@@ -135,8 +142,7 @@ export default class Image extends Component {
     } = this.props
 
     const isLoaded = this.state.status === STATUS_LOADED
-    const defaultImage = defaultSource.uri || null
-    const displayImage = !isLoaded ? defaultImage : source.uri
+    const displayImage = resolveAssetSource(!isLoaded ? defaultSource : source)
     const backgroundImage = displayImage ? `url("${displayImage}")` : null
     const style = StyleSheet.flatten(this.props.style)
 

--- a/src/components/Image/resolveAssetSource.js
+++ b/src/components/Image/resolveAssetSource.js
@@ -1,0 +1,5 @@
+function resolveAssetSource(source) {
+  return ((typeof source === 'object') ? source.uri : source) || null
+}
+
+export default resolveAssetSource


### PR DESCRIPTION
Native-script allows for directly requiring image assets without the need of wrapping it in an uri object{uri: 'someasset'}. This commit adds this feature <Image source={require('someasset.png')} /> as well as adds strong typing for uri-based sources:

```js
const ImageSourcePropType = PropTypes.oneOfType([
  PropTypes.shape({
    uri: PropTypes.string.isRequired
  }),
  PropTypes.string // Opaque type returned by require('./image.jpg')
])
```
final result, these both work:

```
<Image source={require('../assets/myasset.png')} />
<Image source={{uri: require('../assets/myasset.png')}} />
```