### PR TITLE
Added NativeModules shim (adds support for 'react-native-vector-icons')

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,9 @@ import TextInput from './components/TextInput'
 import Touchable from './components/Touchable'
 import View from './components/View'
 
+// modules
+import NativeModules from './modules/NativeModules'
+
 const ReactNative = {
   // apis
   Animated,
@@ -57,6 +60,9 @@ const ReactNative = {
   TouchableOpacity: Touchable,
   TouchableWithoutFeedback: Touchable,
   View,
+
+  // modules
+  NativeModules,
 
   // React
   ...React,

--- a/src/modules/NativeModules/index.js
+++ b/src/modules/NativeModules/index.js
@@ -1,0 +1,4 @@
+// NativeModules shim, required by react-native plugins
+// such as 'react-native-vector-icons' that expect this object to exist
+const NativeModules = {}
+export default NativeModules


### PR DESCRIPTION
The NativeModules namespace is used by external libraries such as 'react-native-vector-icons'. That particular library throws an error because the NativeModules namespace doesn't exist. This commit adds the NativeModules namespace shim.

'react-native-vector-icons' can then be used with 'react-native-web' like this:

```html
<head>
   ...
  <style type="text/css">
    @font-face {
      font-family: 'Ionicons';
      src: url(node_modules/react-native-vector-icons/Fonts/Ionicons.ttf);
    }
  </style>
   ...
</head>
```