### PR TITLE
Update README.md to import from react-native-web

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Demos:
 Sample:
 
 ```js
-import React, { AppRegistry, Image, StyleSheet, Text, View } from 'react-native'
+import React, { AppRegistry, Image, StyleSheet, Text, View } from 'react-native-web'
 
 // Components
 const Card = ({ children }) => <View style={styles.card}>{children}</View>


### PR DESCRIPTION
Shouldn't this be `react-native-web` instead of `react-native`?