### PR TITLE
Fix TextInput placeholder issues

### DIFF
--- a/src/components/TextInput/__tests__/index-test.js
+++ b/src/components/TextInput/__tests__/index-test.js
@@ -186,17 +186,17 @@ suite('components/TextInput', () => {
   test('prop "placeholder"', () => {
     const placeholder = 'placeholder'
     const result = findShallowPlaceholder(utils.shallowRender(<TextInput placeholder={placeholder} />))
-    assert.equal(result.props.children, placeholder)
+    assert.equal(result.props.children.props.children, placeholder)
   })
 
   test('prop "placeholderTextColor"', () => {
     const placeholder = 'placeholder'
 
     let result = findShallowPlaceholder(utils.shallowRender(<TextInput placeholder={placeholder} />))
-    assert.equal(StyleSheet.flatten(result.props.style).color, 'darkgray')
+    assert.equal(StyleSheet.flatten(result.props.children.props.style).color, 'darkgray')
 
     result = findShallowPlaceholder(utils.shallowRender(<TextInput placeholder={placeholder} placeholderTextColor='red' />))
-    assert.equal(StyleSheet.flatten(result.props.style).color, 'red')
+    assert.equal(StyleSheet.flatten(result.props.children.props.style).color, 'red')
   })
 
   test('prop "secureTextEntry"', () => {

--- a/src/components/TextInput/index.js
+++ b/src/components/TextInput/index.js
@@ -198,13 +198,17 @@ class TextInput extends Component {
       >
         <View style={styles.wrapper}>
           <CoreComponent {...props} ref='input' />
-          {placeholder && this.state.showPlaceholder && <Text
+          {placeholder && this.state.showPlaceholder && <View
             pointerEvents='none'
-            style={[
-              styles.placeholder,
-              placeholderTextColor && { color: placeholderTextColor }
-            ]}
-          >{placeholder}</Text>}
+            style={styles.placeholder}
+          >
+            <Text
+              style={[
+                styles.placeholderText,
+                placeholderTextColor && { color: placeholderTextColor }
+              ]}
+            >{placeholder}</Text>
+          </View>}
         </View>
       </View>
     )
@@ -232,12 +236,15 @@ const styles = StyleSheet.create({
   },
   placeholder: {
     bottom: 0,
-    color: 'darkgray',
+    justifyContent: 'center',
     left: 0,
-    overflow: 'hidden',
     position: 'absolute',
     right: 0,
-    top: 0,
+    top: 0
+  },
+  placeholderText: {
+    color: 'darkgray',
+    overflow: 'hidden',
     whiteSpace: 'pre'
   }
 })


### PR DESCRIPTION
Fixes the following issues:
1) Having placeholder makes it impossible to activate input due to pointer-events not being accepted by Text
2) TextInput placeholder doesn't match up with text (#119)

I have originally only tried to fix (1), but then discovered issue #119 where @tuckerconnelly has already provided a working solution — so all credits really goes to him :)