### PR TITLE
Fixing the lineHeight style property to match iOS and Android

### DIFF
--- a/src/apis/StyleSheet/normalizeValue.js
+++ b/src/apis/StyleSheet/normalizeValue.js
@@ -9,7 +9,6 @@ const unitlessNumbers = {
   flexNegative: true,
   fontWeight: true,
   lineClamp: true,
-  lineHeight: true,
   opacity: true,
   order: true,
   orphans: true,


### PR DESCRIPTION
Removing the "lineHeight" flag from the "unitlessNumbers" map to match the behavior of react-native for iOS and Android.

**Description**
The browser treats a unit less "line-height" css property value as an "em" value, while react-native treats it as a pixel unit (or device unit, which should be "px" for the web; same as in the font-size property), this issue is causing the TextInput component to be sized incorrectly.

I've created a simple bug repro app on [CodePen](http://codepen.io/monir/pen/ac3cde551625f2d6eabdac897f790a07?editors=0010).