### PR TITLE
Add an API to wrap and initialize animated

### DIFF
--- a/src/apis/Animated/index.js
+++ b/src/apis/Animated/index.js
@@ -1,0 +1,14 @@
+import Animated from 'animated'
+import StyleSheet from '../StyleSheet'
+import Image from '../../components/Image'
+import Text from '../../components/Text'
+import View from '../../components/View'
+
+Animated.inject.FlattenStyle(StyleSheet.flatten)
+
+module.exports = {
+  ...Animated,
+  Image: Animated.createAnimatedComponent(Image),
+  Text: Animated.createAnimatedComponent(Text),
+  View: Animated.createAnimatedComponent(View)
+}

--- a/src/components/Touchable/TouchableBounce.js
+++ b/src/components/Touchable/TouchableBounce.js
@@ -12,7 +12,7 @@
  */
 'use strict';
 
-var Animated = require('animated');
+var Animated = require('../../apis/Animated');
 var EdgeInsetsPropType = require('../../apis/StyleSheet/EdgeInsetsPropType');
 var NativeMethodsMixin = require('../../modules/NativeMethodsMixin');
 var React = require('react');

--- a/src/components/Touchable/TouchableOpacity.js
+++ b/src/components/Touchable/TouchableOpacity.js
@@ -14,7 +14,7 @@
 
 // Note (avik): add @flow when Flow supports spread properties in propTypes
 
-var Animated = require('animated');
+var Animated = require('../../apis/Animated');
 var NativeMethodsMixin = require('../../modules/NativeMethodsMixin');
 var React = require('react');
 var StyleSheet = require('../../apis/StyleSheet');

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import ReactDOM from 'react-dom'
 import ReactDOMServer from 'react-dom/server'
 
 // apis
-import Animated from 'animated'
+import Animated from './apis/Animated'
 import AppRegistry from './apis/AppRegistry'
 import AppState from './apis/AppState'
 import AsyncStorage from './apis/AsyncStorage'
@@ -43,8 +43,6 @@ import ColorPropType from './apis/StyleSheet/ColorPropType'
 import EdgeInsetsPropType from './apis/StyleSheet/EdgeInsetsPropType'
 import PointPropType from './apis/StyleSheet/PointPropType'
 
-Animated.inject.FlattenStyle(StyleSheet.flatten)
-
 const ReactNative = {
   // top-level API
   findNodeHandle,
@@ -55,12 +53,7 @@ const ReactNative = {
   renderToString: ReactDOMServer.renderToString,
 
   // apis
-  Animated: {
-    ...Animated,
-    Image: Animated.createAnimatedComponent(Image),
-    Text: Animated.createAnimatedComponent(Text),
-    View: Animated.createAnimatedComponent(View)
-  },
+  Animated,
   AppRegistry,
   AppState,
   AsyncStorage,


### PR DESCRIPTION
Both `TouchableBounce` and `TouchableOpacity` broke because they expect `Animated.View` to exist on the animated module. I added back `src/apis/Animated/index.js` so it's initialized in a single place.
