### PR TITLE
Allow other valid button `type`s when `accessibilityRole` is `button`

### DIFF
--- a/src/modules/createReactDOMComponent/__tests__/index-test.js
+++ b/src/modules/createReactDOMComponent/__tests__/index-test.js
@@ -29,6 +29,18 @@ suite('modules/createReactDOMComponent', () => {
     assert.equal(element.is('button'), true)
   })
 
+  test('prop "type"', () => {
+    const accessibilityRole = 'button'
+    let element = shallow(createReactDOMComponent({ accessibilityRole }))
+    assert.equal(element.prop('type'), accessibilityRole)
+    assert.equal(element.is('button'), true)
+
+    const type = 'submit'
+    element = shallow(createReactDOMComponent({ accessibilityRole, type }))
+    assert.equal(element.prop('type'), type)
+    assert.equal(element.is('button'), true)
+  })
+
   test('prop "accessible"', () => {
     // accessible (implicit)
     let element = shallow(createReactDOMComponent({}))

--- a/src/modules/createReactDOMComponent/index.js
+++ b/src/modules/createReactDOMComponent/index.js
@@ -28,6 +28,9 @@ const createReactDOMComponent = ({
   ...other
 }) => {
   const role = accessibilityRole
+  const shouldTypeBeButton = (
+    role === 'button' && !(type === 'submit' || type === 'reset' || type === 'menu')
+  )
   const Component = role && roleComponents[role] ? roleComponents[role] : component
 
   return (
@@ -39,7 +42,7 @@ const createReactDOMComponent = ({
       aria-live={accessibilityLiveRegion}
       data-testid={testID}
       role={role}
-      type={role === 'button' ? 'button' : type}
+      type={shouldTypeBeButton ? 'button' : type}
     />
   )
 }


### PR DESCRIPTION
I might be missing something, but it doesn't currently seem possible to specify e.g. `type='submit'` in conjunction with `accessibilityRole='button'`. This patch adds a check to see if `type` is one of the other possible valid values. The values are taken from [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button). Let me know if I'm doing the check in the wrong place or you have issues with this in general. Thanks!