### PR TITLE
Fix broken link and typo in StyleSheet API docs

### DIFF
--- a/docs/apis/StyleSheet.md
+++ b/docs/apis/StyleSheet.md
@@ -2,8 +2,8 @@
 
 The `StyleSheet` abstraction converts predefined styles to (vendor-prefixed)
 CSS without requiring a compile-time step. Some styles cannot be resolved
-outside of the render loop and are applied as inline styles. Read more about to
-[how style your application](docs/guides/style).
+outside of the render loop and are applied as inline styles. Read more about
+[how to style your application](../guides/style.md).
 
 ## Methods
 


### PR DESCRIPTION
**This patch solves the following problem**
Fix a broken internal link and a typo in the StyleSheet API docs page.

**Test plan**
Go to [docs/api/StyleSheet.md](https://github.com/vitorbal/react-native-web/blob/patch-1/docs/apis/StyleSheet.md), click the link in the first paragraph that says "how to style your application". The link should now work whereas it didn't before.

**This pull request**

- [x] includes documentation

