### PR TITLE
Fix incomplete prop types for TextInput

### DIFF
--- a/src/components/TextInput/index.js
+++ b/src/components/TextInput/index.js
@@ -22,7 +22,7 @@ class TextInput extends Component {
     clearTextOnFocus: PropTypes.bool,
     defaultValue: PropTypes.string,
     editable: PropTypes.bool,
-    keyboardType: PropTypes.oneOf(['default', 'email-address', 'numeric', 'phone-pad', 'url']),
+    keyboardType: PropTypes.oneOf(['default', 'email-address', 'numeric', 'phone-pad', 'search', 'url', 'web-search']),
     maxLength: PropTypes.number,
     maxNumberOfLines: PropTypes.number,
     multiline: PropTypes.bool,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Make sure the PR does only one thing.
Please provide enough information so that others can review your pull
request. Make sure you have read the Contributing Guidelines -
https://github.com/necolas/react-native-web/CONTRIBUTING.md
-->

**This patch solves the following problem**

Matching `TextInput`'s prop types with `TextInput.md`.

**Test plan**

**This pull request**

- [ ] includes documentation
- [ ] includes tests
- [ ] includes an interactive example
- [ ] includes screenshots/videos

