### PR TITLE
export modules and propTypes to enable development of RTCView:

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,12 +38,16 @@ import View from './components/View';
 
 // modules
 import NativeModules from './modules/NativeModules';
+import createDOMElement from './modules/createDOMElement'
+import applyNativeMethods from './modules/applyNativeMethods'
 
 // propTypes
 
 import ColorPropType from './propTypes/ColorPropType';
 import EdgeInsetsPropType from './propTypes/EdgeInsetsPropType';
 import PointPropType from './propTypes/PointPropType';
+import StyleSheetPropType from './propTypes/StyleSheetPropType';
+import BaseComponentPropTypes from './propTypes/BaseComponentPropTypes';
 
 const ReactNative = {
   // top-level API
@@ -88,11 +92,15 @@ const ReactNative = {
 
   // modules
   NativeModules,
+  createDOMElement,
+  applyNativeMethods,
 
   // propTypes
   ColorPropType,
   EdgeInsetsPropType,
-  PointPropType
+  PointPropType,
+  StyleSheetPropType,
+  BaseComponentPropTypes
 };
 
 module.exports = ReactNative;


### PR DESCRIPTION

**This patch solves the following problem**

I needed to develop a react-native web tag for a WebRTC implementation for react-native.  I wanted to use the same tag with react-native-web.  The new tag is called "RTCView" and resolves to a <video> html element.  This new tag parallels a react-native-webrtc project that has a tag developed for WebRTC in Android and iOS (https://github.com/liivevideo/react-native-webrtc). 

In order to implement <RTCView> outside the react-native-web project and within a reat-native-web-rtcweb project, I needed to have access to two modules and two propTypes within react-native-web: 

/modules/createDOMElement
/modules/applyNativeMethods
/propTypes/StyleSheetPropType
/propTypes/BaseComponentPropTypes

**This pull request**

I have include these exports in index.js so that they can be accessed by the new RTCVideo tag in react-native-web-webrtc.  See https://github.com/liivevideo/react-native-web-webrtc for the implementation of RTCVideo.  See https://github.com/liivevideo/react-native-webrtc for the sister project that implements WebRTC in react-native.
