### PR TITLE
Corrected Image docs for resizeMode prop default

### DIFF
--- a/docs/components/Image.md
+++ b/docs/components/Image.md
@@ -46,7 +46,7 @@ Invoked when load either succeeds or fails,
 
 Invoked on load start.
 
-**resizeMode**: oneOf('center', 'contain', 'cover', 'none', 'repeat', 'stretch') = 'stretch'
+**resizeMode**: oneOf('center', 'contain', 'cover', 'none', 'repeat', 'stretch') = 'cover'
 
 Determines how to resize the image when the frame doesn't match the raw image
 dimensions.


### PR DESCRIPTION
**This patch solves the following problem**
Updating the Image doc as the default resizeMode value appears to be cover, not stretch.
See https://github.com/necolas/react-native-web/blob/master/src/components/Image/index.js#L96

**Test plan**

**This pull request**

- [x] includes documentation
- [ ] includes tests
- [ ] includes an interactive example
- [ ] includes screenshots/videos