### PR TITLE
ListView fixes for contained ScrollView

### DIFF
--- a/src/components/ListView/index.js
+++ b/src/components/ListView/index.js
@@ -2,10 +2,11 @@ import applyNativeMethods from '../../modules/applyNativeMethods';
 import ListViewDataSource from './ListViewDataSource';
 import ListViewPropTypes from './ListViewPropTypes';
 import pick from 'lodash/pick';
-import keys from 'lodash/keys';
 import ScrollView from '../ScrollView';
 import View from '../View';
 import React, { Component } from 'react';
+
+const scrollViewProps = Object.keys(ScrollView.propTypes);
 
 class ListView extends Component {
   static propTypes = ListViewPropTypes;
@@ -89,7 +90,7 @@ class ListView extends Component {
       }
     }
 
-    const props = pick(this.props, keys(ScrollView.propTypes));
+    const props = pick(this.props, scrollViewProps);
 
     return React.cloneElement(this.props.renderScrollComponent(props), {
       ref: this._setScrollViewRef

--- a/src/components/ListView/index.js
+++ b/src/components/ListView/index.js
@@ -2,6 +2,7 @@ import applyNativeMethods from '../../modules/applyNativeMethods';
 import ListViewDataSource from './ListViewDataSource';
 import ListViewPropTypes from './ListViewPropTypes';
 import pick from 'lodash/pick';
+import keys from 'lodash/keys';
 import ScrollView from '../ScrollView';
 import View from '../View';
 import React, { Component } from 'react';
@@ -88,7 +89,7 @@ class ListView extends Component {
       }
     }
 
-    const props = pick(ScrollView.propTypes, this.props);
+    const props = pick(this.props, keys(ScrollView.propTypes));
 
     return React.cloneElement(this.props.renderScrollComponent(props), {
       ref: this._setScrollViewRef

--- a/src/components/ListView/index.js
+++ b/src/components/ListView/index.js
@@ -95,7 +95,7 @@ class ListView extends Component {
     }, header, children, footer);
   }
 
-  _setScrollViewRef(component) {
+  _setScrollViewRef = (component) => {
     this._scrollViewRef = component;
   }
 }


### PR DESCRIPTION
**This patch solves the following problem**

The current ListView implementation (v0.0.45) fails to proxy the relevant calls to its contained ScrollView, this seems due to two things:

- the `_setScrollViewRef()` function is not bound to the class, so `this` points to `window` rather than the ListView instance
- no props are passed to the ScrollView, the arguments provided to [Lodash's `pick()`](https://lodash.com/docs/4.15.0#pick) do not match the expected signature

This PR addresses these two issues.

**Test plan**

No existing test for ListView to update, so only local test usage

**This pull request**

- [ ] includes documentation
- [ ] includes tests
- [ ] includes an interactive example
- [ ] includes screenshots/videos
