### PR TITLE
Add doc section on rendering within a React webapp

### DIFF
--- a/docs/guides/rendering.md
+++ b/docs/guides/rendering.md
@@ -72,3 +72,10 @@ AppRegistry.runApplication('App', {
 // prerender the app
 const { html, styleElement } = AppRegistry.prerenderApplication('App', { initialProps })
 ```
+
+
+## Rendering within a React web application
+
+It can be convenient to include React Native components in a web application (for instance as a back-office application, to preview mobile rendering).
+As React Native web is implemented using ReactJS, you don't have to setup React Native Web within your React application.
+You can use directly the React Native components within your React application.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Make sure the PR does only one thing.
Please provide enough information so that others can review your pull
request. Make sure you have read the Contributing Guidelines -
https://github.com/necolas/react-native-web/CONTRIBUTING.md
-->

**This patch solves the following problem**
This section was missing and we spent some time implementing a very simple wrapper that setup/teardown React Native Web in componendDidMount() / componentWillUnmount. 
It turned out to be unnecessary since it actually just worked out of the box !

**This pull request**

- [X] includes documentation

We use React Native Web as a preview tool in our back-office application at fluo.com so that our back-office operators can preview how it will render on the mobile app ! It works really great !