### PR TITLE
fix for placeholder not returning when programmatically cleared

### DIFF
--- a/src/components/TextInput/index.js
+++ b/src/components/TextInput/index.js
@@ -64,6 +64,7 @@ class TextInput extends Component {
   }
 
   clear() {
+    this.setState({showPlaceholder: true})
     this.setNativeProps({ text: '' });
   }
 
@@ -160,7 +161,7 @@ class TextInput extends Component {
     const component = multiline ? TextareaAutosize : 'input';
     const props = multiline ? propsMultiline : propsSingleline;
 
-    const optionalPlaceholder = placeholder && this.state.showPlaceholder && (
+    const optionalPlaceholder = placeholder && (this.state.showPlaceholder || !value) && (
       <View pointerEvents='none' style={styles.placeholder}>
         <Text
           children={placeholder}


### PR DESCRIPTION
currently the placeholder does not come back if `state.value` is programmatically set to '' or if `clear()` is called
