### PR TITLE
proposal for touchables as position: static

### DIFF
--- a/src/components/Touchable/TouchableOpacity.js
+++ b/src/components/Touchable/TouchableOpacity.js
@@ -200,7 +200,8 @@ var TouchableOpacity = React.createClass({
 var styles = StyleSheet.create({
   root: {
     cursor: 'pointer',
-    userSelect: 'none'
+    userSelect: 'none',
+    position: 'static',
   },
   disabled: {
     cursor: 'default'


### PR DESCRIPTION
In RN proper, Touchables can be positioned absolutely or statically by positioning the children of a `Touchable`. It's as if the Touchable container serves no other purpose other than to animate the children (opacity, highlight) and provide `onPress` handlers. However, in RNW, all views are position `relative`, therefore children when absolutely positioned move relative to the generated touchable `<button>`, rather than the first position relative parent view that contains the touchable component. This change will need to be applied to TouchableHightly, TouchableWithoutFeedback, etc. It will also be a breaking change for developers who utilized absolute positioning in relation to the incorrectly position relative button, but it will make RNW consistent with RN.