### PR TITLE
[fix] NetInfo event handler registration

### DIFF
--- a/src/apis/NetInfo/__tests__/index-test.js
+++ b/src/apis/NetInfo/__tests__/index-test.js
@@ -1,5 +1,33 @@
 /* eslint-env mocha */
 
+import NetInfo from '..';
+import assert from 'assert';
+
 suite('apis/NetInfo', () => {
-  test.skip('NO TEST COVERAGE', () => {});
+  suite('isConnected', () => {
+    const handler = () => {};
+
+    teardown(() => {
+      try { NetInfo.isConnected.removeEventListener('change', handler); } catch (e) {}
+    });
+
+    suite('addEventListener', () => {
+      test('throws if the provided "eventType" is not supported', () => {
+        assert.throws(() => NetInfo.isConnected.addEventListener('foo', handler));
+        assert.doesNotThrow(() => NetInfo.isConnected.addEventListener('change', handler));
+      });
+    });
+
+    suite('removeEventListener', () => {
+      test('throws if the handler is not registered', () => {
+        assert.throws(() => NetInfo.isConnected.removeEventListener('change', handler));
+      });
+
+      test('throws if the provided "eventType" is not supported', () => {
+        NetInfo.isConnected.addEventListener('change', handler);
+        assert.throws(() => NetInfo.isConnected.removeEventListener('foo', handler));
+        assert.doesNotThrow(() => NetInfo.isConnected.removeEventListener('change', handler));
+      });
+    });
+  });
 });

--- a/src/apis/NetInfo/index.js
+++ b/src/apis/NetInfo/index.js
@@ -76,7 +76,7 @@ const NetInfo = {
 
       const listenerIndex = findIndex(connectionListeners, (pair) => pair[0] === handler);
       invariant(listenerIndex !== -1, 'Trying to remove NetInfo connection listener for unregistered handler');
-      const [ onlineCallback, offlineCallback ] = connectionListeners[listenerIndex];
+      const [ , onlineCallback, offlineCallback ] = connectionListeners[listenerIndex];
 
       window.removeEventListener('online', onlineCallback, false);
       window.removeEventListener('offline', offlineCallback, false);


### PR DESCRIPTION
**This patch solves the following problem**

Similar to #151 and [this commit](https://github.com/necolas/react-native-web/commit/af40f98f2380861a95f8219557384b497c0dee95), `NetInfo.isConnected` was creating new functions when adding event listeners and, subsequently, removing them, thus, never actually removing the listeners.

**Test plan**

Added tests.

**This pull request**

- [ ] includes documentation
- [x] includes tests
- [ ] includes an interactive example
- [ ] includes screenshots/videos
