### PR TITLE
Provide source files (allow npm install via git with a building step)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "React Native for Web",
   "main": "dist/index.js",
   "files": [
-    "dist"
+    "dist",
+    "src",
+    "!**/__tests__"
   ],
   "scripts": {
     "build": "del ./dist && mkdir dist && babel src -d dist --ignore **/__tests__",


### PR DESCRIPTION
Without this change, if you use npm to install the repo (or a fork 😉) you get a folder with just a package.json, which sucks.

With this change, you get the source files too and allow to build yourself “dist” (using `cd node_modules/react-native-web && npm install`, build is in prepublish and prepublish is run in install with npm@2/3, with npm@4 you need to add `npm run build`)