### PR TITLE
[fix] Add shadow style prop types to View styles

### DIFF
--- a/src/components/View/ViewStylePropTypes.js
+++ b/src/components/View/ViewStylePropTypes.js
@@ -1,6 +1,7 @@
 import BorderPropTypes from '../../propTypes/BorderPropTypes';
 import ColorPropType from '../../propTypes/ColorPropType';
 import LayoutPropTypes from '../../propTypes/LayoutPropTypes';
+import ShadowStylePropTypes from '../../propTypes/ShadowStylePropTypes';
 import { PropTypes } from 'react';
 import TransformPropTypes from '../../propTypes/TransformPropTypes';
 
@@ -12,6 +13,7 @@ module.exports = process.env.NODE_ENV !== 'production' ? {
   ...BorderPropTypes,
   ...LayoutPropTypes,
   ...TransformPropTypes,
+  ...ShadowStylePropTypes,
   backfaceVisibility: hiddenOrVisible,
   backgroundColor: ColorPropType,
   opacity: number,

--- a/src/propTypes/ShadowStylePropTypes.js
+++ b/src/propTypes/ShadowStylePropTypes.js
@@ -1,0 +1,16 @@
+import { PropTypes } from 'react';
+
+const { number, oneOfType, string, shape } = PropTypes;
+const numberOrString = oneOfType([ number, string ]);
+
+const ShadowPropTypes = process.env.NODE_ENV !== 'production' ? {
+  shadowColor: string,
+  shadowOffset: shape({
+    width: numberOrString,
+    height: numberOrString
+  }),
+  shadowOpacity: numberOrString,
+  shadowRadius: numberOrString
+} : {};
+
+module.exports = ShadowPropTypes;


### PR DESCRIPTION
**This patch solves the following problem**

Fixes console warnings when supplying `shadow*` style props to a `View` element (https://github.com/necolas/react-native-web/issues/272)
