### PR TITLE
Add WebkitTapHighlightColor to ViewStylePropTypes

### DIFF
--- a/src/components/View/ViewStylePropTypes.js
+++ b/src/components/View/ViewStylePropTypes.js
@@ -35,5 +35,6 @@ module.exports = process.env.NODE_ENV !== 'production' ? {
   transition: string,
   userSelect: string,
   visibility: hiddenOrVisible,
-  WebkitOverflowScrolling: oneOf([ 'auto', 'touch' ])
+  WebkitOverflowScrolling: oneOf([ 'auto', 'touch' ]),
+  WebkitTapHighlightColor: ColorPropType
 } : {};


### PR DESCRIPTION
**This patch solves the following problem**

Adds [WebkitTapHighlightColor](https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-tap-highlight-color) to valid ViewStylePropTypes. This is necessary for a good mobile-web experience because the default color is grey and is applied even if you're providing touch feedback yourself (like with TouchableRipple in carbon-ui).
