### PR TITLE
mock for libraries that uses BackAndroid

### DIFF
--- a/src/apis/BackAndroid/index.js
+++ b/src/apis/BackAndroid/index.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * web stub for BackAndroid.android.js
+ *
+ * @providesModule BackAndroid
+ */
+
+'use strict';
+
+function emptyFunction() {}
+
+const BackAndroid = {
+  exitApp: emptyFunction,
+  addEventListener() {
+    return {
+      remove: emptyFunction
+    };
+  },
+  removeEventListener: emptyFunction
+};
+
+module.exports = BackAndroid;

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ import Dimensions from './apis/Dimensions';
 import Easing from 'animated/lib/Easing';
 import I18nManager from './apis/I18nManager';
 import InteractionManager from './apis/InteractionManager';
+import BackAndroid from './apis/BackAndroid';
 import Linking from './apis/Linking';
 import NetInfo from './apis/NetInfo';
 import PanResponder from './apis/PanResponder';
@@ -72,6 +73,7 @@ const ReactNative = {
   StyleSheet,
   UIManager,
   Vibration,
+  BackAndroid,
 
   // components
   ActivityIndicator,


### PR DESCRIPTION
react-native [has a mock for BackAndroid in ios version](https://github.com/facebook/react-native/blob/9ee815f6b52e0c2417c04e5a05e1e31df26daed2/Libraries/Utilities/BackAndroid.ios.js), my version is just a copy/paste of it.

**This patch solves the following problem**

A lot of libraries at least ([react-native-router-flux](https://github.com/aksonov/react-native-router-flux) and [react-native-action-sheet](https://github.com/exponent/react-native-action-sheet)). This patch helps those libraries working smooth in react-native-web (avoiding runtime errors).