### PR TITLE
Fixes for ListView

### DIFF
--- a/src/components/ListView/ListViewDataSource.js
+++ b/src/components/ListView/ListViewDataSource.js
@@ -222,6 +222,10 @@ class ListViewDataSource {
     return this._cachedRowCount;
   }
 
+  getRowAndSectionCount(): number {
+    return (this._cachedRowCount + this.sectionIdentities.length);
+  }
+
   /**
    * Returns if the row is dirtied and needs to be rerendered
    */

--- a/src/components/ListView/index.js
+++ b/src/components/ListView/index.js
@@ -4,7 +4,7 @@ import ListViewPropTypes from './ListViewPropTypes';
 import ScrollView from '../ScrollView';
 import StaticRenderer from '../StaticRenderer';
 import React, { Component } from 'react';
-import { isEmpty, merge } from 'lodash';
+import isEmpty from 'fbjs/lib/isEmpty';
 import requestAnimationFrame from 'fbjs/lib/requestAnimationFrame';
 
 const DEFAULT_PAGE_SIZE = 1;
@@ -246,7 +246,7 @@ class ListView extends Component {
     }
     if (updatedFrames) {
       updatedFrames.forEach((newFrame) => {
-        this._childFrames[newFrame.index] = merge(newFrame);
+        this._childFrames[newFrame.index] = Object.assign({}, newFrame);
       });
     }
     const isVertical = !this.props.horizontal;

--- a/src/components/ListView/index.js
+++ b/src/components/ListView/index.js
@@ -3,7 +3,8 @@ import ListViewDataSource from './ListViewDataSource';
 import ListViewPropTypes from './ListViewPropTypes';
 import ScrollView from '../ScrollView';
 import StaticRenderer from '../StaticRenderer';
-import React, { Component, isEmpty, merge } from 'react';
+import React, { Component } from 'react';
+import { isEmpty, merge } from 'lodash';
 import requestAnimationFrame from 'fbjs/lib/requestAnimationFrame';
 
 const DEFAULT_PAGE_SIZE = 1;


### PR DESCRIPTION
**This patch solves the following problem**

The ListView component makes calls to undefined functions: `isEmpty()` and `merge()` that it tries to get from React (replaced by Lodash in this PR but could probably be using fbjs) and `ListViewDataSource.getRowAndSectionCount()` (added in this PR copying React-Native implementation).

**Test plan**

**This pull request**

- [ ] includes documentation
- [ ] includes tests
- [ ] includes benchmark reports
- [ ] includes an interactive example
- [ ] includes screenshots/videos
