### PR TITLE
Fixes error in NativeMethodsMixin when style props could not be resolved

### DIFF
--- a/src/modules/NativeMethodsMixin/index.js
+++ b/src/modules/NativeMethodsMixin/index.js
@@ -78,44 +78,51 @@ const NativeMethodsMixin = {
    * the initial styles from the DOM node and merge them with incoming props.
    */
   setNativeProps(nativeProps: Object) {
-    // DOM state
-    const node = findNodeHandle(this);
-    const domClassList = [ ...node.classList ];
+      // DOM state
+      const node = findNodeHandle(this);
+      const domClassList = [ ...node.classList ];
 
-    // Resolved state
-    const resolvedProps = StyleRegistry.resolve(nativeProps.style);
-    const resolvedClassList = classNameToList(resolvedProps.className);
+      // Resolved state
+      const resolvedProps = StyleRegistry.resolve(nativeProps.style);
+      let resolvedClassList = []
 
-    // Merged state
-    const classList = [];
-    const style = { ...resolvedProps.style };
+      // Merged state
+      const classList = [];
+      let style = {}
 
-    // The node has class names that we need to override.
-    // Only pass on a class name when the style is unchanged.
-    domClassList.forEach((c) => {
-      const prop = getStyleProp(c);
-      if (resolvedProps.className.indexOf(prop) === -1) {
-        classList.push(c);
+      // Check if props could be resolved
+      if( resolvedProps ) {
+          resolvedClassList = classNameToList(resolvedProps.className);
+          style = { ...resolvedProps.style };
+
+          // The node has styles that we need to override.
+          // Remove any inline style that may collide with a new class name.
+          resolvedClassList.forEach((c) => {
+            const prop = getStyleProp(c);
+            classList.push(c);
+            style[prop] = null;
+          });
       }
-    });
 
-    // The node has styles that we need to override.
-    // Remove any inline style that may collide with a new class name.
-    resolvedClassList.forEach((c) => {
-      const prop = getStyleProp(c);
-      classList.push(c);
-      style[prop] = null;
-    });
 
-    const className = `\n${classList.sort().join('\n')}`;
+      // The node has class names that we need to override.
+      // Only pass on a class name when the style is unchanged.
+      domClassList.forEach((c) => {
+        const prop = getStyleProp(c);
+        if (!resolvedProps || resolvedProps.className.indexOf(prop) === -1) {
+          classList.push(c);
+        }
+      });
 
-    const props = {
-      ...nativeProps,
-      className,
-      style
-    };
+      const className = `\n${classList.sort().join('\n')}`;
 
-    UIManager.updateView(node, props, this);
+      const props = {
+        ...nativeProps,
+        className,
+        style
+      };
+
+      UIManager.updateView(node, props, this);
   }
 };
 

--- a/src/modules/NativeMethodsMixin/index.js
+++ b/src/modules/NativeMethodsMixin/index.js
@@ -78,51 +78,50 @@ const NativeMethodsMixin = {
    * the initial styles from the DOM node and merge them with incoming props.
    */
   setNativeProps(nativeProps: Object) {
-      // DOM state
-      const node = findNodeHandle(this);
-      const domClassList = [ ...node.classList ];
+    // DOM state
+    const node = findNodeHandle(this);
+    const domClassList = [ ...node.classList ];
 
-      // Resolved state
-      const resolvedProps = StyleRegistry.resolve(nativeProps.style);
-      let resolvedClassList = []
+    // Resolved state
+    const resolvedProps = StyleRegistry.resolve(nativeProps.style);
+    let resolvedClassList = [];
 
-      // Merged state
-      const classList = [];
-      let style = {}
+    // Merged state
+    const classList = [];
+    let style = {};
 
-      // Check if props could be resolved
-      if( resolvedProps ) {
-          resolvedClassList = classNameToList(resolvedProps.className);
-          style = { ...resolvedProps.style };
+    // Check if props could be resolved
+    if (resolvedProps) {
+      resolvedClassList = classNameToList(resolvedProps.className);
+      style = { ...resolvedProps.style };
 
-          // The node has styles that we need to override.
-          // Remove any inline style that may collide with a new class name.
-          resolvedClassList.forEach((c) => {
-            const prop = getStyleProp(c);
-            classList.push(c);
-            style[prop] = null;
-          });
-      }
-
-
-      // The node has class names that we need to override.
-      // Only pass on a class name when the style is unchanged.
-      domClassList.forEach((c) => {
+      // The node has styles that we need to override.
+      // Remove any inline style that may collide with a new class name.
+      resolvedClassList.forEach((c) => {
         const prop = getStyleProp(c);
-        if (!resolvedProps || resolvedProps.className.indexOf(prop) === -1) {
-          classList.push(c);
-        }
+        classList.push(c);
+        style[prop] = null;
       });
+    }
 
-      const className = `\n${classList.sort().join('\n')}`;
+    // The node has class names that we need to override.
+    // Only pass on a class name when the style is unchanged.
+    domClassList.forEach((c) => {
+      const prop = getStyleProp(c);
+      if (!resolvedProps || resolvedProps.className.indexOf(prop) === -1) {
+        classList.push(c);
+      }
+    });
 
-      const props = {
-        ...nativeProps,
-        className,
-        style
-      };
+    const className = `\n${classList.sort().join('\n')}`;
 
-      UIManager.updateView(node, props, this);
+    const props = {
+      ...nativeProps,
+      className,
+      style
+    };
+
+    UIManager.updateView(node, props, this);
   }
 };
 


### PR DESCRIPTION
When applying nativeProps to View component it could happen that `nativeProps.style` is `undefined`. In this case calling `StyleRegistry.resolve( nativeProps.style )` will return `undefined`. But in the next line you try to extract className property from the resolvedProps variable(which is undefined at the moment) it will cause an Exception.

Now persistance checking of required properties are made in order to avoid exceptions.