### PR TITLE
Add resize style property to TextInput component

### DIFF
--- a/docs/components/TextInput.md
+++ b/docs/components/TextInput.md
@@ -145,6 +145,7 @@ If `true`, all text will automatically be selected on focus.
 
 + ...[Text#style](./Text.md)
 + `outline`
++ `resize`
 
 **testID**: string
 

--- a/src/components/TextInput/TextInputStylePropTypes.js
+++ b/src/components/TextInput/TextInputStylePropTypes.js
@@ -1,0 +1,14 @@
+import TextStylePropTypes from '../Text/TextStylePropTypes';
+import { PropTypes } from 'react';
+
+const { oneOf } = PropTypes;
+
+const TextInputOnlyStylePropTypes = {
+  /* @platform web */
+  resize: oneOf([ 'none', 'vertical', 'horizontal', 'both' ])
+};
+
+module.exports = {
+  ...TextStylePropTypes,
+  ...TextInputOnlyStylePropTypes
+};

--- a/src/components/TextInput/index.js
+++ b/src/components/TextInput/index.js
@@ -5,7 +5,7 @@ import createDOMElement from '../../modules/createDOMElement';
 import findNodeHandle from '../../modules/findNodeHandle';
 import StyleSheet from '../../apis/StyleSheet';
 import StyleSheetPropType from '../../propTypes/StyleSheetPropType';
-import TextStylePropTypes from '../Text/TextStylePropTypes';
+import TextInputStylePropTypes from './TextInputStylePropTypes';
 import TextareaAutosize from 'react-textarea-autosize';
 import TextInputState from './TextInputState';
 import ViewPropTypes from '../View/ViewPropTypes';
@@ -84,7 +84,7 @@ class TextInput extends Component {
       start: PropTypes.number.isRequired,
       end: PropTypes.number
     }),
-    style: StyleSheetPropType(TextStylePropTypes),
+    style: StyleSheetPropType(TextInputStylePropTypes),
     value: PropTypes.string
   };
 


### PR DESCRIPTION
**This patch solves the following problem**

Adds the `resize` style property which is useful on desktop browsers with `textarea`

**This pull request**

- [x] includes documentation
- [ ] includes tests
- [ ] includes benchmark reports
- [ ] includes an interactive example
- [ ] includes screenshots/videos
