### PR TITLE
Add elevation as a valid View style propType, since it is ignored in expandStyle

### DIFF
--- a/src/components/View/ViewStylePropTypes.js
+++ b/src/components/View/ViewStylePropTypes.js
@@ -21,6 +21,7 @@ module.exports = {
   opacity: number,
   overflow: autoOrHiddenOrVisible,
   zIndex: number,
+  elevation: number,
   /*
    * @platform web
    */


### PR DESCRIPTION
**This patch solves the following problem**

I get this error when using [react-native-router-flux](https://github.com/aksonov/react-native-router-flux):

```
Warning: "elevation" is not a valid style property.
```

The `elevation` property is already [ignored in expandStyle](https://github.com/necolas/react-native-web/blob/master/src/apis/StyleSheet/expandStyle.js#L62), so this just removes the warning.