### PR TITLE
Fix keyboard navigation for React normalization

### DIFF
--- a/src/components/Touchable/TouchableHighlight.js
+++ b/src/components/Touchable/TouchableHighlight.js
@@ -225,7 +225,7 @@ var TouchableHighlight = React.createClass({
 
   _onKeyEnter(e, callback) {
     var ENTER = 13
-    if (e.keyCode === ENTER) {
+    if ((e.type === 'keypress' ? e.charCode : e.keyCode) === ENTER) {
       callback && callback(e)
     }
   },

--- a/src/components/Touchable/TouchableOpacity.js
+++ b/src/components/Touchable/TouchableOpacity.js
@@ -157,7 +157,7 @@ var TouchableOpacity = React.createClass({
 
   _onKeyEnter(e, callback) {
     var ENTER = 13
-    if (e.keyCode === ENTER) {
+    if ((e.type === 'keypress' ? e.charCode : e.keyCode) === ENTER) {
       callback && callback(e)
     }
   },


### PR DESCRIPTION
**This patch solves the following problem**

React currently normalizes the `keypress` event differently, by setting `keyCode` to `0` 
https://github.com/facebook/react/blob/master/src/renderers/dom/shared/syntheticEvents/SyntheticKeyboardEvent.js#L35-L58. The current implementation in `TouchableHighlight` and `TouchableOpacity` has a broken event test.

**Test plan**

**This pull request**

- [ ] includes documentation
- [ ] includes tests
- [ ] includes benchmark reports
- [ ] includes an interactive example
- [ ] includes screenshots/videos