### PR TITLE
don't pass onChangeVisibleRows and onEndReachedThreshold to ScrollView

### DIFF
--- a/src/components/ListView/index.js
+++ b/src/components/ListView/index.js
@@ -125,6 +125,8 @@ class ListView extends Component {
       renderSeparator,
       /* eslint-disable */
       initialListSize,
+      onChangeVisibleRows,
+      onEndReached,
       onEndReachedThreshold,
       onKeyboardDidHide,
       onKeyboardDidShow,


### PR DESCRIPTION
Removes the following warning:

```
Warning: Unknown props `onChangeVisibleRows`, `onEndReached` on <div> tag. Remove these props from the element.
```
