### PR TITLE
add two dummy TouchableNativeFeedback & Picker components

### DIFF
--- a/src/components/Picker/index.js
+++ b/src/components/Picker/index.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule Picker
+ * @flow
+ */
+
+'use strict';
+
+var React = require('react');
+var StyleSheet = require('../../apis/StyleSheet');
+var Text = require('../Text');
+var View = require('../View');
+
+class DummyPicker extends React.Component {
+  render() {
+    return (
+      <View style={[styles.container, this.props.style]}>
+        <Text style={styles.info}>Picker is not supported on this platform yet!</Text>
+      </View>
+    );
+  }
+}
+
+var styles = StyleSheet.create({
+  container: {
+    height: 100,
+    width: 300,
+    backgroundColor: '#ffbcbc',
+    borderWidth: 1,
+    borderColor: 'red',
+    alignItems: 'center',
+    justifyContent: 'center',
+    margin: 10,
+  },
+  info: {
+    color: '#333333',
+    margin: 20,
+  }
+});
+
+module.exports = DummyPicker;

--- a/src/components/Touchable/TouchableNativeFeedback.js
+++ b/src/components/Touchable/TouchableNativeFeedback.js
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @providesModule TouchableNativeFeedback
+ */
+
+'use strict';
+
+var React = require('react');
+var StyleSheet = require('../../apis/StyleSheet');
+var Text = require('../Text');
+var View = require('../View');
+
+class DummyTouchableNativeFeedback extends React.Component {
+  render() {
+    return (
+      <View style={[styles.container, this.props.style]}>
+        <Text style={styles.info}>TouchableNativeFeedback is not supported on this platform!</Text>
+      </View>
+    );
+  }
+}
+
+var styles = StyleSheet.create({
+  container: {
+    height: 100,
+    width: 300,
+    backgroundColor: '#ffbcbc',
+    borderWidth: 1,
+    borderColor: 'red',
+    alignItems: 'center',
+    justifyContent: 'center',
+    margin: 10,
+  },
+  info: {
+    color: '#333333',
+    margin: 20,
+  }
+});
+
+module.exports = DummyTouchableNativeFeedback;

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,7 @@ import Button from './components/Button';
 import Image from './components/Image';
 import ListView from './components/ListView';
 import ProgressBar from './components/ProgressBar';
+import Picker from './components/Picker';
 import ScrollView from './components/ScrollView';
 import Switch from './components/Switch';
 import Text from './components/Text';
@@ -35,6 +36,7 @@ import Touchable from './components/Touchable/Touchable';
 import TouchableHighlight from './components/Touchable/TouchableHighlight';
 import TouchableOpacity from './components/Touchable/TouchableOpacity';
 import TouchableWithoutFeedback from './components/Touchable/TouchableWithoutFeedback';
+import TouchableNativeFeedback from './components/Touchable/TouchableNativeFeedback';
 import View from './components/View';
 
 // modules
@@ -81,6 +83,7 @@ const ReactNative = {
   Image,
   ListView,
   ProgressBar,
+  Picker,
   ScrollView,
   Switch,
   Text,
@@ -89,6 +92,7 @@ const ReactNative = {
   TouchableHighlight,
   TouchableOpacity,
   TouchableWithoutFeedback,
+  TouchableNativeFeedback,
   View,
 
   // modules


### PR DESCRIPTION

**This patch solves the following problem**
Hi guys~~ Add two dummy TouchableNativeFeedback & Picker components, which are lacked from RNW. Best wishes : )

**Test plan**

**This pull request**

- [ ] includes documentation
- [ ] includes tests
- [ ] includes benchmark reports
- [ ] includes an interactive example
- [ ] includes screenshots/videos