### PR TITLE
Added multiple heading levels

### DIFF
--- a/docs/components/Text.md
+++ b/docs/components/Text.md
@@ -21,6 +21,13 @@ NOTE: `Text` will transfer all other props to the rendered HTML element.
 Defines the text available to assistive technologies upon interaction with the
 element. (This is implemented using `aria-label`.)
 
+(web) **accessibilityLevel**: number
+
+Allows the user to set a heading's level (h1 through h6) when used alongside `accessibilityRole='heading'`.
+This will render out the actual `<h1>` through `<h6>` DOM elements, and thus may break current styling of elements.
+
+- Must be used alongside `accessibilityRole='heading'`
+
 (web) **accessibilityRole**: oneOf(roles)
 
 Allows assistive technologies to present and support interaction with the view

--- a/examples/components/Text/TextExample.js
+++ b/examples/components/Text/TextExample.js
@@ -455,6 +455,23 @@ const examples = [
       </View>
     );
   },
+},{
+  title: 'Heading levels',
+  render: function() {
+    return (
+      <View>
+        <Text style={{marginBottom: 10}}>
+          This is an example of multiple accessible heading levels. These are styled as regular text, but if inspected they are {`<h1>`} through {`<h6>`}.
+        </Text>
+        <Text accessibilityRole="heading" style={{}}>H1 Example</Text>
+        <Text accessibilityRole="heading" accessibilityLevel={2}>H2 Example</Text>
+        <Text accessibilityRole="heading" accessibilityLevel={3}>H3 Example</Text>
+        <Text accessibilityRole="heading" accessibilityLevel={4}>H4 Example</Text>
+        <Text accessibilityRole="heading" accessibilityLevel={5}>H5 Example</Text>
+        <Text accessibilityRole="heading" accessibilityLevel={6}>H6 Example</Text>
+      </View>
+    )
+  },
 }];
 
 var styles = StyleSheet.create({

--- a/src/components/Text/__tests__/__snapshots__/index-test.js.snap
+++ b/src/components/Text/__tests__/__snapshots__/index-test.js.snap
@@ -32,3 +32,18 @@ exports[`components/Text prop "selectable" 2`] = `
   dir="auto"
 />
 `;
+
+exports[`components/Text prop \`accessibilityLevel\` 1`] = `
+<h2
+  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-color-homxoj rn-display-1471scf rn-font-1lw9tu2 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+  dir="auto"
+/>
+`;
+
+exports[`components/Text prop \`accessibilityRole=heading\` 1`] = `
+<h1
+  className="rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-color-homxoj rn-display-1471scf rn-font-1lw9tu2 rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-textDecoration-bauka4 rn-whiteSpace-q42fyq rn-wordWrap-qvutc0"
+  dir="auto"
+  role="heading"
+/>
+`;

--- a/src/components/Text/__tests__/index-test.js
+++ b/src/components/Text/__tests__/index-test.js
@@ -26,4 +26,17 @@ describe('components/Text', () => {
     component = renderer.create(<Text selectable={false} />);
     expect(component.toJSON()).toMatchSnapshot();
   });
+
+  test('prop `accessibilityRole=heading`', () => {
+    const component = renderer.create(<Text accessibilityRole='heading'/>);
+    expect(component.toJSON().type).toEqual('h1');
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+
+  test('prop `accessibilityLevel`', () => {
+    // when used with accessibilityRole=heading, should render heading of `level`
+    const component = renderer.create(<Text accessibilityLevel={2} accessibilityRole='heading' />);
+    expect(component.toJSON().type).toEqual('h2');
+    expect(component.toJSON()).toMatchSnapshot();
+  });
 });

--- a/src/components/Text/index.js
+++ b/src/components/Text/index.js
@@ -12,6 +12,7 @@ class Text extends Component {
 
   static propTypes = {
     ...BaseComponentPropTypes,
+    accessibilityLevel: PropTypes.number,
     accessibilityRole: PropTypes.oneOf(['button', 'heading', 'link', 'listitem']),
     children: PropTypes.any,
     numberOfLines: PropTypes.number,
@@ -60,6 +61,13 @@ class Text extends Component {
     // allow browsers to automatically infer the language writing direction
     otherProps.dir = 'auto';
 
+    if (otherProps.accessibilityRole === 'heading' && typeof otherProps.accessibilityLevel === 'number'){
+      const level = otherProps.accessibilityLevel;
+      delete otherProps.accessibilityLevel; delete otherProps.accessibilityRole;
+      return createDOMElement(`h${level}`, otherProps);
+    }
+
+    delete otherProps.accessibilityLevel;
     return createDOMElement('span', otherProps);
   }
 


### PR DESCRIPTION
resolves #401 

**This patch solves the following problem**

- using `accessibilityRole='heading'` renders an `h1` with no ability to set different heading levels.

<img width="881" alt="screen shot 2017-03-24 at 2 41 51 pm" src="https://cloud.githubusercontent.com/assets/9259509/24309672/1dd0fdf4-10a3-11e7-98be-dad5f21704ad.png">

**Test plan**

- Added tests to ensure that different heading levels are being rendered when `accessibilityRole='heading'` is used alongside `accessibilityLevel={level}`

**Performance Benchmarks**
```
performance.bundle.js:33 Deep tree [css-modules]
40.5ms ±11.74ms
performance.bundle.js:33 First: 90.79ms
performance.bundle.js:33 Median: 39.33ms
performance.bundle.js:33 Mean: 40.5ms
performance.bundle.js:33 Standard deviation: 5.87ms
performance.bundle.js:33 Array[20]
performance.bundle.js:33 Deep tree [react-native-web]
48ms ±9.86ms
performance.bundle.js:33 First: 67.25ms
performance.bundle.js:33 Median: 47.59ms
performance.bundle.js:33 Mean: 48ms
performance.bundle.js:33 Standard deviation: 4.93ms
performance.bundle.js:33 Array[20]
performance.bundle.js:33 Deep tree [styled-components]
146.06ms ±15.18ms
performance.bundle.js:33 First: 188.33ms
performance.bundle.js:33 Median: 143.24ms
performance.bundle.js:33 Mean: 146.06ms
performance.bundle.js:33 Standard deviation: 7.59ms
performance.bundle.js:33 Array[20]
performance.bundle.js:33 Deep tree [glamor]
177.3ms ±38.33ms
performance.bundle.js:33 First: 220.16ms
performance.bundle.js:33 Median: 172.79ms
performance.bundle.js:33 Mean: 177.3ms
performance.bundle.js:33 Standard deviation: 19.16ms
performance.bundle.js:33 Array[20]
performance.bundle.js:33 Wide tree [css-modules]
82.09ms ±27.27ms
performance.bundle.js:33 First: 83.8ms
performance.bundle.js:33 Median: 79.66ms
performance.bundle.js:33 Mean: 82.09ms
performance.bundle.js:33 Standard deviation: 13.64ms
performance.bundle.js:33 Array[20]
performance.bundle.js:33 Wide tree [react-native-web]
105.8ms ±22.63ms
performance.bundle.js:33 First: 125.5ms
performance.bundle.js:33 Median: 102.84ms
performance.bundle.js:33 Mean: 105.8ms
performance.bundle.js:33 Standard deviation: 11.31ms
performance.bundle.js:33 Array[20]
performance.bundle.js:33 Wide tree [styled-components]
312.85ms ±21.29ms
performance.bundle.js:33 First: 309.69ms
performance.bundle.js:33 Median: 312.8ms
performance.bundle.js:33 Mean: 312.85ms
performance.bundle.js:33 Standard deviation: 10.64ms
performance.bundle.js:33 Array[20]
performance.bundle.js:33 Wide tree [glamor]
265.42ms ±20.84ms
performance.bundle.js:33 First: 284.05ms
performance.bundle.js:33 Median: 264.67ms
performance.bundle.js:33 Mean: 265.42ms
performance.bundle.js:33 Standard deviation: 10.42ms
performance.bundle.js:33 Array[20]
```

**This pull request**

- [x] includes documentation
- [x] includes tests
- [x] includes benchmark reports
- [x] includes an interactive example
- [x] includes screenshots/videos
