### PR TITLE
Add Modal component

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Exported modules:
   * [`Button`](docs/components/Button.md)
   * [`Image`](docs/components/Image.md)
   * [`ListView`](docs/components/ListView.md)
+  * [`Modal`](docs/components/Modal.md)
   * [`ProgressBar`](docs/components/ProgressBar.md)
   * [`ScrollView`](docs/components/ScrollView.md)
   * [`Switch`](docs/components/Switch.md)

--- a/docs/components/Modal.md
+++ b/docs/components/Modal.md
@@ -1,0 +1,61 @@
+# Modal
+
+The Modal component is a simple way to present content above an enclosing view.
+
+## Props
+
+**animationType**: oneOf('none', 'slide', 'fade') = 'none'
+
+The `animationType` prop controls how the modal animates.
+
+* `slide` slides in from the bottom
+* `fade` fades into view
+* `none` appears without an animation
+
+**onShow**: function
+
+The `onShow` prop allows passing a function that will be called once the modal has been shown.
+
+**transparent**: bool
+
+The `transparent` prop determines whether your modal will fill the entire view. Setting this to `true` will render the modal over a transparent background.
+
+**visible**: bool = true
+
+The `visible` prop determines whether your modal is visible.
+
+## Examples
+
+```js
+import React, { Component } from 'react'
+import { View, Text, Button, Modal } from 'react-native'
+
+class ModalExample extends Component {
+  state = { visible: false };
+
+  _handlePress = () => this.setState(state => ({ visible: !state.visible }));
+
+  render() {
+    return (
+      <View>
+        <Button onPress={this._handlePress} title="Toggle modal" />
+        <Modal animationType="slide" visible={this.state.visible}>
+          <View style={styles.modal}>
+            <Text>Modal content</Text>
+            <Button onPress={this._handlePress} title="Close modal" />
+          </View>
+        </Modal>
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  modal: {
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});
+```

--- a/examples/components/Modal/ModalExample.js
+++ b/examples/components/Modal/ModalExample.js
@@ -1,0 +1,45 @@
+import React, { Component, PropTypes } from 'react';
+import { storiesOf } from '@kadira/storybook';
+import { StyleSheet, View, Text, Button, Modal } from 'react-native';
+
+class ModalExample extends Component {
+  static propTypes = {
+    animationType: PropTypes.oneOf(['none', 'slide', 'fade']),
+  };
+
+  state = {
+    visible: false,
+  };
+
+  _handlePress = () => this.setState(state => ({ visible: !state.visible }));
+
+  render() {
+    return (
+      <View>
+        <Text>Animation type: {this.props.animationType}</Text>
+        <Button onPress={this._handlePress} title="Toggle modal" />
+        <Modal {...this.props} visible={this.state.visible}>
+          <View style={styles.modal}>
+            <Text>Modal content</Text>
+            <Button onPress={this._handlePress} title="Close modal" />
+          </View>
+        </Modal>
+      </View>
+    );
+  }
+}
+
+storiesOf('component: Modal', module)
+  .add('animationType: none', () => <ModalExample animationType="none" />)
+  .add('animationType: slide', () => <ModalExample animationType="slide" />)
+  .add('animationType: fade', () => <ModalExample animationType="fade" />)
+  .add('transparent', () => <ModalExample animationType="slide" transparent />);
+
+const styles = StyleSheet.create({
+  modal: {
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/src/components/Modal/__tests__/__snapshots__/index-test.js.snap
+++ b/src/components/Modal/__tests__/__snapshots__/index-test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/Modal visible when "false" a container is not rendered 1`] = `null`;
+
+exports[`components/Modal visible when "true" a container is rendered 1`] = `
+<div
+  className="rn-alignItems-1oszu61 rn-backgroundColor-1ikg2hk rn-borderTopStyle-1efd50x rn-borderRightStyle-14skgim rn-borderBottomStyle-rull8r rn-borderLeftStyle-mm0ijv rn-borderTopWidth-13yce4e rn-borderRightWidth-fnigne rn-borderBottomWidth-ndvcnb rn-borderLeftWidth-gxnn5r rn-bottom-1p0dtai rn-boxSizing-deolkf rn-color-homxoj rn-display-6koalj rn-flexShrink-1qe8dj5 rn-flexBasis-1mlwlqe rn-flexDirection-eqz5dr rn-font-1lw9tu2 rn-left-1d2f490 rn-listStyle-1ebb2ja rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw rn-minHeight-ifefl9 rn-minWidth-bcqeeo rn-paddingTop-wk8lta rn-paddingRight-9aemit rn-paddingBottom-1mdbw0j rn-paddingLeft-gy4na3 rn-position-1xcajam rn-right-zchlnj rn-textAlign-1ttztb7 rn-textDecoration-bauka4 rn-top-ipm5af rn-zIndex-sfbmgh"
+/>
+`;

--- a/src/components/Modal/__tests__/index-test.js
+++ b/src/components/Modal/__tests__/index-test.js
@@ -1,0 +1,22 @@
+/* eslint-env jasmine, jest */
+
+import React from 'react';
+import renderer from 'react-test-renderer';
+import Modal from '..';
+
+jest.mock('react-dom');
+
+describe('components/Modal', () => {
+  describe('visible', () => {
+    test('when "true" a container is rendered', () => {
+      const component = renderer.create(<Modal />);
+      expect(component.toJSON()).toMatchSnapshot();
+    });
+    test('when "false" a container is not rendered', () => {
+      const component = renderer.create(
+        <Modal visible={false} />
+      );
+      expect(component.toJSON()).toMatchSnapshot();
+    });
+  });
+})

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -1,0 +1,129 @@
+import Animated from '../../apis/Animated';
+import Dimensions from '../../apis/Dimensions';
+import StyleSheet from '../../apis/StyleSheet';
+import React, { Component, PropTypes } from 'react';
+
+const shortAnimTime = 200;
+
+class Modal extends Component {
+  static displayName = 'Modal';
+
+  static propTypes = {
+    animationType: PropTypes.oneOf(['none', 'slide', 'fade']),
+    children: PropTypes.any,
+    onShow: PropTypes.func,
+    transparent: PropTypes.bool,
+    visible: PropTypes.bool,
+  };
+
+  static defaultProps = {
+    animationType: 'none',
+    visible: true,
+  };
+
+  constructor(props) {
+    super(props);
+    const { height } = Dimensions.get('window');
+    this.state = {
+      visible: false,
+      positionY: new Animated.Value(height),
+      opacity: new Animated.Value(0),
+    };
+  }
+
+  componentDidMount() {
+    if (this.props.visible) {
+      this.show();
+    }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.visible) {
+      this.show();
+    } else {
+      this.hide();
+    }
+  }
+
+  show() {
+    if (this.state.visible) return;
+
+    const { onShow, animationType } = this.props;
+    if (animationType === 'slide') {
+      this.setState({ visible: true }, () =>
+        Animated.timing(this.state.positionY, {
+          toValue: 0,
+          duration: shortAnimTime,
+        })
+        .start(() => onShow && onShow()),
+      );
+    } else if (animationType === 'fade') {
+      this.setState({ visible: true }, () =>
+        Animated.timing(this.state.opacity, {
+          toValue: 1,
+          duration: shortAnimTime,
+        })
+        .start(() => onShow && onShow())
+      );
+    }
+  }
+
+  hide() {
+    if (!this.state.visible) return;
+
+    const { animationType } = this.props;
+    if (animationType === 'slide') {
+      const { height } = Dimensions.get('window');
+      Animated.timing(this.state.positionY, {
+        toValue: +height,
+        duration: shortAnimTime,
+      })
+      .start(() => this.setState({ visible: false }));
+    } else if (animationType === 'fade') {
+      Animated.timing(this.state.opacity, {
+        toValue: 0,
+        duration: shortAnimTime,
+      })
+      .start(() => this.setState({ visible: false }));
+    }
+  }
+
+  render() {
+    const { animationType, transparent, visible } = this.props;
+    if (
+      (animationType !== 'none' && !this.state.visible) ||
+      (animationType === 'none' && !visible)
+    ) {
+      return null;
+    }
+
+    let modalStyles = {};
+    if (animationType === 'slide') {
+      modalStyles = { transform: [{ translateY: this.state.positionY }]};
+    } else if (animationType === 'fade') {
+      modalStyles = { opacity: this.state.opacity };
+    }
+    if (transparent) {
+      modalStyles.backgroundColor = 'transparent';
+    }
+    return (
+      <Animated.View style={[styles.modal, modalStyles]}>
+        {this.props.children}
+      </Animated.View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  modal: {
+    position: 'fixed',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    zIndex: 9999,
+    backgroundColor: 'white',
+  },
+});
+
+module.exports = Modal;

--- a/src/index.js
+++ b/src/index.js
@@ -30,6 +30,7 @@ import ActivityIndicator from './components/ActivityIndicator';
 import Button from './components/Button';
 import Image from './components/Image';
 import ListView from './components/ListView';
+import Modal from './components/Modal';
 import ProgressBar from './components/ProgressBar';
 import ScrollView from './components/ScrollView';
 import Switch from './components/Switch';
@@ -85,6 +86,7 @@ const ReactNative = {
   Button,
   Image,
   ListView,
+  Modal,
   ProgressBar,
   ScrollView,
   Switch,


### PR DESCRIPTION
**This patch solves the following problem**

#91 Modal component

* The `shortAnimTime` is referenced from [RN for Android](https://github.com/facebook/react-native/tree/cfae3e376d96653e5ad48e0d0398674a954d3637/ReactAndroid/src/main/res/views/modal/anim) anim duration, that used for modal. ([`config_shortAnimTime`](https://github.com/android/platform_frameworks_base/blob/15e69df9218575a3695c97a856322de3bf54e8da/core/res/res/values/config.xml#L119): 200)
* Referenced [official documentation](https://facebook.github.io/react-native/docs/modal.html) (havn't add deprecated `animated` prop and platform only props)

**Test plan**

* Simple [snapshot tests](https://github.com/necolas/react-native-web/blob/9d6fec8f7e7cbcd99d3ffcc831bfa2c4d06e7c2d/src/components/Modal/__tests__/index-test.js) for `visible` prop. [index-test.js.snap](https://github.com/necolas/react-native-web/blob/9d6fec8f7e7cbcd99d3ffcc831bfa2c4d06e7c2d/src/components/Modal/__tests__/__snapshots__/index-test.js.snap)
* Added examples to storybook, [deployed on my fork](http://jhen0409.github.io/react-native-web/storybook/?selectedKind=component%3A%20Modal&selectedStory=animationType%3A%20none&full=0&down=1&left=1&panelRight=0&downPanel=kadirahq%2Fstorybook-addon-actions%2Factions-panel)

**This pull request**

- [x] includes documentation
- [x] includes tests
- [ ] includes benchmark reports
- [x] includes an interactive example
- [ ] includes screenshots/videos