### PR TITLE
updated the script hook for publishing to match it's intent when it was originally added

### DIFF
--- a/npm-debug.log
+++ b/npm-debug.log
@@ -1,0 +1,43 @@
+0 info it worked if it ends with ok
+1 verbose cli [ '/usr/local/bin/node', '/usr/local/bin/npm', 'run', 'prepare' ]
+2 info using npm@4.0.5
+3 info using node@v7.4.0
+4 verbose run-script [ 'prepare' ]
+5 info lifecycle react-native-web@0.0.81~prepare: react-native-web@0.0.81
+6 verbose lifecycle react-native-web@0.0.81~prepare: unsafe-perm in lifecycle true
+7 verbose lifecycle react-native-web@0.0.81~prepare: PATH: /usr/local/lib/node_modules/npm/bin/node-gyp-bin:/Users/cortopasta/projects/dev/react-native-web/node_modules/.bin:/usr/local/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin:/usr/local/MacGPG2/bin:/Library/TeX/texbin:/path/to/elixir/bin:/path/to/elixir/bin
+8 verbose lifecycle react-native-web@0.0.81~prepare: CWD: /Users/cortopasta/projects/dev/react-native-web
+9 silly lifecycle react-native-web@0.0.81~prepare: Args: [ '-c', 'npm run build && npm run build:umd' ]
+10 silly lifecycle react-native-web@0.0.81~prepare: Returned: code: 1  signal: null
+11 info lifecycle react-native-web@0.0.81~prepare: Failed to exec prepare script
+12 verbose stack Error: react-native-web@0.0.81 prepare: `npm run build && npm run build:umd`
+12 verbose stack Exit status 1
+12 verbose stack     at EventEmitter.<anonymous> (/usr/local/lib/node_modules/npm/lib/utils/lifecycle.js:279:16)
+12 verbose stack     at emitTwo (events.js:106:13)
+12 verbose stack     at EventEmitter.emit (events.js:191:7)
+12 verbose stack     at ChildProcess.<anonymous> (/usr/local/lib/node_modules/npm/lib/utils/spawn.js:40:14)
+12 verbose stack     at emitTwo (events.js:106:13)
+12 verbose stack     at ChildProcess.emit (events.js:191:7)
+12 verbose stack     at maybeClose (internal/child_process.js:885:16)
+12 verbose stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:226:5)
+13 verbose pkgid react-native-web@0.0.81
+14 verbose cwd /Users/cortopasta/projects/dev/react-native-web
+15 error Darwin 16.3.0
+16 error argv "/usr/local/bin/node" "/usr/local/bin/npm" "run" "prepare"
+17 error node v7.4.0
+18 error npm  v4.0.5
+19 error code ELIFECYCLE
+20 error react-native-web@0.0.81 prepare: `npm run build && npm run build:umd`
+20 error Exit status 1
+21 error Failed at the react-native-web@0.0.81 prepare script 'npm run build && npm run build:umd'.
+21 error Make sure you have the latest version of node.js and npm installed.
+21 error If you do, this is most likely a problem with the react-native-web package,
+21 error not with npm itself.
+21 error Tell the author that this fails on your system:
+21 error     npm run build && npm run build:umd
+21 error You can get information on how to open an issue for this project with:
+21 error     npm bugs react-native-web
+21 error Or if that isn't available, you can get their info via:
+21 error     npm owner ls react-native-web
+21 error There is likely additional logging output above.
+22 verbose exit [ 1, true ]

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "examples": "start-storybook -p 9001 -c ./examples/.storybook --dont-track",
     "fmt": "find performance src -name '*.js' | grep -v -E '(node_modules|dist)' | xargs prettier --print-width=100 --single-quote --write",
     "lint": "eslint performance src --ignore-path .gitignore",
-    "prepublish": "npm run build && npm run build:umd",
+    "prepare": "npm run build && npm run build:umd",
     "test": "npm run lint && npm run test:jest",
     "test:jest": "jest",
     "test:watch": "npm run test:jest -- --watch"


### PR DESCRIPTION


<!--
Thanks for submitting a pull request! Make sure the PR does only one thing.
Please provide enough information so that others can review your pull
request. Make sure you have read the Contributing Guidelines -
https://github.com/necolas/react-native-web/CONTRIBUTING.md
-->

**This patch solves the following problem**
The `prepublish` npm hook has changed in functionality a few times since it was utilized by this script. This has caused branching from `master` to have an extra/un-needed step of building every time before working on it. This update is to remove that step by trying to restore to what appears to be the original intention of adding `prepublish`

**Test plan**
locally link branch, and you won't have to run `npm run build` in the `node_modules/react-native-web` directory every time you use it in your project


