### PR TITLE
updated the script hook for publishing to match it's intent when it was originally added

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "examples": "start-storybook -p 9001 -c ./examples/.storybook --dont-track",
     "fmt": "find performance src -name '*.js' | grep -v -E '(node_modules|dist)' | xargs prettier --print-width=100 --single-quote --write",
     "lint": "eslint performance src --ignore-path .gitignore",
-    "prepublish": "npm run build && npm run build:umd",
+    "prepare": "npm run build && npm run build:umd",
     "test": "npm run lint && npm run test:jest",
     "test:jest": "jest",
     "test:watch": "npm run test:jest -- --watch"


### PR DESCRIPTION


<!--
Thanks for submitting a pull request! Make sure the PR does only one thing.
Please provide enough information so that others can review your pull
request. Make sure you have read the Contributing Guidelines -
https://github.com/necolas/react-native-web/CONTRIBUTING.md
-->


**This patch solves the following problem**
The prepublish npm hook has changed in functionality a few times since it was utilized by this script. This has caused branching from master to have an extra/un-needed step of building every time before working on it. This update is to remove that step by trying to restore to what appears to be the original intention of adding prepublish

**Test plan**
locally link branch, and you won't have to run npm run build in the node_modules/react-native-web directory every time you use it in your project