### PR TITLE
[change] render Image 'source' immediately if previously loaded

### DIFF
--- a/src/components/Image/ImageUriCache.js
+++ b/src/components/Image/ImageUriCache.js
@@ -1,0 +1,60 @@
+class ImageUriCache {
+  static _maximumItems: number = 256;
+  static _entries = {};
+
+  static has(uri: string) {
+    const entries = ImageUriCache._entries;
+    const isDataUri = /^data:/.test(uri);
+    return isDataUri || Boolean(entries[uri]);
+  }
+
+  static add(uri: string) {
+    const entries = ImageUriCache._entries;
+    const lastUsedTimestamp = Date.now();
+    if (entries[uri]) {
+      entries[uri].lastUsedTimestamp = lastUsedTimestamp;
+      entries[uri].refCount += 1;
+    } else {
+      entries[uri] = {
+        lastUsedTimestamp,
+        refCount: 1
+      };
+    }
+  }
+
+  static remove(uri: string) {
+    const entries = ImageUriCache._entries;
+    if (entries[uri]) {
+      entries[uri].refCount -= 1;
+    }
+    ImageUriCache._cleanUpIfNeeded();
+  }
+
+  // If the cache is "full", remove the oldest unused entry (if any)
+  static _cleanUpIfNeeded() {
+    const entries = ImageUriCache._entries;
+    const entriesArray = Object.keys(entries);
+
+    if (entriesArray.length + 1 > ImageUriCache._maximumItems) {
+      let oldestUnusedKey;
+      let oldestUnusedEntry;
+
+      entriesArray.forEach(key => {
+        const entry = entries[key];
+        if (
+          (!oldestUnusedEntry || entry.lastUsedTimestamp < oldestUnusedEntry.lastUsedTimestamp) &&
+          entry.refCount === 0
+        ) {
+          oldestUnusedKey = key;
+          oldestUnusedEntry = entry;
+        }
+      });
+
+      if (oldestUnusedKey) {
+        delete entries[oldestUnusedKey];
+      }
+    }
+  }
+}
+
+module.exports = ImageUriCache;

--- a/src/components/Image/__tests__/index-test.js
+++ b/src/components/Image/__tests__/index-test.js
@@ -1,8 +1,9 @@
 /* eslint-env jasmine, jest */
 
 import Image from '../';
+import ImageUriCache from '../ImageUriCache';
 import React from 'react';
-import { render } from 'enzyme';
+import { mount, render } from 'enzyme';
 
 const originalImage = window.Image;
 
@@ -85,6 +86,30 @@ describe('components/Image', () => {
         const component = render(<Image resizeMode={resizeMode} />);
         expect(component).toMatchSnapshot();
       });
+    });
+  });
+
+  describe('prop "source"', () => {
+    test('is not set immediately if the image has not already been loaded', () => {
+      const uri = 'https://google.com/favicon.ico';
+      const source = { uri };
+      const component = render(<Image source={source} />);
+      expect(component.find('img')).toBeUndefined;
+    });
+
+    test('is set immediately if the image has already been loaded', () => {
+      const uriOne = 'https://google.com/favicon.ico';
+      const uriTwo = 'https://twitter.com/favicon.ico';
+      ImageUriCache.add(uriOne);
+      ImageUriCache.add(uriTwo);
+
+      // initial render
+      const component = mount(<Image source={{ uri: uriOne }} />);
+      expect(component.render().find('img').attr('src')).toBe(uriOne);
+
+      // props update
+      component.setProps({ source: { uri: uriTwo } });
+      expect(component.render().find('img').attr('src')).toBe(uriTwo);
     });
   });
 


### PR DESCRIPTION
Maintain a record of loaded images. If an image has already been loaded,
bypass the JS loading logic and render it immediately. This prevents
flashes of placeholder state when moving between screens or items in a
virtualized list.