### PR TITLE
Allow filter property in CSS

### DIFF
--- a/docs/components/View.md
+++ b/docs/components/View.md
@@ -190,6 +190,7 @@ Controls whether the View can be the target of touch events. The enhanced
 + `boxSizing`
 + `cursor` ‡
 + `display`
++ `filter` ‡
 + `flex` (number)
 + `flexBasis`
 + `flexDirection`

--- a/src/components/View/ViewStylePropTypes.js
+++ b/src/components/View/ViewStylePropTypes.js
@@ -30,6 +30,7 @@ module.exports = {
   backgroundSize: string,
   boxShadow: string,
   cursor: string,
+  filter: string,
   outline: string,
   outlineColor: ColorPropType,
   perspective: oneOfType([number, string]),


### PR DESCRIPTION
**This patch solves the following problem**

It allows the `filter` CSS rule.
