### PR TITLE
Minor syntax error in getting started (bracket)

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -61,7 +61,7 @@ module.exports = {
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify('production')
     })
-  },
+  ],
 
   resolve: {
     // Maps the 'react-native' import to 'react-native-web'.


### PR DESCRIPTION
I copied the provided webpack code into a project I'm starting and got a syntax error - looks like there should be a square bracket instead of a curly bracket closing the plugins array in the example config.

Hope this helps!