### PR TITLE
Use my fork of the babel plugin to replace propTypes with empty objects

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,6 +3,6 @@
     "react-native"
   ],
   "plugins": [
-    [ "transform-react-remove-prop-types", { "mode": "wrap" } ]
+    [ "transform-react-remove-prop-types", { "mode": "replace" } ]
   ]
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "babel-core": "^6.24.1",
     "babel-eslint": "^7.2.2",
     "babel-loader": "^6.4.1",
-    "babel-plugin-transform-react-remove-prop-types": "^0.4.0",
+    "babel-plugin-transform-react-remove-prop-types": "ndbroadbent/babel-plugin-transform-react-remove-prop-types#replace-with-object-build",
     "babel-preset-react-native": "^1.9.1",
     "del-cli": "^0.2.1",
     "enzyme": "^2.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -932,8 +932,12 @@ babel-plugin-transform-react-jsx@^6.3.13, babel-plugin-transform-react-jsx@^6.5.
     babel-runtime "^6.0.0"
 
 babel-plugin-transform-react-remove-prop-types@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.0.tgz#f63840e7953563d661be8c647b094d74d7363f17"
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.1.tgz#50d6376d3973c6052087b274ca9bd21b8a07409a"
+
+babel-plugin-transform-react-remove-prop-types@ndbroadbent/babel-plugin-transform-react-remove-prop-types#replace-with-object-build:
+  version "0.4.1"
+  resolved "https://codeload.github.com/ndbroadbent/babel-plugin-transform-react-remove-prop-types/tar.gz/647a93c46117b85e773cfd74d5e0133d085b7ce7"
 
 babel-plugin-transform-regenerator@6.16.1:
   version "6.16.1"


### PR DESCRIPTION
Contains these changes: https://github.com/ndbroadbent/babel-plugin-transform-react-remove-prop-types/commit/18edb329aa4fe7ebfd91af6d4b325cf9204e2ae1

See also: https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types/issues/95