### PR TITLE
Add compatibility for BackHandler

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,6 +70,7 @@ const ReactNative = {
   AppState,
   AsyncStorage,
   BackAndroid,
+  BackHandler: BackAndroid,
   Clipboard,
   Dimensions,
   Easing,


### PR DESCRIPTION
**This patch solves the following problem**
BackAndroid has been deprecated and renamed to BackHandler. Newer apps that have migrated can't use react-native-web because there is no stub for BackHandler yet.

(fix for #480)

**Test plan**
I ran `yarn test`.

**This pull request**
- [ ] includes documentation
- [ ] includes tests
- [ ] includes benchmark reports
- [ ] includes an interactive example
- [ ] includes screenshots/videos

Please let me know if this PR requires new doc/tests/benchmark/example/screenshots.

Thanks!
