### PR TITLE
Fix grey circle animation

### DIFF
--- a/src/components/Switch/__tests__/index-test.js
+++ b/src/components/Switch/__tests__/index-test.js
@@ -45,7 +45,7 @@ describe('components/Switch', () => {
 
   describe('grey circle', () => {
     test('it should show grey circle when user touch / clicks', () => {
-      const component = shallow
+
     });
 
     test('it should dismiss grey circle immediately', () => {

--- a/src/components/Switch/__tests__/index-test.js
+++ b/src/components/Switch/__tests__/index-test.js
@@ -1,7 +1,7 @@
 /* eslint-env jasmine, jest */
 
 import React from 'react';
-import { render } from 'enzyme';
+import { render, shallow } from 'enzyme';
 import Switch from '..';
 
 describe('components/Switch', () => {
@@ -17,7 +17,6 @@ describe('components/Switch', () => {
     });
   });
 
-  /*
   describe('onValueChange', () => {
     test('when value is "false" it receives "true"', () => {
       const handleValueChange = (value) => expect(value === true).toBeTruthy();
@@ -31,7 +30,6 @@ describe('components/Switch', () => {
       component.find('input').simulate('click');
     });
   });
-  */
 
   describe('value', () => {
     test('when "false" an unchecked checkbox is rendered', () => {
@@ -42,6 +40,16 @@ describe('components/Switch', () => {
     test('when "true" a checked checkbox is rendered', () => {
       const component = render(<Switch value />);
       expect(component).toMatchSnapshot();
+    });
+  });
+
+  describe('grey circle', () => {
+    test('it should show grey circle when user touch / clicks', () => {
+      const component = shallow
+    });
+
+    test('it should dismiss grey circle immediately', () => {
+
     });
   });
 });

--- a/src/components/Switch/__tests__/index-test.js
+++ b/src/components/Switch/__tests__/index-test.js
@@ -44,20 +44,4 @@ describe('components/Switch', () => {
   });
 
   // TODO: testing the grey circle
-  // describe('grey circle', () => {
-  //   const thumbDefaultBoxShadow = '0px 1px 3px rgba(0,0,0,0.5)';
-  //   const thumbFocusedBoxShadow = `${thumbDefaultBoxShadow}, 0 0 0 10px rgba(0,0,0,0.1)`;
-
-  //   test('it should show grey circle when user touch / clicks', () => {
-  //     const component = shallow(<Switch value={false} />);
-  //     component.find('input').simulate('click');
-
-  //     const style = component.props().children[1];
-  //     console.log(style);
-  //   });
-
-  //   test('it should dismiss grey circle immediately', () => {
-
-  //   });
-  // });
 });

--- a/src/components/Switch/__tests__/index-test.js
+++ b/src/components/Switch/__tests__/index-test.js
@@ -43,13 +43,21 @@ describe('components/Switch', () => {
     });
   });
 
-  describe('grey circle', () => {
-    test('it should show grey circle when user touch / clicks', () => {
+  // TODO: testing the grey circle
+  // describe('grey circle', () => {
+  //   const thumbDefaultBoxShadow = '0px 1px 3px rgba(0,0,0,0.5)';
+  //   const thumbFocusedBoxShadow = `${thumbDefaultBoxShadow}, 0 0 0 10px rgba(0,0,0,0.1)`;
 
-    });
+  //   test('it should show grey circle when user touch / clicks', () => {
+  //     const component = shallow(<Switch value={false} />);
+  //     component.find('input').simulate('click');
 
-    test('it should dismiss grey circle immediately', () => {
+  //     const style = component.props().children[1];
+  //     console.log(style);
+  //   });
 
-    });
-  });
+  //   test('it should dismiss grey circle immediately', () => {
+
+  //   });
+  // });
 });

--- a/src/components/Switch/__tests__/index-test.js
+++ b/src/components/Switch/__tests__/index-test.js
@@ -42,6 +42,4 @@ describe('components/Switch', () => {
       expect(component).toMatchSnapshot();
     });
   });
-
-  // TODO: testing the grey circle
 });

--- a/src/components/Switch/index.js
+++ b/src/components/Switch/index.js
@@ -98,10 +98,6 @@ class Switch extends PureComponent {
       disabled: disabled,
       onChange: this._handleChange,
       onFocus: this._handleFocusState,
-      onTouchStart: this._handleTouchStart,
-      onTouchEnd: this._handleTouchEnd,
-      onClick: this._handleClick,
-      onMouseUp: this._handleMouseUp,
       onMouseDown: this._handleMouseDown,
       ref: this._setCheckboxRef,
       style: [styles.nativeControl, styles.cursorInherit],
@@ -129,23 +125,15 @@ class Switch extends PureComponent {
   _handleChange = (event: Object) => {
     const { onValueChange } = this.props;
     onValueChange && onValueChange(event.nativeEvent.target.checked);
-  };
 
-  _handleMouseUp = (event: Object) => {
-    this._switchBoxShadow(event);
+    setTimeout(() => {
+      this._switchBoxShadow(false);
+    }, 250);
   };
 
   _handleMouseDown = (event: Object) => {
-    this._switchBoxShadow(event);
+    this._switchBoxShadow(true);
   };
-
-  _handleTouchStart = (event: Object) => {
-    this._switchBoxShadow(event);
-  }
-
-  _handleTouchEnd = (event: Object) => {
-    this._switchBoxShadow(event);
-  }
 
   _setCheckboxRef = component => {
     this._checkbox = component;
@@ -155,10 +143,8 @@ class Switch extends PureComponent {
     this._thumb = component;
   };
 
-  _switchBoxShadow = (event: Object) => {
-    const isTouchStart = event.nativeEvent.type === 'touchstart' ||
-                         event.nativeEvent.type === 'mousedown';
-    const boxShadow = isTouchStart ? thumbFocusedBoxShadow : thumbDefaultBoxShadow;
+  _switchBoxShadow = (on) => {
+    const boxShadow = on ? thumbFocusedBoxShadow : thumbDefaultBoxShadow;
     this._thumb.setNativeProps({ style: { boxShadow } });
   };
 }

--- a/src/components/Switch/index.js
+++ b/src/components/Switch/index.js
@@ -99,6 +99,8 @@ class Switch extends PureComponent {
       onBlur: this._handleFocusState,
       onChange: this._handleChange,
       onFocus: this._handleFocusState,
+      onTouchStart: this._handleTouchStart,
+      onTouchEnd: this._handleTouchEnd,
       ref: this._setCheckboxRef,
       style: [styles.nativeControl, styles.cursorInherit],
       type: 'checkbox'
@@ -128,10 +130,16 @@ class Switch extends PureComponent {
   };
 
   _handleFocusState = (event: Object) => {
-    const isFocused = event.nativeEvent.type === 'focus';
-    const boxShadow = isFocused ? thumbFocusedBoxShadow : thumbDefaultBoxShadow;
-    this._thumb.setNativeProps({ style: { boxShadow } });
+
   };
+
+  _handleTouchStart = (event: Object) => {
+    this._switchBoxShadow(event);
+  }
+
+  _handleTouchEnd = (event: Object) => {
+    this._switchBoxShadow(event);
+  }
 
   _setCheckboxRef = component => {
     this._checkbox = component;
@@ -139,6 +147,12 @@ class Switch extends PureComponent {
 
   _setThumbRef = component => {
     this._thumb = component;
+  };
+
+  _switchBoxShadow = (event: Object) => {
+    const isTouchStart = event.nativeEvent.type === 'touchstart';
+    const boxShadow = isTouchStart ? thumbFocusedBoxShadow : thumbDefaultBoxShadow;
+    this._thumb.setNativeProps({ style: { boxShadow } });
   };
 }
 

--- a/src/components/Switch/index.js
+++ b/src/components/Switch/index.js
@@ -96,11 +96,13 @@ class Switch extends PureComponent {
     const nativeControl = createDOMElement('input', {
       checked: value,
       disabled: disabled,
-      onBlur: this._handleFocusState,
       onChange: this._handleChange,
       onFocus: this._handleFocusState,
       onTouchStart: this._handleTouchStart,
       onTouchEnd: this._handleTouchEnd,
+      onClick: this._handleClick,
+      onMouseUp: this._handleMouseUp,
+      onMouseDown: this._handleMouseDown,
       ref: this._setCheckboxRef,
       style: [styles.nativeControl, styles.cursorInherit],
       type: 'checkbox'
@@ -129,8 +131,12 @@ class Switch extends PureComponent {
     onValueChange && onValueChange(event.nativeEvent.target.checked);
   };
 
-  _handleFocusState = (event: Object) => {
+  _handleMouseUp = (event: Object) => {
+    this._switchBoxShadow(event);
+  };
 
+  _handleMouseDown = (event: Object) => {
+    this._switchBoxShadow(event);
   };
 
   _handleTouchStart = (event: Object) => {
@@ -150,7 +156,8 @@ class Switch extends PureComponent {
   };
 
   _switchBoxShadow = (event: Object) => {
-    const isTouchStart = event.nativeEvent.type === 'touchstart';
+    const isTouchStart = event.nativeEvent.type === 'touchstart' ||
+                         event.nativeEvent.type === 'mousedown';
     const boxShadow = isTouchStart ? thumbFocusedBoxShadow : thumbDefaultBoxShadow;
     this._thumb.setNativeProps({ style: { boxShadow } });
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6081,16 +6081,7 @@ ua-parser-js@^0.7.9:
   version "0.7.12"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.12.tgz#04c81a99bdd5dc52263ea29d24c6bf8d4818a4bb"
 
-uglify-js@^2.6, uglify-js@~2.7.3:
-  version "2.7.4"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.7.4.tgz#a295a0de12b6a650c031c40deb0dc40b14568bd2"
-  dependencies:
-    async "~0.2.6"
-    source-map "~0.5.1"
-    uglify-to-browserify "~1.0.0"
-    yargs "~3.10.0"
-
-uglify-js@^2.8.5:
+uglify-js@^2.6, uglify-js@^2.8.5:
   version "2.8.22"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.22.tgz#d54934778a8da14903fa29a326fb24c0ab51a1a0"
   dependencies:
@@ -6098,6 +6089,15 @@ uglify-js@^2.8.5:
     yargs "~3.10.0"
   optionalDependencies:
     uglify-to-browserify "~1.0.0"
+
+uglify-js@~2.7.3:
+  version "2.7.4"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.7.4.tgz#a295a0de12b6a650c031c40deb0dc40b14568bd2"
+  dependencies:
+    async "~0.2.6"
+    source-map "~0.5.1"
+    uglify-to-browserify "~1.0.0"
+    yargs "~3.10.0"
 
 uglify-to-browserify@~1.0.0:
   version "1.0.2"


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Make sure the PR does only one thing.
Please provide enough information so that others can review your pull
request. Make sure you have read the Contributing Guidelines -
https://github.com/necolas/react-native-web/CONTRIBUTING.md
-->

**This patch solves the following problem**
Current implementation: the grey circle / shadow box does not automatically disappear during movement from `active` to inactive, vice versa. 

This pull request fix this issue by using `mouseUp`, `mouseDown`, `touchStart`, and `touchEnd` event instead of `focus`/ `blur`.

**Updates**:
Now it only uses `mouseUp` to fire the grey circle, and `onChange` to dismiss it.

**Test plan**
run `yarn examples` find the Switch on `component: Switch`, tap and hold the switch.

**This pull request**

- [ ] includes documentation
- [ ] includes tests
- [ ] includes benchmark reports
- [x] includes an interactive example
- [x] includes screenshots/videos

Examples:

![switch](https://cloud.githubusercontent.com/assets/2121162/26480861/31f162b6-4207-11e7-88c1-c6b079edbd5d.gif)
