### PR TITLE
Low level perf optimizations from Chrome flamegraphs

### DIFF
--- a/src/apis/UIManager/index.js
+++ b/src/apis/UIManager/index.js
@@ -20,7 +20,7 @@ let measureLayoutQueue = [];
 
 const processLayoutQueue = () => {
   measureLayoutQueue.splice(0, 250).forEach((item) => {
-    const [node, relativeToNativeNode, callback] = item
+    const [node, relativeToNativeNode, callback] = item;
 
     const relativeNode = relativeToNativeNode || (node && node.parentNode);
     if (node && relativeNode) {
@@ -33,7 +33,7 @@ const processLayoutQueue = () => {
   })
 
   if (measureLayoutQueue.length > 0) {
-    setImmediate(processLayoutQueue)
+    setImmediate(processLayoutQueue);
   }
 }
 

--- a/src/apis/UIManager/index.js
+++ b/src/apis/UIManager/index.js
@@ -16,7 +16,7 @@ const getRect = node => {
 };
 
 let hasRequestedAnimationFrame = false;
-let measureLayoutQueue = [];
+const measureLayoutQueue = [];
 
 const processLayoutQueue = () => {
   measureLayoutQueue.splice(0, 250).forEach((item) => {

--- a/src/modules/createDOMElement/index.js
+++ b/src/modules/createDOMElement/index.js
@@ -49,7 +49,7 @@ const createDOMElement = (component, props) => {
     if (isEventHandler) {
       domProps[prop] = wrapEventHandler(prop);
     }
-  })
+  });
 
   return <Component {...domProps} />;
 };

--- a/src/modules/createDOMElement/index.js
+++ b/src/modules/createDOMElement/index.js
@@ -44,14 +44,12 @@ const createDOMElement = (component, props) => {
 
   // normalize DOM events to match React Native events
   // TODO: move this out of the render path
-  for (const prop in domProps) {
-    if (Object.prototype.hasOwnProperty.call(domProps, prop)) {
-      const isEventHandler = typeof prop === 'function' && eventHandlerNames[prop];
-      if (isEventHandler) {
-        domProps[prop] = wrapEventHandler(prop);
-      }
+  Object.keys(domProps).forEach((prop) => {
+    const isEventHandler = typeof prop === 'function' && eventHandlerNames[prop];
+    if (isEventHandler) {
+      domProps[prop] = wrapEventHandler(prop);
     }
-  }
+  })
 
   return <Component {...domProps} />;
 };

--- a/src/modules/createDOMProps/index.js
+++ b/src/modules/createDOMProps/index.js
@@ -41,7 +41,7 @@ const resolver = style => StyleRegistry.resolve(style);
 
 const createDOMProps = (rnProps, resolveStyle) => {
   if (!resolveStyle) {
-    resolveStyle = resolver
+    resolveStyle = resolver;
   }
 
   const props = rnProps || emptyObject;

--- a/src/modules/createDOMProps/index.js
+++ b/src/modules/createDOMProps/index.js
@@ -39,7 +39,11 @@ const pointerEventStyles = StyleSheet.create({
 
 const resolver = style => StyleRegistry.resolve(style);
 
-const createDOMProps = (rnProps, resolveStyle = resolver) => {
+const createDOMProps = (rnProps, resolveStyle) => {
+  if (!resolveStyle) {
+    resolveStyle = resolver
+  }
+
   const props = rnProps || emptyObject;
   const {
     accessibilityLabel,
@@ -72,19 +76,19 @@ const createDOMProps = (rnProps, resolveStyle = resolver) => {
   if (accessible === true) {
     domProps.tabIndex = AccessibilityUtil.propsToTabIndex(props);
   }
-  if (typeof accessibilityLabel === 'string') {
+  if (accessibilityLabel && accessibilityLabel.constructor === String) {
     domProps['aria-label'] = accessibilityLabel;
   }
-  if (typeof accessibilityLiveRegion === 'string') {
+  if (accessibilityLiveRegion && accessibilityLiveRegion.constructor === String) {
     domProps['aria-live'] = accessibilityLiveRegion === 'none' ? 'off' : accessibilityLiveRegion;
   }
-  if (typeof className === 'string' && className !== '') {
+  if (className && className.constructor === String) {
     domProps.className = domProps.className ? `${domProps.className} ${className}` : className;
   }
   if (importantForAccessibility === 'no-hide-descendants') {
     domProps['aria-hidden'] = true;
   }
-  if (typeof role === 'string') {
+  if (role && role.constructor === String) {
     domProps.role = role;
     if (role === 'button') {
       domProps.type = 'button';
@@ -92,13 +96,13 @@ const createDOMProps = (rnProps, resolveStyle = resolver) => {
       domProps.rel = `${domProps.rel || ''} noopener noreferrer`;
     }
   }
-  if (style != null) {
+  if (style) {
     domProps.style = style;
   }
-  if (typeof testID === 'string') {
+  if (testID && testID.constructor === String) {
     domProps['data-testid'] = testID;
   }
-  if (typeof type === 'string') {
+  if (type && type.constructor === String) {
     domProps.type = type;
   }
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Make sure the PR does only one thing.
Please provide enough information so that others can review your pull
request. Make sure you have read the Contributing Guidelines -
https://github.com/necolas/react-native-web/CONTRIBUTING.md
-->

**This patch solves the following problem**
While exploring performance related to #474, these are some issues that I noticed in Chrome's Performance flamegraphs & JavaScript Profiler:

1. `createDOMProps`:
I noticed that Babel was compiling the function with calls to `arguments` when a default parameter value is used. This dramatically slows down the function execution due to the JavaScript VM not being able to fully optimize the function as it has to check its arguments on every invocation. Changing this to a falsey check avoids this performance pitfall with the same result. This produced a 2x speedup once the function was optimized.
`typeof` calls are also generally slow. I've replaced these with calls to `constructor` which provided an additional 20-30% speedup.

2. `onLayout` callback:
I noticed that the `requestAnimationFrame` was being scheduled many times during the list's scrolling. This was taking a lot of time to schedule work to be done later. Then once the work itself was being processed, it was doing a tiny amount of work, yielding back to the JS VM to schedule the next amount of tiny work, and so on. This would leave a lot of gaps in time which would cause performance to suffer. Moving this over to a single invocation of `requestAnimationFrame` to queue up the work to be batched executed later made this about 2-2.5x faster in my not-overly-scientific testing (i.e. difficult to measure accurately due to the variability of the test scenarios).

**Test plan**
Let me know what you think. I've done some basic testing of `VirtualizedList` and all works fine. I don't believe anything in this PR has a different result than what was there before and therefore shouldn't introduce any issues.

**This pull request**

- [ ] includes documentation
- [ ] includes tests
- [x] includes benchmark reports
- [ ] includes an interactive example
- [ ] includes screenshots/videos
