### PR TITLE
Fix from github.com/text-mask/text-mask/issues/300

### DIFF
--- a/src/components/TextInput/__tests__/index-test.js
+++ b/src/components/TextInput/__tests__/index-test.js
@@ -199,4 +199,28 @@ describe('components/TextInput', () => {
     const input = findNativeInput(shallow(<TextInput value={value} />));
     expect(input.prop('value')).toEqual(value);
   });
+
+  describe('prop "selection"', () => {
+    test('set cursor location', () => {
+
+      const cursorLocation = {start:3,end:3}
+      
+      const inputDefaultSelection = findNativeInput(
+        mount(<TextInput defaultValue="12345"/>)
+      );
+
+      const inputCustomSelection = findNativeInput(
+        mount(<TextInput defaultValue="12345" selection={cursorLocation}/>)
+      );
+
+      //default selection is 0 
+      expect(inputDefaultSelection.node.selectionStart).toEqual(0);
+      expect(inputDefaultSelection.node.selectionEnd).toEqual(0);
+      
+      //custom selection sets cursor at custom position 
+      expect(inputCustomSelection.node.selectionStart).toEqual(cursorLocation.start);
+      expect(inputCustomSelection.node.selectionEnd).toEqual(cursorLocation.end);
+    });
+  });
+
 });

--- a/src/components/TextInput/index.js
+++ b/src/components/TextInput/index.js
@@ -11,6 +11,7 @@ import TextInputState from './TextInputState';
 import ViewPropTypes from '../View/ViewPropTypes';
 import { bool, func, number, oneOf, shape, string } from 'prop-types';
 
+const isAndroid = /Android/i.test(navigator && navigator.userAgent)
 const emptyObject = {};
 
 /**
@@ -39,12 +40,22 @@ const isSelectionStale = (node, selection) => {
 /**
  * Certain input types do no support 'selectSelectionRange' and will throw an
  * error.
+ *
+ * Also handles Android specific issue: see https://github.com/text-mask/text-mask/issues/300
  */
 const setSelection = (node, selection) => {
   try {
     if (isSelectionStale(node, selection)) {
       const { start, end } = selection;
-      node.setSelectionRange(start, end || start);
+      
+      if(isAndroid){
+        setTimeout(() => node.setSelectionRange(start,end||start), 10);
+      }
+
+      else{
+        node.setSelectionRange(start, end || start);
+      }
+
     }
   } catch (e) {}
 };


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Make sure the PR does only one thing.
Please provide enough information so that others can review your pull
request. Make sure you have read the Contributing Guidelines -
https://github.com/necolas/react-native-web/CONTRIBUTING.md
-->

**This patch solves the following problem**
Android Chrome has a quirk that affects cursor position of the TextInput component. Essentially in certain cases the default cursor position is behind the leading character in the TextInput component, and using the `selection` prop to set the intended cursor position doesn't move the cursor.

Appears to be similar to or the same as the issue described in some detail here https://github.com/text-mask/text-mask/issues/300, which is where I got the fix included in this PR. The fix works for my use case, and is exclusively scoped to Android.



Can only be reproduced on Android device running Chrome. Presumably an Android Chrome emulator should have the same issue. I've tested on Android 6.0.1 Chrome 55 and 57. Currently this issue makes the TextInput component unusable for an Android Chrome user in our usecase.

To see live example of issue, visit https://nsipplswezey.github.io/input-test-android/ on an Android device using Chrome and start entering an arbitrary phone number. Cursor position fails to stay at end of input. Source for the demo here https://github.com/nsipplswezey/input-test-android/tree/master

To see the fix in action, using my patched fork of `react-native-web` after applying the patch included in this PR, visit https://nsipplswezey.github.io/input-test-android-fix on an Android device using Chrome and start entering an arbitrary phone number. Cursor position is updated based on `selection` prop. https://github.com/nsipplswezey/input-test-android-fix/tree/master

**Test plan**
Added test for the `selection` prop. Since this is Android device specific behavior, hard to build an automated test without spinning up an Android Chrome simulator and writing an e2e test.

**This pull request**

- [ ] includes documentation
- [x] includes tests
- [ ] includes benchmark reports
- [x] includes an interactive example
- [ ] includes screenshots/videos
