### PR TITLE
added support to -webkit-user-drag

### DIFF
--- a/docs/storybook/components/Image/ImageExample.js
+++ b/docs/storybook/components/Image/ImageExample.js
@@ -291,6 +291,39 @@ const examples = [
     }
   },
   {
+    title: 'Webkit User Drag',
+    description: 'You can modify -webkit-user-drag property using style userDrag: \'none\'',
+    render() {
+      return (
+        <View style={styles.horizontal}>
+          <View style={{ marginRight: 100 }}>
+            <Text>Draggable</Text>
+            <Image
+              source={smallImage}
+              style={[
+                styles.base,
+                styles.background,
+              ]}
+            />
+          </View>
+          <View>
+            <Text>Not Draggable</Text>
+            <Image
+              source={smallImage}
+              style={[
+                styles.base,
+                styles.background,
+                {
+                  userDrag: 'none',
+                }
+              ]}
+            />
+          </View>
+        </View>
+      );
+    }
+  },
+  {
     title: 'Border color',
     render() {
       return (

--- a/src/apis/StyleSheet/StyleManager.js
+++ b/src/apis/StyleSheet/StyleManager.js
@@ -113,7 +113,8 @@ class StyleManager {
           const sheet = this.mainSheet.sheet;
           // avoid injecting if the rule already exists (e.g., server rendered, hot reload)
           if (this.mainSheet.textContent.indexOf(className) === -1) {
-            const rule = createCssRule(className, prop, value);
+            const propName = prop === 'userDrag' ? 'WebkitUserDrag' : prop;
+            const rule = createCssRule(className, propName, value);
             sheet.insertRule(rule, sheet.cssRules.length);
           }
         });

--- a/src/components/Image/ImageStylePropTypes.js
+++ b/src/components/Image/ImageStylePropTypes.js
@@ -23,6 +23,7 @@ module.exports = {
    */
   overlayColor: string,
   tintColor: ColorPropType,
+  userDrag: string,
   /**
    * @platform web
    */

--- a/src/components/Image/index.js
+++ b/src/components/Image/index.js
@@ -167,7 +167,11 @@ class Image extends Component {
     const hiddenImage = displayImage
       ? createDOMElement('img', {
           src: displayImage,
-          style: [StyleSheet.absoluteFill, styles.img]
+          style: [
+            StyleSheet.absoluteFill,
+            styles.img,
+            style.userDrag === 'none' && styles.noDrag,
+          ]
         })
       : null;
 
@@ -272,6 +276,9 @@ const styles = StyleSheet.create({
     opacity: 0,
     width: '100%',
     zIndex: -1
+  },
+  noDrag: {
+    userDrag: 'none',
   }
 });
 

--- a/src/components/View/ViewStylePropTypes.js
+++ b/src/components/View/ViewStylePropTypes.js
@@ -45,6 +45,7 @@ module.exports = {
   transitionProperty: string,
   transitionTimingFunction: string,
   userSelect: string,
+  userDrag: string,
   willChange: string,
   WebkitMaskImage: string,
   WebkitOverflowScrolling: oneOf(['auto', 'touch'])


### PR DESCRIPTION
**This patch solves the following problem**
In a app you can have an image as background. If you drag something over this image, it starts dragging in chrome.

**Test plan**

There's appropriate section in storybook.

**This pull request**

- [ ] includes documentation
- [ ] includes tests
- [ ] includes benchmark reports
- [x] includes an interactive example
- [ ] includes screenshots/videos