### PR TITLE
Remove requestAnimationFrame from StyleManager

### DIFF
--- a/src/apis/StyleSheet/StyleManager.js
+++ b/src/apis/StyleSheet/StyleManager.js
@@ -1,7 +1,6 @@
 import { canUseDOM } from 'fbjs/lib/ExecutionEnvironment';
 import generateCss from './generateCss';
 import hash from './hash';
-import requestAnimationFrame from 'fbjs/lib/requestAnimationFrame';
 import staticCss from './staticCss';
 
 const emptyObject = {};
@@ -126,14 +125,12 @@ export default class StyleManager {
       className = createClassName(prop, value);
       this._addToCache(className, prop, value);
       if (canUseDOM) {
-        requestAnimationFrame(() => {
-          const sheet = this.mainSheet.sheet;
-          // avoid injecting if the rule already exists (e.g., server rendered, hot reload)
-          if (this.mainSheet.textContent.indexOf(className) === -1) {
-            const rule = createCssRule(className, prop, value);
-            sheet.insertRule(rule, sheet.cssRules.length);
-          }
-        });
+        const sheet = this.mainSheet.sheet;
+        // avoid injecting if the rule already exists (e.g., server rendered, hot reload)
+        if (this.mainSheet.textContent.indexOf(className) === -1) {
+          const rule = createCssRule(className, prop, value);
+          sheet.insertRule(rule, sheet.cssRules.length);
+        }
       }
     }
     return className;


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Make sure the PR does only one thing.
Please provide enough information so that others can review your pull
request. Make sure you have read the Contributing Guidelines -
https://github.com/necolas/react-native-web/CONTRIBUTING.md
-->

**This patch solves the following problem** Using `requestAnimationFrame` while registering styles/classes slows down iOS/Mobile Webkit. By removing it, it's possible that we add a little bit of overhead, slowing down current cycles, but should be mostly unnoticed.

**Test plan** Manually tested running `npm run docs:start` and checking that everything looked okay in the storybook. Also did a little perf evaluation using Chrome's devtools to see if this caused any extra jank or thrashing, but didn't see anything sticking out. Not sure what to look for, exactly, but happy to find specific points if anyone has anything in mind that this would directly affect.

Fixes gh-517

**This pull request**

- [ ] includes documentation
- [ ] includes tests
- [ ] includes benchmark reports
- [ ] includes an interactive example
- [ ] includes screenshots/videos
