### PR TITLE
Prevent shift+enter in multiline TextInput from triggering onSubmitEditing

### DIFF
--- a/src/components/TextInput/__tests__/index-test.js
+++ b/src/components/TextInput/__tests__/index-test.js
@@ -170,6 +170,19 @@ describe('components/TextInput', () => {
         done();
       }
     });
+
+    test('multi-line input', done => {
+      const input = findNativeTextarea(
+        mount(<TextInput defaultValue="12345" multiline onSubmitEditing={onSubmitEditing} />)
+      );
+      // shift+enter should enter newline, not submit
+      input.simulate('keyPress', { which: 13, shiftKey: true });
+      input.simulate('keyPress', { which: 13 });
+      function onSubmitEditing(e) {
+        expect(e.shiftKey).toBeFalsy();
+        done();
+      }
+    });
   });
 
   test('prop "secureTextEntry"', () => {

--- a/src/components/TextInput/__tests__/index-test.js
+++ b/src/components/TextInput/__tests__/index-test.js
@@ -161,27 +161,42 @@ describe('components/TextInput', () => {
   });
 
   describe('prop "onSubmitEditing"', () => {
-    test('single-line input', done => {
+    test('single-line input', () => {
+      const onSubmitEditing = jest.fn();
       const input = findNativeInput(
         mount(<TextInput defaultValue="12345" onSubmitEditing={onSubmitEditing} />)
       );
       input.simulate('keyPress', { which: 13 });
-      function onSubmitEditing(e) {
-        done();
-      }
+      expect(onSubmitEditing).toHaveBeenCalledTimes(1);
     });
 
-    test('multi-line input', done => {
+    test('multi-line input', () => {
+      const onSubmitEditing = jest.fn();
       const input = findNativeTextarea(
         mount(<TextInput defaultValue="12345" multiline onSubmitEditing={onSubmitEditing} />)
       );
+      input.simulate('keyPress', { which: 13 });
+      expect(onSubmitEditing).not.toHaveBeenCalled();
+    });
+
+    test('multi-line input with "blurOnSubmit" triggers onSubmitEditing', () => {
+      const onSubmitEditing = jest.fn();
+      const input = findNativeTextarea(
+        mount(
+          <TextInput
+            blurOnSubmit
+            defaultValue="12345"
+            multiline
+            onSubmitEditing={onSubmitEditing}
+          />
+        )
+      );
+
       // shift+enter should enter newline, not submit
       input.simulate('keyPress', { which: 13, shiftKey: true });
       input.simulate('keyPress', { which: 13 });
-      function onSubmitEditing(e) {
-        expect(e.shiftKey).toBeFalsy();
-        done();
-      }
+      expect(onSubmitEditing).toHaveBeenCalledTimes(1);
+      expect(onSubmitEditing).not.toHaveBeenCalledWith(expect.objectContaining({ shiftKey: true }));
     });
   });
 

--- a/src/components/TextInput/index.js
+++ b/src/components/TextInput/index.js
@@ -274,7 +274,7 @@ class TextInput extends Component {
     if (onKeyPress) {
       onKeyPress(e);
     }
-    if (!e.isDefaultPrevented() && e.which === 13) {
+    if (!e.isDefaultPrevented() && e.which === 13 && (!multiline || !e.shiftKey)) {
       if (onSubmitEditing) {
         onSubmitEditing(e);
       }

--- a/src/components/TextInput/index.js
+++ b/src/components/TextInput/index.js
@@ -274,8 +274,8 @@ class TextInput extends Component {
     if (onKeyPress) {
       onKeyPress(e);
     }
-    if (!e.isDefaultPrevented() && e.which === 13 && (!multiline || !e.shiftKey)) {
-      if (onSubmitEditing) {
+    if (!e.isDefaultPrevented() && e.which === 13 && !e.shiftKey) {
+      if ((blurOnSubmit || !multiline) && onSubmitEditing) {
         onSubmitEditing(e);
       }
       if (shouldBlurOnSubmit) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Make sure the PR does only one thing.
Please provide enough information so that others can review your pull
request. Make sure you have read the Contributing Guidelines -
https://github.com/necolas/react-native-web/CONTRIBUTING.md
-->

**This patch solves the following problem**
When multiline is enabled in TextInput, shift + enter should add a new line only, but also triggers onSubmitEnd-callback.

Fixes gh-524.

**Test plan**

* Added test
* Manually tested *Multiline blur on submit* example in storybook

**This pull request**

- [ ] includes documentation
- [x] includes tests
- [ ] includes benchmark reports
- [ ] includes an interactive example
- [ ] includes screenshots/videos
