### PR TITLE
Fix @providesModule for a few APIs

### DIFF
--- a/src/apis/AppState/index.js
+++ b/src/apis/AppState/index.js
@@ -6,7 +6,7 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule AppRegistry
+ * @providesModule AppState
  * @flow
  */
 

--- a/src/apis/AsyncStorage/index.js
+++ b/src/apis/AsyncStorage/index.js
@@ -6,7 +6,7 @@
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @providesModule AppRegistry
+ * @providesModule AsyncStorage
  * @flow
  */
 


### PR DESCRIPTION
AppState and AsyncStorage are tagged as "AppRegistry" instead of their
own names.  BackAndroid is also listed as "BackHandler", but I'm not sure
if that was intentional or not, and there are no conflicts, so I left it alone.

**This patch solves the following problem**

Fixes issues with static analysis tools that expect providesModule directives to be unique

**Test plan**

Used git grep to verify consistency across all remaining modules.

**This pull request**

- [ ] includes documentation
- [ ] includes tests
- [ ] includes benchmark reports
- [ ] includes an interactive example
- [ ] includes screenshots/videos