### PR TITLE
[change] better Touchable support for keyboards

### DIFF
--- a/docs/storybook/1-components/Touchable/TouchableHighlightDocs.js
+++ b/docs/storybook/1-components/Touchable/TouchableHighlightDocs.js
@@ -5,6 +5,8 @@
  */
 
 import CustomStyleOverrides from './examples/CustomStyleOverrides';
+import DelayEvents from './examples/DelayEvents';
+import FeedbackEvents from './examples/FeedbackEvents';
 import React from 'react';
 import { storiesOf } from '@kadira/storybook';
 import { TouchableHighlightDisabled } from './examples/PropDisabled';
@@ -45,10 +47,24 @@ const sections = [
     title: 'More examples',
     entries: [
       <DocItem
-        description="Disabled TouchableHighlight"
+        description="Disabled"
         example={{
           code: '',
           render: () => <TouchableHighlightDisabled />
+        }}
+      />,
+
+      <DocItem
+        description="Feedback events"
+        example={{
+          render: () => <FeedbackEvents touchable="highlight" />
+        }}
+      />,
+
+      <DocItem
+        description="Delay events"
+        example={{
+          render: () => <DelayEvents touchable="highlight" />
         }}
       />,
 

--- a/docs/storybook/1-components/Touchable/TouchableOpacityDocs.js
+++ b/docs/storybook/1-components/Touchable/TouchableOpacityDocs.js
@@ -4,6 +4,8 @@
  * @flow
  */
 
+import DelayEvents from './examples/DelayEvents';
+import FeedbackEvents from './examples/FeedbackEvents';
 import React from 'react';
 import { storiesOf } from '@kadira/storybook';
 import { TouchableOpacityDisabled } from './examples/PropDisabled';
@@ -44,8 +46,21 @@ const sections = [
       <DocItem
         description="Disabled TouchableOpacity"
         example={{
-          code: '',
           render: () => <TouchableOpacityDisabled />
+        }}
+      />,
+
+      <DocItem
+        description="Feedback events"
+        example={{
+          render: () => <FeedbackEvents touchable="opacity" />
+        }}
+      />,
+
+      <DocItem
+        description="Delay events"
+        example={{
+          render: () => <DelayEvents touchable="opacity" />
         }}
       />
     ]

--- a/docs/storybook/1-components/Touchable/TouchableWithoutFeedbackDocs.js
+++ b/docs/storybook/1-components/Touchable/TouchableWithoutFeedbackDocs.js
@@ -4,9 +4,12 @@
  * @flow
  */
 
+import DelayEvents from './examples/DelayEvents';
+import FeedbackEvents from './examples/FeedbackEvents';
 import React from 'react';
 import PropHitSlop from './examples/PropHitSlop';
 import { storiesOf } from '@kadira/storybook';
+import { TouchableWithoutFeedbackDisabled } from './examples/PropDisabled';
 import UIExplorer, { AppText, Code, DocItem } from '../../ui-explorer';
 
 const sections = [
@@ -53,6 +56,9 @@ const sections = [
             If <Code>true</Code>, disable all interactions for this component.
           </AppText>
         }
+        example={{
+          render: () => <TouchableWithoutFeedbackDisabled />
+        }}
       />,
 
       <DocItem name="onLongPress" typeInfo="?function" />,
@@ -83,7 +89,23 @@ constant to reduce memory allocations.`}
 
   {
     title: 'More examples',
-    entries: [<DocItem description="Hit slop" example={{ render: () => <PropHitSlop /> }} />]
+    entries: [
+      <DocItem
+        description="Feedback events"
+        example={{
+          render: () => <FeedbackEvents touchable="withoutFeedback" />
+        }}
+      />,
+
+      <DocItem
+        description="Delay events"
+        example={{
+          render: () => <DelayEvents touchable="withoutFeedback" />
+        }}
+      />,
+
+      <DocItem description="Hit slop" example={{ render: () => <PropHitSlop /> }} />
+    ]
   }
 ];
 

--- a/docs/storybook/1-components/Touchable/examples/DelayEvents.js
+++ b/docs/storybook/1-components/Touchable/examples/DelayEvents.js
@@ -1,0 +1,101 @@
+/**
+ * @flow
+ */
+
+import { oneOf } from 'prop-types';
+import React, { PureComponent } from 'react';
+import {
+  StyleSheet,
+  Text,
+  TouchableHighlight,
+  TouchableOpacity,
+  TouchableWithoutFeedback,
+  View
+} from 'react-native';
+
+const Touchables = {
+  highlight: TouchableHighlight,
+  opacity: TouchableOpacity,
+  withoutFeedback: TouchableWithoutFeedback
+};
+
+export default class TouchableDelayEvents extends PureComponent {
+  static propTypes = {
+    touchable: oneOf(['highlight', 'opacity', 'withoutFeedback'])
+  };
+
+  static defaultProps = {
+    touchable: 'highlight'
+  };
+
+  state = { eventLog: [] };
+
+  render() {
+    const Touchable = Touchables[this.props.touchable];
+    const { displayName } = Touchable;
+    return (
+      <View>
+        <View>
+          <Touchable
+            delayLongPress={800}
+            delayPressIn={400}
+            delayPressOut={1000}
+            onLongPress={this._createPressHandler('longPress: 800ms delay')}
+            onPress={this._createPressHandler('press')}
+            onPressIn={this._createPressHandler('pressIn: 400ms delay')}
+            onPressOut={this._createPressHandler('pressOut: 1000ms delay')}
+          >
+            <Text style={styles.touchableText}>
+              {displayName}
+            </Text>
+          </Touchable>
+        </View>
+        <View style={styles.eventLogBox}>
+          {this.state.eventLog.map((e, ii) =>
+            <Text key={ii}>
+              {e}
+            </Text>
+          )}
+        </View>
+      </View>
+    );
+  }
+
+  _createPressHandler = eventName => {
+    return () => {
+      const limit = 6;
+      this.setState(state => {
+        const eventLog = state.eventLog.slice(0, limit - 1);
+        eventLog.unshift(eventName);
+        return { eventLog };
+      });
+    };
+  };
+}
+
+const styles = StyleSheet.create({
+  touchableText: {
+    borderRadius: 8,
+    padding: 5,
+    borderWidth: 1,
+    borderColor: 'black',
+    color: '#007AFF',
+    borderStyle: 'solid',
+    textAlign: 'center'
+  },
+  logBox: {
+    padding: 20,
+    margin: 10,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: '#f0f0f0',
+    backgroundColor: '#f9f9f9'
+  },
+  eventLogBox: {
+    padding: 10,
+    margin: 10,
+    height: 120,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: '#f0f0f0',
+    backgroundColor: '#f9f9f9'
+  }
+});

--- a/docs/storybook/1-components/Touchable/examples/FeedbackEvents.js
+++ b/docs/storybook/1-components/Touchable/examples/FeedbackEvents.js
@@ -1,0 +1,95 @@
+/**
+ * @flow
+ */
+
+import { oneOf } from 'prop-types';
+import React, { PureComponent } from 'react';
+import {
+  StyleSheet,
+  Text,
+  TouchableHighlight,
+  TouchableOpacity,
+  TouchableWithoutFeedback,
+  View
+} from 'react-native';
+
+const Touchables = {
+  highlight: TouchableHighlight,
+  opacity: TouchableOpacity,
+  withoutFeedback: TouchableWithoutFeedback
+};
+
+export default class TouchableFeedbackEvents extends PureComponent {
+  static propTypes = {
+    touchable: oneOf(['highlight', 'opacity', 'withoutFeedback'])
+  };
+
+  static defaultProps = {
+    touchable: 'highlight'
+  };
+
+  state = { eventLog: [] };
+
+  render() {
+    const Touchable = Touchables[this.props.touchable];
+    return (
+      <View>
+        <View>
+          <Touchable
+            onLongPress={this._createPressHandler('longPress')}
+            onPress={this._createPressHandler('press')}
+            onPressIn={this._createPressHandler('pressIn')}
+            onPressOut={this._createPressHandler('pressOut')}
+          >
+            <Text style={styles.touchableText}>Press Me</Text>
+          </Touchable>
+        </View>
+        <View style={styles.eventLogBox}>
+          {this.state.eventLog.map((e, ii) =>
+            <Text key={ii}>
+              {e}
+            </Text>
+          )}
+        </View>
+      </View>
+    );
+  }
+
+  _createPressHandler = eventName => {
+    return () => {
+      const limit = 6;
+      this.setState(state => {
+        const eventLog = state.eventLog.slice(0, limit - 1);
+        eventLog.unshift(eventName);
+        return { eventLog };
+      });
+    };
+  };
+}
+
+const styles = StyleSheet.create({
+  touchableText: {
+    borderRadius: 8,
+    padding: 5,
+    borderWidth: 1,
+    borderColor: 'black',
+    color: '#007AFF',
+    borderStyle: 'solid',
+    textAlign: 'center'
+  },
+  logBox: {
+    padding: 20,
+    margin: 10,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: '#f0f0f0',
+    backgroundColor: '#f9f9f9'
+  },
+  eventLogBox: {
+    padding: 10,
+    margin: 10,
+    height: 120,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: '#f0f0f0',
+    backgroundColor: '#f9f9f9'
+  }
+});

--- a/docs/storybook/1-components/Touchable/examples/PropDisabled.js
+++ b/docs/storybook/1-components/Touchable/examples/PropDisabled.js
@@ -4,7 +4,14 @@
 
 import React from 'react';
 import { action } from '@kadira/storybook';
-import { StyleSheet, View, Text, TouchableHighlight, TouchableOpacity } from 'react-native';
+import {
+  StyleSheet,
+  View,
+  Text,
+  TouchableHighlight,
+  TouchableOpacity,
+  TouchableWithoutFeedback
+} from 'react-native';
 
 class TouchableHighlightDisabled extends React.Component {
   render() {
@@ -57,7 +64,27 @@ class TouchableOpacityDisabled extends React.Component {
   }
 }
 
-export { TouchableHighlightDisabled, TouchableOpacityDisabled };
+class TouchableWithoutFeedbackDisabled extends React.Component {
+  render() {
+    return (
+      <View>
+        <TouchableWithoutFeedback disabled={true} onPress={action('TouchableWithoutFeedback')}>
+          <View style={[styles.row, styles.block]}>
+            <Text style={styles.disabledButton}>Disabled TouchableWithoutFeedback</Text>
+          </View>
+        </TouchableWithoutFeedback>
+
+        <TouchableWithoutFeedback disabled={false} onPress={action('TouchableWithoutFeedback')}>
+          <View style={[styles.row, styles.block]}>
+            <Text style={styles.button}>Enabled TouchableWithoutFeedback</Text>
+          </View>
+        </TouchableWithoutFeedback>
+      </View>
+    );
+  }
+}
+
+export { TouchableHighlightDisabled, TouchableOpacityDisabled, TouchableWithoutFeedbackDisabled };
 
 const styles = StyleSheet.create({
   row: {
@@ -66,12 +93,5 @@ const styles = StyleSheet.create({
   },
   block: {
     padding: 10
-  },
-  button: {
-    color: '#007AFF'
-  },
-  disabledButton: {
-    color: '#007AFF',
-    opacity: 0.5
   }
 });

--- a/docs/storybook/1-components/Touchable/examples/legacy.js
+++ b/docs/storybook/1-components/Touchable/examples/legacy.js
@@ -17,92 +17,6 @@ import {
   View
 } from 'react-native';
 
-class TouchableFeedbackEvents extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = { eventLog: [] };
-  }
-
-  render() {
-    return (
-      <View testID="touchable_feedback_events">
-        <View style={[styles.row, { justifyContent: 'center' }]}>
-          <TouchableOpacity
-            accessibilityComponentType="button"
-            accessibilityLabel="touchable feedback events"
-            accessibilityTraits="button"
-            onLongPress={this._createPressHandler('longPress')}
-            onPress={this._createPressHandler('press')}
-            onPressIn={this._createPressHandler('pressIn')}
-            onPressOut={this._createPressHandler('pressOut')}
-            style={styles.wrapper}
-            testID="touchable_feedback_events_button"
-          >
-            <Text style={styles.button}>
-              Press Me
-            </Text>
-          </TouchableOpacity>
-        </View>
-        <View style={styles.eventLogBox} testID="touchable_feedback_events_console">
-          {this.state.eventLog.map((e, ii) => <Text key={ii}>{e}</Text>)}
-        </View>
-      </View>
-    );
-  }
-
-  _createPressHandler = eventName => {
-    return () => {
-      const limit = 6;
-      const eventLog = this.state.eventLog.slice(0, limit - 1);
-      eventLog.unshift(eventName);
-      this.setState({ eventLog });
-    };
-  };
-}
-
-class TouchableDelayEvents extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = { eventLog: [] };
-  }
-
-  render() {
-    return (
-      <View testID="touchable_delay_events">
-        <View style={[styles.row, { justifyContent: 'center' }]}>
-          <TouchableOpacity
-            delayLongPress={800}
-            delayPressIn={400}
-            delayPressOut={1000}
-            onLongPress={this._createPressHandler('longPress - 800ms delay')}
-            onPress={this._createPressHandler('press')}
-            onPressIn={this._createPressHandler('pressIn - 400ms delay')}
-            onPressOut={this._createPressHandler('pressOut - 1000ms delay')}
-            style={styles.wrapper}
-            testID="touchable_delay_events_button"
-          >
-            <Text style={styles.button}>
-              Press Me
-            </Text>
-          </TouchableOpacity>
-        </View>
-        <View style={styles.eventLogBox} testID="touchable_delay_events_console">
-          {this.state.eventLog.map((e, ii) => <Text key={ii}>{e}</Text>)}
-        </View>
-      </View>
-    );
-  }
-
-  _createPressHandler = eventName => {
-    return () => {
-      const limit = 6;
-      const eventLog = this.state.eventLog.slice(0, limit - 1);
-      eventLog.unshift(eventName);
-      this.setState({ eventLog });
-    };
-  };
-}
-
 const heartImage = { uri: 'https://pbs.twimg.com/media/BlXBfT3CQAA6cVZ.png:small' };
 
 const styles = StyleSheet.create({
@@ -214,33 +128,5 @@ const examples = [
       );
     }
   },
-  {
-    title: 'Touchable feedback events',
-    description:
-      '<Touchable*> components accept onPress, onPressIn, ' +
-        'onPressOut, and onLongPress as props.',
-    render() {
-      return <TouchableFeedbackEvents />;
-    }
-  },
-  {
-    title: 'Touchable delay for events',
-    description:
-      '<Touchable*> components also accept delayPressIn, ' +
-        'delayPressOut, and delayLongPress as props. These props impact the ' +
-        'timing of feedback events.',
-    render() {
-      return <TouchableDelayEvents />;
-    }
-  },
-  {
-    title: 'Disabled Touchable*',
-    description:
-      '<Touchable*> components accept disabled prop which prevents ' +
-        'any interaction with component',
-    render() {
-      return <TouchableDisabled />;
-    }
-  }
 ];
 */

--- a/src/components/TextInput/index.js
+++ b/src/components/TextInput/index.js
@@ -14,7 +14,6 @@ import applyLayout from '../../modules/applyLayout';
 import applyNativeMethods from '../../modules/applyNativeMethods';
 import { canUseDOM } from 'fbjs/lib/ExecutionEnvironment';
 import { Component } from 'react';
-import NativeMethodsMixin from '../../modules/NativeMethodsMixin';
 import createDOMElement from '../../modules/createDOMElement';
 import findNodeHandle from '../../modules/findNodeHandle';
 import StyleSheet from '../../apis/StyleSheet';
@@ -143,10 +142,6 @@ class TextInput extends Component {
 
   isFocused() {
     return TextInputState.currentlyFocusedField() === this._node;
-  }
-
-  setNativeProps(props) {
-    NativeMethodsMixin.setNativeProps.call(this, props);
   }
 
   componentDidMount() {

--- a/src/components/Touchable/TouchableNativeFeedback.js
+++ b/src/components/Touchable/TouchableNativeFeedback.js
@@ -1,2 +1,12 @@
+/**
+ * Copyright 2017-present, Nicolas Gallagher
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ */
+
 import UnimplementedView from '../UnimplementedView';
 export default UnimplementedView;

--- a/src/components/Touchable/TouchableWithoutFeedback.js
+++ b/src/components/Touchable/TouchableWithoutFeedback.js
@@ -1,5 +1,3 @@
-/* eslint-disable */
-
 /**
  * Copyright (c) 2016-present, Nicolas Gallagher.
  * Copyright (c) 2015-present, Facebook, Inc.
@@ -9,9 +7,10 @@
  * LICENSE file in the root directory of this source tree.
  *
  * @providesModule TouchableWithoutFeedback
- * @noflow
+ * @flow
  */
 
+import BaseComponentPropTypes from '../../propTypes/BaseComponentPropTypes';
 import createReactClass from 'create-react-class';
 import EdgeInsetsPropType from '../../propTypes/EdgeInsetsPropType';
 import ensurePositiveDelayProps from './ensurePositiveDelayProps';
@@ -27,42 +26,29 @@ type Event = Object;
 const PRESS_RETENTION_OFFSET = { top: 20, left: 20, right: 20, bottom: 30 };
 
 /**
- * Do not use unless you have a very good reason. All the elements that
- * respond to press should have a visual feedback when touched. This is
- * one of the primary reasons a "web" app doesn't feel "native".
+ * Do not use unless you have a very good reason. All elements that
+ * respond to press should have a visual feedback when touched.
  *
- * > **NOTE**: TouchableWithoutFeedback supports only one child
- * >
- * > If you wish to have several child components, wrap them in a View.
+ * TouchableWithoutFeedback supports only one child.
+ * If you wish to have several child components, wrap them in a View.
  */
+
+/* eslint-disable react/prefer-es6-class */
 const TouchableWithoutFeedback = createReactClass({
+  displayName: 'TouchableWithoutFeedback',
   mixins: [TimerMixin, Touchable.Mixin],
 
   propTypes: {
-    accessible: bool,
+    accessibilityComponentType: BaseComponentPropTypes.accessibilityComponentType,
     accessibilityLabel: string,
-    accessibilityRole: string,
+    accessibilityRole: BaseComponentPropTypes.accessibilityRole,
+    accessibilityTraits: BaseComponentPropTypes.accessibilityTraits,
+    accessible: bool,
     children: element,
     /**
-     * If true, disable all interactions for this component.
+     * Delay in ms, from onPressIn, before onLongPress is called.
      */
-    disabled: bool,
-    /**
-     * Called when the touch is released, but not if cancelled (e.g. by a scroll
-     * that steals the responder lock).
-     */
-    onPress: func,
-    onPressIn: func,
-    onPressOut: func,
-    /**
-     * Invoked on mount and layout changes with
-     *
-     *   `{nativeEvent: {layout: {x, y, width, height}}}`
-     */
-    onLayout: func,
-
-    onLongPress: func,
-
+    delayLongPress: number,
     /**
      * Delay in ms, from the start of the touch, before onPressIn is called.
      */
@@ -72,9 +58,29 @@ const TouchableWithoutFeedback = createReactClass({
      */
     delayPressOut: number,
     /**
-     * Delay in ms, from onPressIn, before onLongPress is called.
+     * If true, disable all interactions for this component.
      */
-    delayLongPress: number,
+    disabled: bool,
+    /**
+     * This defines how far your touch can start away from the button. This is
+     * added to `pressRetentionOffset` when moving off of the button.
+     */
+    // $FlowFixMe(>=0.41.0)
+    hitSlop: EdgeInsetsPropType,
+    /**
+     * Invoked on mount and layout changes with
+     *
+     *   `{nativeEvent: {layout: {x, y, width, height}}}`
+     */
+    onLayout: func,
+    onLongPress: func,
+    /**
+     * Called when the touch is released, but not if cancelled (e.g. by a scroll
+     * that steals the responder lock).
+     */
+    onPress: func,
+    onPressIn: func,
+    onPressOut: func,
     /**
      * When the scroll view is disabled, this defines how far your touch may
      * move off of the button, before deactivating the button. Once deactivated,
@@ -84,16 +90,7 @@ const TouchableWithoutFeedback = createReactClass({
      */
     // $FlowFixMe
     pressRetentionOffset: EdgeInsetsPropType,
-    /**
-     * This defines how far your touch can start away from the button. This is
-     * added to `pressRetentionOffset` when moving off of the button.
-     * ** NOTE **
-     * The touch area never extends past the parent view bounds and the Z-index
-     * of sibling views always takes precedence if a touch hits two overlapping
-     * views.
-     */
-    // $FlowFixMe
-    hitSlop: EdgeInsetsPropType
+    testID: string
   },
 
   getInitialState: function() {
@@ -187,19 +184,19 @@ const TouchableWithoutFeedback = createReactClass({
     return (React: any).cloneElement(child, {
       ...other,
       accessible: this.props.accessible !== false,
-      onStartShouldSetResponder: this.touchableHandleStartShouldSetResponder,
-      onResponderTerminationRequest: this.touchableHandleResponderTerminationRequest,
+      children,
       onResponderGrant: this.touchableHandleResponderGrant,
       onResponderMove: this.touchableHandleResponderMove,
       onResponderRelease: this.touchableHandleResponderRelease,
       onResponderTerminate: this.touchableHandleResponderTerminate,
-      style,
-      children
+      onResponderTerminationRequest: this.touchableHandleResponderTerminationRequest,
+      onStartShouldSetResponder: this.touchableHandleStartShouldSetResponder,
+      style
     });
   }
 });
 
-var styles = StyleSheet.create({
+const styles = StyleSheet.create({
   root: {
     cursor: 'pointer'
   },


### PR DESCRIPTION
**Problem**

Although 'Touchable' supports basic keyboard usage, it doesn't support
delays or interaction via the Space key.

**Solution**

Extend the 'Touchable' mixin to better support keyboard interactions.
All touchable callbacks and delays are now supported when interacted
with via a keyboard's Enter and Space keys (as would be expected of
native 'button' elements). However, events are not normalized to mimic
touch events.

Minor upstream changes to the Touchables in React Native are also
included.