### PR TITLE
Fix async race condition in Touchable mixin

### DIFF
--- a/src/components/Touchable/Touchable.js
+++ b/src/components/Touchable/Touchable.js
@@ -399,6 +399,7 @@ const TouchableMixin = {
     if (delayMS !== 0) {
       this.touchableDelayTimeout = setTimeout(this._handleDelay.bind(this, e), delayMS);
     } else {
+      this.state.touchable.positionOnActivate = null;
       this._handleDelay(e);
     }
 


### PR DESCRIPTION
When a Touchable component returns 0 for `touchableGetHighlightDelayMS()` the mixin may occasionally try to detect if the press event occurred on the hit area _before_ the hit area has been determined. Clearing out this value ensures that `positionOnActivate` is recalculated before that takes place.

This fixes #585 
