### PR TITLE
Fix example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Guides:
 
 ```js
 import React from 'react'
-import { AppRegistry, Image, StyleSheet, Text, View } from 'react-native'
+import { AppRegistry, Image, StyleSheet, Text, View } from 'react-native-web'
 
 // Components
 const Card = ({ children }) => <View style={styles.card}>{children}</View>


### PR DESCRIPTION
All I know is that it wasn't working to read the dependencies from the `react-native` package. I had to use `react-native-web` instead.

Otherwise, I got `Cannot find module` errors when attempting to read any properties of ReactNative.

**Before submitting a pull request,** please make sure you have followed the steps the CONTRIBUTING guide.
