### PR TITLE
Kim/normalizenativeevent check before bind

### DIFF
--- a/src/modules/normalizeNativeEvent/__tests__/index-test.js
+++ b/src/modules/normalizeNativeEvent/__tests__/index-test.js
@@ -1,0 +1,40 @@
+/* eslint-env jasmine, jest */
+
+import normalizeNativeEvent from '../index';
+
+describe('modules/normalizeNativeEvent', () => {
+  it('handles mouse events without preventDefault, stopPropagation and stopImmediatePropagation', () => {
+    const event = {
+      type: 'mouse'
+    };
+
+    normalizeNativeEvent(event);
+  });
+
+  it('handles mouse events with preventDefault, stopPropagation and stopImmediatePropagation', () => {
+    const event = {
+      type: 'mouse',
+      preventDefault: () => {},
+      stopPropagation: () => {},
+      stopImmediatePropagation: () => {}
+    };
+
+    normalizeNativeEvent(event);
+  })
+
+  it('handles touch events without preventDefault, stopPropagation and stopImmediatePropagation', () => {
+    const event = {};
+
+    normalizeNativeEvent(event);
+  });
+
+  it('handles touch events with preventDefault, stopPropagation and stopImmediatePropagation', () => {
+    const event = {
+      preventDefault: () => {},
+      stopPropagation: () => {},
+      stopImmediatePropagation: () => {}
+    };
+
+    normalizeNativeEvent(event);
+  })
+});

--- a/src/modules/normalizeNativeEvent/index.js
+++ b/src/modules/normalizeNativeEvent/index.js
@@ -45,14 +45,26 @@ function normalizeTouchEvent(nativeEvent) {
   const changedTouches = normalizeTouches(nativeEvent.changedTouches);
   const touches = normalizeTouches(nativeEvent.touches);
 
+  const preventDefault = nativeEvent.preventDefault != null
+    ? nativeEvent.preventDefault.bind(nativeEvent)
+    : () => {};
+
+  const stopImmediatePropagation = nativeEvent.stopImmediatePropagation != null
+    ? nativeEvent.preventDefault.bind(nativeEvent)
+    : () => {};
+
+  const stopPropagation = nativeEvent.stopPropagation != null
+    ? nativeEvent.stopPropagation.bind(nativeEvent)
+    : () => {};
+
   const event = {
     _normalized: true,
     changedTouches,
     pageX: nativeEvent.pageX,
     pageY: nativeEvent.pageY,
-    preventDefault: nativeEvent.preventDefault.bind(nativeEvent),
-    stopImmediatePropagation: nativeEvent.stopImmediatePropagation.bind(nativeEvent),
-    stopPropagation: nativeEvent.stopPropagation.bind(nativeEvent),
+    preventDefault: preventDefault,
+    stopImmediatePropagation: stopImmediatePropagation,
+    stopPropagation: stopPropagation,
     target: nativeEvent.target,
     // normalize the timestamp
     // https://stackoverflow.com/questions/26177087/ios-8-mobile-safari-wrong-timestamp-on-touch-events
@@ -89,6 +101,19 @@ function normalizeMouseEvent(nativeEvent) {
       timestamp: Date.now()
     }
   ];
+
+  const preventDefault = nativeEvent.preventDefault != null
+    ? nativeEvent.preventDefault.bind(nativeEvent)
+    : () => {};
+
+  const stopImmediatePropagation = nativeEvent.stopImmediatePropagation != null
+    ? nativeEvent.preventDefault.bind(nativeEvent)
+    : () => {};
+
+  const stopPropagation = nativeEvent.stopPropagation != null
+    ? nativeEvent.stopPropagation.bind(nativeEvent)
+    : () => {};
+
   return {
     _normalized: true,
     changedTouches: touches,
@@ -97,9 +122,9 @@ function normalizeMouseEvent(nativeEvent) {
     locationY: nativeEvent.offsetY,
     pageX: nativeEvent.pageX,
     pageY: nativeEvent.pageY,
-    preventDefault: nativeEvent.preventDefault.bind(nativeEvent),
-    stopImmediatePropagation: nativeEvent.stopImmediatePropagation.bind(nativeEvent),
-    stopPropagation: nativeEvent.stopPropagation.bind(nativeEvent),
+    preventDefault: preventDefault,
+    stopImmediatePropagation: stopImmediatePropagation,
+    stopPropagation: stopPropagation,
     target: nativeEvent.target,
     timestamp: touches[0].timestamp,
     touches: nativeEvent.type === 'mouseup' ? emptyArray : touches


### PR DESCRIPTION
The two functions normalizeTouchEvent() and normalizeMouseEvent() in `module/normalizeNativeEvent/index.js` assume the native event object contains the following three functions:

- preventDefault
- stopImmediatePropagation
- stopPropagation

However, events simulated by React Test Util (e.g. via Enzyme) do not contain these three functions, causing a crash when React Native Web tries to normalize (simulated) native events.

Adding a simple check before attempting to bind said three properties fixes the problem and enables click and touch events to be simulated when testing React components using Enzyme and JSDOM.

* React Native for Web (version): 0.0.119
* React (version): 15.4.2