### PR TITLE
Disallow text nodes as children of View

### DIFF
--- a/src/components/View/__tests__/index-test.js
+++ b/src/components/View/__tests__/index-test.js
@@ -12,10 +12,18 @@ describe('components/View', () => {
     });
   });
 
-  test('prop "children"', () => {
-    const children = <View testID="1" />;
-    const component = shallow(<View>{children}</View>);
-    expect(component.contains(children)).toEqual(true);
+  describe('prop "children"', () => {
+    test('text node throws error', () => {
+      const children = 'hello';
+      const render = () => shallow(<View>{children}</View>);
+      expect(() => render()).toThrow();
+    });
+
+    test('non-text is rendered', () => {
+      const children = <View testID="1" />;
+      const component = shallow(<View>{children}</View>);
+      expect(component.contains(children)).toEqual(true);
+    });
   });
 
   describe('prop "hitSlop"', () => {

--- a/src/components/View/index.js
+++ b/src/components/View/index.js
@@ -11,6 +11,7 @@ import applyLayout from '../../modules/applyLayout';
 import applyNativeMethods from '../../modules/applyNativeMethods';
 import { bool } from 'prop-types';
 import createElement from '../../modules/createElement';
+import invariant from 'fbjs/lib/invariant';
 import StyleSheet from '../../apis/StyleSheet';
 import ViewPropTypes from './ViewPropTypes';
 import React, { Component } from 'react';
@@ -48,6 +49,10 @@ class View extends Component {
       /* eslint-enable */
       ...otherProps
     } = this.props;
+
+    if (process.env.NODE_ENV !== 'production') {
+      invariant(typeof this.props.children !== 'string', 'A text node cannot be a child of a <View>');
+    }
 
     const { isInAParentText } = this.context;
 

--- a/src/propTypes/ColorPropType.js
+++ b/src/propTypes/ColorPropType.js
@@ -10,6 +10,9 @@
  * @flow
  */
 
+const isWebColor = (color: string) =>
+  color === 'currentcolor' || color === 'inherit' || color.indexOf('var(') === 0;
+
 const colorPropType = function(isRequired, props, propName, componentName, location, propFullName) {
   const normalizeColor = require('normalize-css-color');
   const color = props[propName];
@@ -35,8 +38,8 @@ const colorPropType = function(isRequired, props, propName, componentName, locat
     return;
   }
 
-  // Web supports additional color keywords and custom property values
-  if (color === 'currentcolor' || color === 'inherit' || color.indexOf('var(') === 0) {
+  if (typeof color === 'string' && isWebColor(color)) {
+    // Web supports additional color keywords and custom property values. Ignore them.
     return;
   }
 


### PR DESCRIPTION
Throws an error when a string is provided as a child of View