### PR TITLE
[fix] event normalization

### DIFF
--- a/src/modules/createElement/__tests__/__snapshots__/index-test.js.snap
+++ b/src/modules/createElement/__tests__/__snapshots__/index-test.js.snap
@@ -4,6 +4,9 @@ exports[`modules/createElement it normalizes event.nativeEvent 1`] = `
 Object {
   "_normalized": true,
   "changedTouches": Array [],
+  "identifier": undefined,
+  "locationX": undefined,
+  "locationY": undefined,
   "pageX": undefined,
   "pageY": undefined,
   "preventDefault": [Function],

--- a/src/modules/createElement/__tests__/index-test.js
+++ b/src/modules/createElement/__tests__/index-test.js
@@ -19,11 +19,7 @@ describe('modules/createElement', () => {
     };
     const component = shallow(createElement('span', { onClick }));
     component.find('span').simulate('click', {
-      nativeEvent: {
-        preventDefault() {},
-        stopImmediatePropagation() {},
-        stopPropagation() {}
-      }
+      nativeEvent: {}
     });
   });
 
@@ -38,11 +34,7 @@ describe('modules/createElement', () => {
             );
             component.find('span').simulate('keyPress', {
               isDefaultPrevented() {},
-              nativeEvent: {
-                preventDefault() {},
-                stopImmediatePropagation() {},
-                stopPropagation() {}
-              },
+              nativeEvent: {},
               preventDefault() {},
               which
             });

--- a/src/modules/normalizeNativeEvent/__tests__/__snapshots__/index-test.js.snap
+++ b/src/modules/normalizeNativeEvent/__tests__/__snapshots__/index-test.js.snap
@@ -1,0 +1,124 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`modules/normalizeNativeEvent mouse events simulated event 1`] = `
+Object {
+  "_normalized": true,
+  "changedTouches": Array [
+    Object {
+      "_normalized": true,
+      "clientX": undefined,
+      "clientY": undefined,
+      "force": undefined,
+      "identifier": 0,
+      "locationX": undefined,
+      "locationY": undefined,
+      "pageX": undefined,
+      "pageY": undefined,
+      "screenX": undefined,
+      "screenY": undefined,
+      "target": undefined,
+      "timestamp": 1496876171255,
+    },
+  ],
+  "identifier": 0,
+  "locationX": undefined,
+  "locationY": undefined,
+  "pageX": undefined,
+  "pageY": undefined,
+  "preventDefault": [Function],
+  "stopImmediatePropagation": [Function],
+  "stopPropagation": [Function],
+  "target": undefined,
+  "timestamp": 1496876171255,
+  "touches": Array [],
+}
+`;
+
+exports[`modules/normalizeNativeEvent mouse events synthetic event 1`] = `
+Object {
+  "_normalized": true,
+  "changedTouches": Array [
+    Object {
+      "_normalized": true,
+      "clientX": 100,
+      "clientY": 100,
+      "force": false,
+      "identifier": 0,
+      "locationX": 100,
+      "locationY": 100,
+      "pageX": 300,
+      "pageY": 300,
+      "screenX": 400,
+      "screenY": 400,
+      "target": undefined,
+      "timestamp": 1496876171255,
+    },
+  ],
+  "identifier": 0,
+  "locationX": 200,
+  "locationY": 200,
+  "pageX": 300,
+  "pageY": 300,
+  "preventDefault": [Function],
+  "stopImmediatePropagation": [Function],
+  "stopPropagation": [Function],
+  "target": undefined,
+  "timestamp": 1496876171255,
+  "touches": Array [],
+}
+`;
+
+exports[`modules/normalizeNativeEvent touch events simulated event 1`] = `
+Object {
+  "_normalized": true,
+  "changedTouches": Array [],
+  "identifier": undefined,
+  "locationX": undefined,
+  "locationY": undefined,
+  "pageX": undefined,
+  "pageY": undefined,
+  "preventDefault": [Function],
+  "stopImmediatePropagation": [Function],
+  "stopPropagation": [Function],
+  "target": undefined,
+  "timestamp": 1496876171255,
+  "touches": Array [],
+}
+`;
+
+exports[`modules/normalizeNativeEvent touch events synthetic event 1`] = `
+Object {
+  "_normalized": true,
+  "changedTouches": Array [
+    Object {
+      "_normalized": true,
+      "clientX": 100,
+      "clientY": 100,
+      "force": false,
+      "identifier": undefined,
+      "locationX": undefined,
+      "locationY": undefined,
+      "pageX": 300,
+      "pageY": 300,
+      "radiusX": 10,
+      "radiusY": 10,
+      "rotationAngle": 45,
+      "screenX": 400,
+      "screenY": 400,
+      "target": undefined,
+      "timestamp": 1496876171255,
+    },
+  ],
+  "identifier": undefined,
+  "locationX": undefined,
+  "locationY": undefined,
+  "pageX": 300,
+  "pageY": 300,
+  "preventDefault": [Function],
+  "stopImmediatePropagation": [Function],
+  "stopPropagation": [Function],
+  "target": undefined,
+  "timestamp": 1496876171255,
+  "touches": Array [],
+}
+`;

--- a/src/modules/normalizeNativeEvent/__tests__/index-test.js
+++ b/src/modules/normalizeNativeEvent/__tests__/index-test.js
@@ -1,0 +1,82 @@
+/* eslint-env jasmine, jest */
+
+import normalizeNativeEvent from '..';
+
+const normalizeEvent = (nativeEvent) => {
+  const result = normalizeNativeEvent(nativeEvent);
+  result.timestamp = 1496876171255;
+  if (result.changedTouches && result.changedTouches[0]) {
+    result.changedTouches[0].timestamp = 1496876171255;
+  }
+  if (result.touches && result.touches[0]) {
+    result.touches[0].timestamp = 1496876171255;
+  }
+  return result;
+}
+
+describe('modules/normalizeNativeEvent', () => {
+  describe('mouse events', () => {
+    test('simulated event', () => {
+      const nativeEvent = {
+        type: 'mouseup'
+      };
+
+      const result = normalizeEvent(nativeEvent);
+      expect(result).toMatchSnapshot();
+    });
+
+    test('synthetic event', () => {
+      const nativeEvent = {
+        type: 'mouseup',
+        clientX: 100,
+        clientY: 100,
+        force: false,
+        offsetX: 200,
+        offsetY: 200,
+        pageX: 300,
+        pageY: 300,
+        screenX: 400,
+        screenY: 400
+      };
+
+      const result = normalizeEvent(nativeEvent);
+      expect(result).toMatchSnapshot();
+    });
+  });
+
+  describe('touch events', () => {
+    test('simulated event', () => {
+      const nativeEvent = {
+        type: 'touchstart'
+      };
+
+      const result = normalizeEvent(nativeEvent);
+      expect(result).toMatchSnapshot();
+    });
+
+    test('synthetic event', () => {
+      const nativeEvent = {
+        type: 'touchstart',
+        changedTouches: [
+          {
+            clientX: 100,
+            clientY: 100,
+            force: false,
+            pageX: 300,
+            pageY: 300,
+            radiusX: 10,
+            radiusY: 10,
+            rotationAngle: 45,
+            screenX: 400,
+            screenY: 400
+          }
+        ],
+        pageX: 300,
+        pageY: 300
+      };
+
+      const result = normalizeEvent(nativeEvent);
+      expect(result).toMatchSnapshot();
+    });
+  });
+});


### PR DESCRIPTION
Work better with simulated events, and avoid crashing if
'nativeEvent.target' isn't an element node.

Close #597
