### PR TITLE
Update NetInfo API to conform to new React Native spec

### DIFF
--- a/docs/apis/NetInfo.md
+++ b/docs/apis/NetInfo.md
@@ -3,7 +3,7 @@
 `NetInfo` asynchronously determines the online/offline status of the
 application and depending on browser support, additional information about the connection.
 
-Effective Connection types:
+EffectiveConnectionType:
 
 * `4g`
 * `3g`
@@ -11,7 +11,7 @@ Effective Connection types:
 * `slow-2g`
 * `unknown`
 
-Deprecated Connection types:
+ConnectionType:
 
 * `bluetooth` - The user agent is using a Bluetooth connection.
 * `cellular` - The user agent is using a cellular connection (e.g., EDGE, HSPA, LTE, etc.).
@@ -55,7 +55,7 @@ Fetching the connection type:
 ```js
 NetInfo.getConnectionInfo().then(({ effectiveType, type }) => {
   console.log('Effective connection type:', effectiveType);
-  console.log('Legacy connection type:', type);
+  console.log('Connection type:', type);
 });
 ```
 
@@ -63,7 +63,7 @@ Subscribing to changes in the connection type:
 
 ```js
 const handleConnectivityTypeChange = ({ effectiveType }) => {
-  console.log('Current connection type:', effectiveType);
+  console.log('Current effective connection type:', effectiveType);
 }
 NetInfo.addEventListener('connectionChange', handleConnectivityTypeChange);
 ```

--- a/docs/apis/NetInfo.md
+++ b/docs/apis/NetInfo.md
@@ -1,9 +1,17 @@
 # NetInfo
 
 `NetInfo` asynchronously determines the online/offline status of the
-application.
+application and depending on browser support, additional information about the connection.
 
-Connection types:
+Effective Connection types:
+
+* `4g`
+* `3g`
+* `2g`
+* `slow-2g`
+* `unknown`
+
+Deprecated Connection types:
 
 * `bluetooth` - The user agent is using a Bluetooth connection.
 * `cellular` - The user agent is using a cellular connection (e.g., EDGE, HSPA, LTE, etc.).
@@ -18,12 +26,12 @@ Connection types:
 ## Methods
 
 Note that support for retrieving the connection type depends upon browswer
-support (and is limited to mobile browsers). It will default to `unknown` when
+support and the current platform. It will default to `unknown` when
 support is missing.
 
 static **addEventListener**(eventName: ChangeEventName, handler: Function)
 
-static **fetch**(): Promise
+static **getConnectionInfo**(): Promise
 
 static **removeEventListener**(eventName: ChangeEventName, handler: Function)
 
@@ -36,7 +44,7 @@ internet connectivity. Use this if you are only interested with whether the devi
 
 **isConnected.addEventListener**(eventName: ChangeEventName, handler: Function)
 
-**isConnected.fetch**(): Promise
+**isConnected.getConnectionInfo**(): Promise
 
 **isConnected.removeEventListener**(eventName: ChangeEventName, handler: Function)
 
@@ -45,24 +53,25 @@ internet connectivity. Use this if you are only interested with whether the devi
 Fetching the connection type:
 
 ```js
-NetInfo.fetch().then((connectionType) => {
-  console.log('Connection type:', connectionType);
+NetInfo.getConnectionInfo().then(({ effectiveType, type }) => {
+  console.log('Effective connection type:', effectiveType);
+  console.log('Legacy connection type:', type);
 });
 ```
 
 Subscribing to changes in the connection type:
 
 ```js
-const handleConnectivityTypeChange = (connectionType) => {
-  console.log('Current connection type:', connectionType);
+const handleConnectivityTypeChange = ({ effectiveType }) => {
+  console.log('Current connection type:', effectiveType);
 }
-NetInfo.addEventListener('change', handleConnectivityTypeChange);
+NetInfo.addEventListener('connectionChange', handleConnectivityTypeChange);
 ```
 
 Fetching the connection status:
 
 ```js
-NetInfo.isConnected.fetch().then((isConnected) => {
+NetInfo.isConnected.getConnectionInfo().then((isConnected) => {
   console.log('Connection status:', (isConnected ? 'online' : 'offline'));
 });
 ```
@@ -73,5 +82,5 @@ Subscribing to changes in the connection status:
 const handleConnectivityStatusChange = (isConnected) => {
   console.log('Current connection status:', (isConnected ? 'online' : 'offline'));
 }
-NetInfo.isConnected.addEventListener('change', handleConnectivityStatusChange);
+NetInfo.isConnected.addEventListener('connectionChange', handleConnectivityStatusChange);
 ```

--- a/docs/apis/NetInfo.md
+++ b/docs/apis/NetInfo.md
@@ -1,7 +1,9 @@
 # NetInfo
 
 `NetInfo` asynchronously determines the online/offline status of the
-application and depending on browser support, additional information about the connection.
+application and depending on browser support via
+[NetworkInformation API](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation),
+additional information about the connection.
 
 EffectiveConnectionType:
 

--- a/docs/storybook/2-apis/NetInfo/NetInfoScreen.js
+++ b/docs/storybook/2-apis/NetInfo/NetInfoScreen.js
@@ -17,12 +17,12 @@ const NetInfoScreen = () => (
   <UIExplorer title="NetInfo" url="2-apis/NetInfo">
     <Description>
       <AppText>
-        NetInfo asynchronously determines the online/offline status of the application.
+        NetInfo asynchronously determines the online/offline status and additional connection
+        information (where available) of the application.
       </AppText>
       <AppText>
-        Note that support for retrieving the connection type depends upon browser support (and is
-        limited to mobile browsers). It will default to <Code>unknown</Code> when support is
-        missing.
+        Note that support for retrieving the connection type depends upon browswer support and the
+        current platform. It will default to <Code>unknown</Code> when support is missing.
       </AppText>
     </Description>
 
@@ -30,9 +30,12 @@ const NetInfoScreen = () => (
       <DocItem
         description={[
           <AppText>
-            Invokes the listener whenever network status changes. The listener receives one of the
-            following connectivity types (from the DOM connection API):
+            Invokes the listener whenever network status changes. The listener an object with at
+            least <Code>effectiveType</Code> and <Code>type</Code> (from the DOM connection API):
           </AppText>,
+          <AppText style={{ fontWeight: '500' }}>effectiveType (EffectiveConnectionType)</AppText>,
+          <TextList items={['slow-2g', '2g', '3g', '4g', 'unknown']} />,
+          <AppText style={{ fontWeight: '500' }}>type (ConnectionType)</AppText>,
           <TextList
             items={[
               'bluetooth',
@@ -48,20 +51,21 @@ const NetInfoScreen = () => (
           />
         ]}
         example={{
-          code: "NetInfo.addEventListener('change', (connectionType) => {})"
+          code: "NetInfo.addEventListener('connectionChange', ({ effectiveType, type }) => {})"
         }}
         name="static addEventListener"
         typeInfo="(eventName, handler) => void"
       />
 
       <DocItem
-        description="Returns a promise that resolves with one of the connectivity types listed above."
+        description="Returns a promise that resolves with an object of the format listed above."
         example={{
-          code: `NetInfo.fetch().then((connectionType) => {
-  console.log('Connection type:', connectionType);
+          code: `NetInfo.getConnectionInfo().then(({ effectiveType, type }) => {
+  console.log('Effective connection type:', effectiveType);
+  console.log('Legacy connection type:', type);
 });`
         }}
-        name="static fetch"
+        name="static getConnectionInfo"
         typeInfo="() => Promise<string>"
       />
 
@@ -76,7 +80,7 @@ const NetInfoScreen = () => (
       <DocItem
         description="An object with the same methods as above but the listener receives a boolean which represents the internet connectivity. Use this if you are only interested with whether the device has internet connectivity."
         example={{
-          code: `NetInfo.isConnected.fetch().then((isConnected) => {
+          code: `NetInfo.isConnected.getConnectionInfo().then((isConnected) => {
   console.log('Connection status:', (isConnected ? 'online' : 'offline'));
 });`
         }}

--- a/docs/storybook/2-apis/NetInfo/NetInfoScreen.js
+++ b/docs/storybook/2-apis/NetInfo/NetInfoScreen.js
@@ -8,6 +8,7 @@ import UIExplorer, {
   Code,
   Description,
   DocItem,
+  ExternalLink,
   Section,
   storiesOf,
   TextList
@@ -22,7 +23,11 @@ const NetInfoScreen = () => (
       </AppText>
       <AppText>
         Note that support for retrieving the connection type depends upon browswer support and the
-        current platform. It will default to <Code>unknown</Code> when support is missing.
+        current platform. It will default to <Code>unknown</Code> when support is missing. Under the
+        hood it leverages the{' '}
+        <ExternalLink href="https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation">
+          NetworkInformation API
+        </ExternalLink>.
       </AppText>
     </Description>
 
@@ -31,7 +36,8 @@ const NetInfoScreen = () => (
         description={[
           <AppText>
             Invokes the listener whenever network status changes. The listener an object with at
-            least <Code>effectiveType</Code> and <Code>type</Code> (from the DOM connection API):
+            least <Code>effectiveType</Code> and <Code>type</Code>, plus any additional properties
+            from the browser's NetworkInformation API:
           </AppText>,
           <AppText style={{ fontWeight: '500' }}>effectiveType (EffectiveConnectionType)</AppText>,
           <TextList items={['slow-2g', '2g', '3g', '4g', 'unknown']} />,

--- a/src/apis/NetInfo/__tests__/index-test.js
+++ b/src/apis/NetInfo/__tests__/index-test.js
@@ -3,31 +3,44 @@
 import NetInfo from '..';
 
 describe('apis/NetInfo', () => {
+  describe('getConnectionInfo', () => {
+    test('fills out basic fields', done => {
+      NetInfo.getConnectionInfo().then(result => {
+        expect(result.effectiveType).toBeDefined();
+        expect(result.type).toBeDefined();
+        done();
+      });
+    });
+  });
+
   describe('isConnected', () => {
     const handler = () => {};
 
     afterEach(() => {
       try {
-        NetInfo.isConnected.removeEventListener('change', handler);
+        NetInfo.isConnected.removeEventListener('connectionChange', handler);
       } catch (e) {}
     });
 
     describe('addEventListener', () => {
       test('throws if the provided "eventType" is not supported', () => {
         expect(() => NetInfo.isConnected.addEventListener('foo', handler)).toThrow();
-        expect(() => NetInfo.isConnected.addEventListener('change', handler)).not.toThrow();
+        expect(() =>
+          NetInfo.isConnected.addEventListener('connectionChange', handler)
+        ).not.toThrow();
       });
     });
 
     describe('removeEventListener', () => {
       test('throws if the handler is not registered', () => {
-        expect(() => NetInfo.isConnected.removeEventListener('change', handler)).toThrow;
+        expect(() => NetInfo.isConnected.removeEventListener('connectionChange', handler)).toThrow;
       });
 
       test('throws if the provided "eventType" is not supported', () => {
-        NetInfo.isConnected.addEventListener('change', handler);
+        NetInfo.isConnected.addEventListener('connectionChange', handler);
         expect(() => NetInfo.isConnected.removeEventListener('foo', handler)).toThrow;
-        expect(() => NetInfo.isConnected.removeEventListener('change', handler)).not.toThrow;
+        expect(() => NetInfo.isConnected.removeEventListener('connectionChange', handler)).not
+          .toThrow;
       });
     });
   });

--- a/src/apis/NetInfo/index.js
+++ b/src/apis/NetInfo/index.js
@@ -20,7 +20,27 @@ const connection =
     window.navigator.mozConnection ||
     window.navigator.webkitConnection);
 
-const eventTypes = ['change'];
+// Prevent the underlying event handlers from leaking,
+// while still including additional info from the browser api
+const getConnectionInfoObject = () => {
+  const result = {};
+  if (!connection) {
+    return result;
+  }
+  for (const prop in connection) {
+    if (typeof connection[prop] !== 'function') {
+      result[prop] = connection[prop];
+    }
+  }
+  return result;
+};
+
+// Map react-native events to browser NetInfo events
+const eventTypesMap = {
+  change: 'change',
+  connectionChange: 'change'
+};
+const eventTypes = Object.keys(eventTypesMap);
 
 const connectionListeners = [];
 
@@ -31,6 +51,10 @@ const connectionListeners = [];
 const NetInfo = {
   addEventListener(type: string, handler: Function): { remove: () => void } {
     invariant(eventTypes.indexOf(type) !== -1, 'Trying to subscribe to unknown event: "%s"', type);
+    if (type === 'change') {
+      console.warn('Listening to event `change` is deprecated. Use `connectionChange` instead.');
+    }
+
     if (!connection) {
       console.error(
         'Network Connection API is not supported. Not listening for connection type changes.'
@@ -40,27 +64,43 @@ const NetInfo = {
       };
     }
 
-    connection.addEventListener(type, handler);
+    connection.addEventListener(eventTypesMap[type], handler);
     return {
-      remove: () => NetInfo.removeEventListener(type, handler)
+      remove: () => NetInfo.removeEventListener(eventTypesMap[type], handler)
     };
   },
 
   removeEventListener(type: string, handler: Function): void {
     invariant(eventTypes.indexOf(type) !== -1, 'Trying to subscribe to unknown event: "%s"', type);
+    if (type === 'change') {
+      console.warn('Listening to event `change` is deprecated. Use `connectionChange` instead.');
+    }
     if (!connection) {
       return;
     }
-    connection.removeEventListener(type, handler);
+    connection.removeEventListener(eventTypesMap[type], handler);
   },
 
   fetch(): Promise<any> {
+    console.warn('`fetch` is deprecated. Use `getConnectionInfo` instead.');
     return new Promise((resolve, reject) => {
       try {
         resolve(connection.type);
       } catch (err) {
         resolve('unknown');
       }
+    });
+  },
+
+  getConnectionInfo(): Promise<any> {
+    return new Promise((resolve, reject) => {
+      // Allow extra, browser-specifc fields to be returned
+      const result = {
+        effectiveType: 'unknown',
+        type: 'unknown',
+        ...getConnectionInfoObject()
+      };
+      resolve(result);
     });
   },
 
@@ -71,6 +111,10 @@ const NetInfo = {
         'Trying to subscribe to unknown event: "%s"',
         type
       );
+      if (type === 'change') {
+        console.warn('Listening to event `change` is deprecated. Use `connectionChange` instead.');
+      }
+
       const onlineCallback = () => handler(true);
       const offlineCallback = () => handler(false);
       connectionListeners.push([handler, onlineCallback, offlineCallback]);
@@ -79,7 +123,7 @@ const NetInfo = {
       window.addEventListener('offline', offlineCallback, false);
 
       return {
-        remove: () => NetInfo.isConnected.removeEventListener(type, handler)
+        remove: () => NetInfo.isConnected.removeEventListener(eventTypesMap[type], handler)
       };
     },
 
@@ -89,6 +133,9 @@ const NetInfo = {
         'Trying to subscribe to unknown event: "%s"',
         type
       );
+      if (type === 'change') {
+        console.warn('Listening to event `change` is deprecated. Use `connectionChange` instead.');
+      }
 
       const listenerIndex = findIndex(connectionListeners, pair => pair[0] === handler);
       invariant(
@@ -104,6 +151,11 @@ const NetInfo = {
     },
 
     fetch(): Promise<any> {
+      console.warn('`fetch` is deprecated. Use `getConnectionInfo` instead.');
+      return this.getConnectionInfo();
+    },
+
+    getConnectionInfo(): Promise<any> {
       return new Promise((resolve, reject) => {
         try {
           resolve(window.navigator.onLine);

--- a/src/apis/NetInfo/index.js
+++ b/src/apis/NetInfo/index.js
@@ -94,13 +94,11 @@ const NetInfo = {
 
   getConnectionInfo(): Promise<any> {
     return new Promise((resolve, reject) => {
-      // Allow extra, browser-specifc fields to be returned
-      const result = {
+      resolve({
         effectiveType: 'unknown',
         type: 'unknown',
         ...getConnectionInfoObject()
-      };
-      resolve(result);
+      });
     });
   },
 


### PR DESCRIPTION
Closes #662 
The [React Native NetInfo Spec](https://facebook.github.io/react-native/docs/netinfo.html) was updated to include a few new changes. 

This implements the following changes:
- fetch() is deprecated in favor of getConnectionInfo()
- eventName 'change' was deprecated in event handlers for the new 'connectionChange'
- returns from getConnectionInfo() and eventHandlers are now objects instead of string ConnectionType

**A few implementation notes:**
In order to prevent this from being a blocking change, I needed to support 'change' and 'connectionChange'. There's a few ways of mapping 'connectionChange' back to 'change', I'm open to other suggestions here.

I also added a little functionality which allows for incorporation of additional information beyond type and effectiveType in the returned objects. Chrome in particular supports other properties and I felt it gave users more flexibility to have access to those through this API as opposed to needed to re-implement their own duplicate functionality. In short, in addition to always returning type and effectiveType, we'll return whatever other props appear on navigator.connection.
