### PR TITLE
Set package.json module to use ES6 module for webpack/rollup.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.3",
   "description": "React Native for Web",
   "main": "dist/index.js",
-  "module": "dist/module.js",
+  "module": "src/module.js",
   "files": [
     "babel",
     "dist",


### PR DESCRIPTION
This just points the `package.json` `module` field at the uncompiled ES6 code, for use with webpack or rollup and tree shaking.
