### PR TITLE
Babel: Fix import path of ViewPropTypes and TextPropTypes

### DIFF
--- a/babel/index.js
+++ b/babel/index.js
@@ -69,10 +69,14 @@ const getDistLocation = importName => {
     // propTypes
     case 'ColorPropType':
     case 'EdgeInsetsPropType':
-    case 'PointPropType':
-    case 'TextPropTypes':
-    case 'ViewPropTypes': {
+    case 'PointPropType': {
       return `${root}/propTypes/${importName}`;
+    }
+    case 'TextPropTypes': {
+      return `${root}/components/Text/${importName}`;
+    }
+    case 'ViewPropTypes': {
+      return `${root}/components/View/${importName}`;
     }
 
     default:


### PR DESCRIPTION
These prop types file should be in `components/`.