### PR TITLE
[Babel plugin] Support 'export' statement

### DIFF
--- a/babel/__tests__/__snapshots__/index-test.js.snap
+++ b/babel/__tests__/__snapshots__/index-test.js.snap
@@ -122,7 +122,7 @@ export { Switch, Text, View as MyView, ViewPropTypes } from 'react-native';
 
 export { default as Switch } from 'react-native-web/dist/components/Switch';
 export { default as Text } from 'react-native-web/dist/components/Text';
-export { View as MyView } from 'react-native-web';
+export { default as MyView } from 'react-native-web/dist/components/View';
 export { default as ViewPropTypes } from 'react-native-web/dist/components/View/ViewPropTypes';
 "
 `;

--- a/babel/__tests__/__snapshots__/index-test.js.snap
+++ b/babel/__tests__/__snapshots__/index-test.js.snap
@@ -103,3 +103,59 @@ const { InvalidThing, TouchableOpacity } = require('react-native');
 const TouchableOpacity = require('react-native-web/dist/components/Touchable/TouchableOpacity');
 "
 `;
+
+exports[`10. Rewrite react-native paths for react-native-web 1`] = `
+"
+export { View } from 'react-native';
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+export { default as View } from 'react-native-web/dist/components/View';
+"
+`;
+
+exports[`11. Rewrite react-native paths for react-native-web 1`] = `
+"
+export { Switch, Text, View as MyView, ViewPropTypes } from 'react-native';
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+export { default as Switch } from 'react-native-web/dist/components/Switch';
+export { default as Text } from 'react-native-web/dist/components/Text';
+export { View as MyView } from 'react-native-web';
+export { default as ViewPropTypes } from 'react-native-web/dist/components/View/ViewPropTypes';
+"
+`;
+
+exports[`12. Rewrite react-native paths for react-native-web 1`] = `
+"
+export { createElement, Switch, StyleSheet } from 'react-native';
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+export { default as createElement } from 'react-native-web/dist/modules/createElement';
+export { default as Switch } from 'react-native-web/dist/components/Switch';
+export { default as StyleSheet } from 'react-native-web/dist/apis/StyleSheet';
+"
+`;
+
+exports[`13. Rewrite react-native paths for react-native-web 1`] = `
+"
+export { InvalidThing, TouchableOpacity } from 'react-native';
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+export { InvalidThing } from 'react-native-web';
+export { default as TouchableOpacity } from 'react-native-web/dist/components/Touchable/TouchableOpacity';
+"
+`;
+
+exports[`14. Rewrite react-native paths for react-native-web 1`] = `
+"
+export { default as RNW } from 'react-native';
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+export { default as RNW } from 'react-native-web';
+"
+`;

--- a/babel/__tests__/index-test.js
+++ b/babel/__tests__/index-test.js
@@ -30,6 +30,13 @@ pluginTester({
     // "let { Switch, Text, View: MyView } = require('react-native-web');",
     // "var { createElement, Switch, StyleSheet } = require('react-native-web');",
     // "const { InvalidThing, TouchableOpacity } = require('react-native-web');",
+
+    // export react-native
+    "export { View } from 'react-native';",
+    "export { Switch, Text, View as MyView, ViewPropTypes } from 'react-native';",
+    "export { createElement, Switch, StyleSheet } from 'react-native';",
+    "export { InvalidThing, TouchableOpacity } from 'react-native';",
+    "export { default as RNW } from 'react-native';",
     {
       code: "const RNW = require('react-native');",
       output: "const RNW = require('react-native');",

--- a/babel/index.js
+++ b/babel/index.js
@@ -127,6 +127,30 @@ module.exports = function({ types: t }) {
           path.replaceWithMultiple(imports);
         }
       },
+      ExportNamedDeclaration(path) {
+        const { source, specifiers } = path.node;
+        if (source.value === 'react-native' && specifiers.length) {
+          const exports = specifiers
+            .map(specifier => {
+              if (t.isExportSpecifier(specifier)) {
+                const exportName = specifier.exported.name
+                const distLocation = getDistLocation(exportName);
+
+                if (distLocation) {
+                  return t.exportNamedDeclaration(
+                    null,
+                    [t.exportSpecifier(t.identifier('default'), t.identifier(exportName))],
+                    t.stringLiteral(distLocation)
+                  );
+                }
+                return t.exportNamedDeclaration(null, [specifier], t.stringLiteral('react-native-web'));
+              }
+            })
+            .filter(Boolean)
+          
+          path.replaceWithMultiple(exports);
+        }
+      },
       VariableDeclaration(path) {
         if (isReactNativeRequire(t, path.node)) {
           const { id } = path.node.declarations[0];

--- a/babel/index.js
+++ b/babel/index.js
@@ -134,7 +134,8 @@ module.exports = function({ types: t }) {
             .map(specifier => {
               if (t.isExportSpecifier(specifier)) {
                 const exportName = specifier.exported.name
-                const distLocation = getDistLocation(exportName);
+                const localName = specifier.local.name
+                const distLocation = getDistLocation(localName);
 
                 if (distLocation) {
                   return t.exportNamedDeclaration(


### PR DESCRIPTION
Add support transpile `export` statement in babel plugin

```js
// from
export { View, Text } from 'react-native';
export { View as MyView } from 'react-native';
export { default as RNW } from 'react-native';

// to
export { default as View } from 'react-native-web/..';
export { default as Text } from 'react-native-web/..';
export { default as MyView } from 'react-native-web/..';
export { default as RNW } from 'react-native-web';
```