### PR TITLE
wip: Added Extend function to allow custom components

### DIFF
--- a/src/apis/Extend
+++ b/src/apis/Extend
@@ -1,3 +1,0 @@
-export default function(name, module){
-  this[name] = module
-}

--- a/src/apis/Extend
+++ b/src/apis/Extend
@@ -1,0 +1,3 @@
+export default function(name, module){
+  this[name] = module
+}

--- a/src/apis/Extend/index.js
+++ b/src/apis/Extend/index.js
@@ -1,0 +1,3 @@
+export default function(name, module){
+  this[name] = module
+}

--- a/src/module.js
+++ b/src/module.js
@@ -24,6 +24,7 @@ import Platform from './apis/Platform';
 import StyleSheet from './apis/StyleSheet';
 import UIManager from './apis/UIManager';
 import Vibration from './apis/Vibration';
+import Extend from './apis/Extend';
 
 // components
 import ActivityIndicator from './components/ActivityIndicator';
@@ -88,6 +89,7 @@ export {
   StyleSheet,
   UIManager,
   Vibration,
+  Extend,
   // components
   ActivityIndicator,
   Button,
@@ -153,6 +155,7 @@ const ReactNative = {
   StyleSheet,
   UIManager,
   Vibration,
+  Extend,
 
   // components
   ActivityIndicator,


### PR DESCRIPTION
this functions allows a user to register a react component to replace or extend the default ones.

So this is possible
`const Modal = class Test extends Component {
  render(){
    return (
      <div className="modal" style={{
        display: this.props.visible ? 'block' : 'none'
      }}>
        {this.props.children}
      </div>
    )
  }
}
ReactNative.OverWrite('Modal',  Modal)`