### PR TITLE
Fix typo in Dimensions doc

### DIFF
--- a/docs/storybook/2-apis/Dimensions/DimensionsScreen.js
+++ b/docs/storybook/2-apis/Dimensions/DimensionsScreen.js
@@ -43,7 +43,7 @@ const DimensionsScreen = () => (
       />
 
       <DocItem
-        name="static addEventLitener"
+        name="static addEventListener"
         typeInfo="(type: string, handler: function) => void"
         description={[
           <AppText>Add an event handler. Supported events:</AppText>,
@@ -65,7 +65,7 @@ const DimensionsScreen = () => (
       />
 
       <DocItem
-        name="static removeEventLitener"
+        name="static removeEventListener"
         typeInfo="(type: string, handler: function) => void"
         description="Remove an event handler."
       />


### PR DESCRIPTION
Fix typo of the`Dimensions.addEventListener` and 'Dimensions.removeEventListener' methods within the documentation.