### PR TITLE
Update TextInputState when TextInput is focused

### DIFF
--- a/src/components/TextInput/TextInputState.js
+++ b/src/components/TextInput/TextInputState.js
@@ -40,9 +40,11 @@ const TextInputState = {
    * noop if the text field was already focused
    */
   focusTextInput(textFieldNode: ?Object) {
-    if (document.activeElement !== textFieldNode && textFieldNode !== null) {
+    if (textFieldNode !== null) {
       this._currentlyFocusedNode = textFieldNode;
-      UIManager.focus(textFieldNode);
+      if (document.activeElement !== textFieldNode) {
+        UIManager.focus(textFieldNode);
+      }
     }
   },
 

--- a/src/components/TextInput/index.js
+++ b/src/components/TextInput/index.js
@@ -289,6 +289,9 @@ class TextInput extends Component {
   _handleFocus = e => {
     const { clearTextOnFocus, onFocus, selectTextOnFocus } = this.props;
     const node = this._node;
+
+    TextInputState.focusTextInput(this._node);
+
     if (onFocus) {
       onFocus(e);
     }


### PR DESCRIPTION
Problem: when you click on a `TextInput`, the `TextInputState` is not updated, thus, when you call `Keyboard.dismiss`, the `TextInput` is not blurred.
This PR fixes it. I'm not sure if this is the best solution though. 

Maybe `TextInputState._currentlyFocusedNode` should always be `document.activeElement`? 