### PR TITLE
Fix NetInfo API to return data directly instead of the event wrapper

### DIFF
--- a/src/apis/NetInfo/__tests__/index-test.js
+++ b/src/apis/NetInfo/__tests__/index-test.js
@@ -13,6 +13,27 @@ describe('apis/NetInfo', () => {
     });
   });
 
+  describe('event handlers', () => {
+    const handler = () => {};
+
+    describe('addEventListener', () => {
+      test('throws if the provided "eventType" is not supported', () => {
+        expect(() => NetInfo.addEventListener('foo', handler)).toThrow();
+        expect(() => NetInfo.addEventListener('connectionChange', handler)).not.toThrow();
+      });
+    });
+
+    describe('removeEventListener', () => {
+      test('throws if the handler is not registered', () => {
+        expect(() => NetInfo.removeEventListener('connectionChange', handler)).toThrow();
+      });
+
+      test('throws if the provided "eventType" is not supported', () => {
+        expect(() => NetInfo.removeEventListener('foo', handler)).toThrow();
+      });
+    });
+  });
+
   describe('isConnected', () => {
     const handler = () => {};
 
@@ -33,14 +54,17 @@ describe('apis/NetInfo', () => {
 
     describe('removeEventListener', () => {
       test('throws if the handler is not registered', () => {
-        expect(() => NetInfo.isConnected.removeEventListener('connectionChange', handler)).toThrow;
+        expect(() =>
+          NetInfo.isConnected.removeEventListener('connectionChange', handler)
+        ).toThrow();
       });
 
       test('throws if the provided "eventType" is not supported', () => {
         NetInfo.isConnected.addEventListener('connectionChange', handler);
-        expect(() => NetInfo.isConnected.removeEventListener('foo', handler)).toThrow;
-        expect(() => NetInfo.isConnected.removeEventListener('connectionChange', handler)).not
-          .toThrow;
+        expect(() => NetInfo.isConnected.removeEventListener('foo', handler)).toThrow();
+        expect(() =>
+          NetInfo.isConnected.removeEventListener('connectionChange', handler)
+        ).not.toThrow();
       });
     });
   });


### PR DESCRIPTION
**Problem**
Right now, when using addEventListener from the NetInfo API, the callback is called with an Event object. This means that end-users cannot use the same handler function as their initial call, and that further, it's not in conformance with the React Native spec. This was a bug in my initial implementation.

**Solution**
Create a wrapped event handler which gets the data out of the event and only passes that to the user-provided handler. The approach is similar to the existing connected functions. Since we are wrapping the handler, we create a key-value list of all handlers so that the user can use removeEventHandler with their initial handler reference. (Otherwise they'd have to take the return result and call .remove())