### PR TITLE
[fix] corrupt hydrate import breaking v0.2.0

### DIFF
--- a/src/apis/AppRegistry/renderApplication.js
+++ b/src/apis/AppRegistry/renderApplication.js
@@ -10,7 +10,7 @@
  */
 
 import invariant from 'fbjs/lib/invariant';
-import { hydrate } from '../../modules/hydrate';
+import hydrate from '../../modules/hydrate';
 import AppContainer from './AppContainer';
 import StyleSheet from '../../apis/StyleSheet';
 import React, { type ComponentType } from 'react';


### PR DESCRIPTION
I think, version v0.2.0 is broken due to named import of default export