### PR TITLE
[bug] initialize src/api/AppRegistry/AppContainer.js state

### DIFF
--- a/src/apis/AppRegistry/AppContainer.js
+++ b/src/apis/AppRegistry/AppContainer.js
@@ -29,6 +29,10 @@ type State = {
 };
 
 export default class AppContainer extends Component<Props, State> {
+  state = {
+    mainKey: 1  
+  };
+
   static childContextTypes = {
     rootTag: any
   };


### PR DESCRIPTION
regression from: https://github.com/necolas/react-native-web/commit/217ad97bfd3d4caf2ad04dd59ad9f04d7ec630e7

fixes 
```shell
fatal: Cannot read property 'mainKey' of undefined stack=TypeError: Cannot read property 'mainKey' of undefined
    at AppContainer.render (/Users/koulmomo/dev/debit-card-web/node_modules/react-native-web/dist/apis/AppRegistry/AppContainer.js:1:2563)
```

**Before submitting a pull request,** please make sure you have followed the steps the CONTRIBUTING guide.
