### PR TITLE
Add missing babel plugin dependency

### DIFF
--- a/website/guides/getting-started.md
+++ b/website/guides/getting-started.md
@@ -149,7 +149,7 @@ using [Webpack](https://webpack.js.org) and [Babel](https://babeljs.io/).
 Install webpack-related dependencies, for example:
 
 ```
-yarn add --dev babel-loader url-loader webpack webpack-dev-server
+yarn add --dev babel-loader url-loader webpack webpack-dev-server babel-plugin-transform-runtime
 ```
 
 Create a `web/webpack.config.js` file:


### PR DESCRIPTION
The transform-runtime plugin is used in the sample webpack config, but not suggested as a package to install.