### PR TITLE
Add husky to setup precommit hook automatically

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -99,6 +99,9 @@ To format and lint code before commit:
 yarn precommit
 ```
 
+**Note**: _this command is called automatically when you commit_
+thanks to [husky](https://github.com/typicode/husky).
+
 To format and lint the entire project:
 
 ```
@@ -118,8 +121,7 @@ that we won't want to accept.
 1. Fork the repository and create your branch from `master`.
 2. If you've added code that should be tested, add tests!
 3. If you've changed APIs, update the documentation.
-4. Lint and format your code (`yarn precommit`).
-5. Ensure the tests pass (`yarn test`).
+4. Ensure the tests pass (`yarn test`).
 
 You can now submit a pull request, referencing any issues it addresses.
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint-plugin-promise": "^3.6.0",
     "eslint-plugin-react": "^7.5.1",
     "flow-bin": "^0.61.0",
+    "husky": "^0.14.3",
     "jest": "^21.2.1",
     "lerna": "^2.5.1",
     "lint-staged": "^4.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4100,6 +4100,14 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
 
+husky@^0.14.3:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-0.14.3.tgz#c69ed74e2d2779769a17ba8399b54ce0b63c12c3"
+  dependencies:
+    is-ci "^1.0.10"
+    normalize-path "^1.0.0"
+    strip-indent "^2.0.0"
+
 hyphenate-style-name@^1.0.1, hyphenate-style-name@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
@@ -5608,6 +5616,10 @@ normalize-package-data@^2.3.0, normalize-package-data@^2.3.2, normalize-package-
     is-builtin-module "^1.0.0"
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
+
+normalize-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-1.0.0.tgz#32d0e472f91ff345701c15a8311018d3b0a90379"
 
 normalize-path@^2.0.0, normalize-path@^2.0.1:
   version "2.1.1"


### PR DESCRIPTION
Since the precommit command was actually called `precommit`, nothing to do more than installing husky as a dev dep!

Closes #755