### PR TITLE
Use prettier config instead of CLI args

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "docs:release": "cd website && yarn release",
     "flow": "flow",
     "fmt": "find packages scripts types website -name '*.js' | grep -v -E '(node_modules|dist|vendor)' | xargs yarn fmt:cmd",
-    "fmt:cmd": "prettier --print-width=100 --single-quote --write",
+    "fmt:cmd": "prettier --write",
     "jest": "jest --config ./scripts/jest/config.js",
     "lint": "yarn lint:check --fix",
     "lint:check": "eslint packages scripts website",
@@ -60,6 +60,10 @@
       "git update-index --again",
       "lint:cmd"
     ]
+  },
+  "prettier": {
+    "printWidth": 100,
+    "singleQuote": true
   },
   "author": "Nicolas Gallagher",
   "license": "BSD-3-Clause"


### PR DESCRIPTION
This allow IDE plugins that rely on prettier config (introduced in [1.6.0](https://github.com/prettier/prettier/pull/2434)) to detect prettier and run it automatically with the correct config!
