### PR TITLE
[fix] KeyboardAvoidingView missing this binding

### DIFF
--- a/packages/react-native-web/src/exports/KeyboardAvoidingView/index.js
+++ b/packages/react-native-web/src/exports/KeyboardAvoidingView/index.js
@@ -40,7 +40,7 @@ class KeyboardAvoidingView extends Component<*> {
 
   onKeyboardChange(event: Object) {}
 
-  onLayout(event: ViewLayoutEvent) {
+  onLayout = (event: ViewLayoutEvent) => {
     this.frame = event.nativeEvent.layout;
   }
 


### PR DESCRIPTION
Fixes `Uncaught TypeError: Cannot set property 'frame' of undefined`