### PR TITLE
Include Object.assign polyfill recommendation

### DIFF
--- a/website/guides/getting-started.md
+++ b/website/guides/getting-started.md
@@ -2,8 +2,8 @@
 
 This guide will help you to use and test React Native for Web once it has been installed.
 
-It is recommended that your application provide a `Promise` and `Array.from`
-polyfill.
+It is recommended that your application provide a `Promise`, `Object.assign`,
+and `Array.from` polyfill.
 
 ## Adding to a new web app
 


### PR DESCRIPTION
**Problem:** Since react-native-web@0.3.0, if you target older browsers, you will need to polyfill `Object.assign`. This was previously not a problem.

**Solution:** Add to the list of recommended polyfills in the getting started doc.