### PR TITLE
Add styled-jss to benchmarks

### DIFF
--- a/packages/benchmarks/package.json
+++ b/packages/benchmarks/package.json
@@ -21,6 +21,7 @@
     "react-jss": "8.2.1",
     "react-native-web": "^0.3.2",
     "reactxp": "0.51.0-alpha.9",
+    "styled-jss": "2.1.2",
     "styled-components": "2.4.0",
     "styletron-client": "3.0.2",
     "styletron-react": "3.0.3"

--- a/packages/benchmarks/src/implementations/styled-jss-core/Box.js
+++ b/packages/benchmarks/src/implementations/styled-jss-core/Box.js
@@ -1,0 +1,15 @@
+import styled from './styled';
+import View from './View';
+
+const COLORS = ['#14171A', '#AAB8C2', '#E6ECF0', '#FFAD1F', '#F45D22', '#E0245E'];
+
+const Box = styled(View)({
+  'align-self': 'flex-start',
+  'flex-direction': props => (props.layout === 'column' ? 'column' : 'row'),
+  padding: props => (props.outer ? '4px' : '0'),
+  height: props => (props.fixed ? '6px' : 'initial'),
+  width: props => (props.fixed ? '6px' : 'initial'),
+  'background-color': props => COLORS[props.color] || 'transparent'
+});
+
+export default Box;

--- a/packages/benchmarks/src/implementations/styled-jss-core/Dot.js
+++ b/packages/benchmarks/src/implementations/styled-jss-core/Dot.js
@@ -1,0 +1,21 @@
+import styled from './styled';
+
+const Dot = styled('div')({
+  position: 'absolute',
+  cursor: 'pointer',
+  width: 0,
+  height: 0,
+  'border-color': 'transparent',
+  'border-style': 'solid',
+  'border-top-width': 0,
+  transform: 'translateX(50%) translateY(50%)',
+
+  'border-bottom-color': props => props.color,
+  'border-right-width': props => `${props.size / 2}px`,
+  'border-bottom-width': props => `${props.size / 2}px`,
+  'border-left-width': props => `${props.size / 2}px`,
+  'margin-left': props => `${props.x}px`,
+  'margin-top': props => `${props.y}px`
+});
+
+export default Dot;

--- a/packages/benchmarks/src/implementations/styled-jss-core/Provider.js
+++ b/packages/benchmarks/src/implementations/styled-jss-core/Provider.js
@@ -1,0 +1,2 @@
+import View from './View';
+export default View;

--- a/packages/benchmarks/src/implementations/styled-jss-core/View.js
+++ b/packages/benchmarks/src/implementations/styled-jss-core/View.js
@@ -1,0 +1,19 @@
+import styled from './styled';
+
+const View = styled('div')({
+  'align-items': 'stretch',
+  'border-width': '0px',
+  'border-style': 'solid',
+  'box-sizing': 'border-box',
+  display: 'flex',
+  'flex-basis': 'auto',
+  'flex-direction': 'column',
+  'flex-shrink': '0',
+  margin: '0px',
+  padding: '0x',
+  position: 'relative',
+  'min-height': '0px',
+  'min-width': '0px'
+});
+
+export default View;

--- a/packages/benchmarks/src/implementations/styled-jss-core/index.js
+++ b/packages/benchmarks/src/implementations/styled-jss-core/index.js
@@ -1,0 +1,11 @@
+import Box from './Box';
+import Dot from './Dot';
+import Provider from './Provider';
+import View from './View';
+
+export default {
+  Box,
+  Dot,
+  Provider,
+  View
+};

--- a/packages/benchmarks/src/implementations/styled-jss-core/styled.js
+++ b/packages/benchmarks/src/implementations/styled-jss-core/styled.js
@@ -1,0 +1,8 @@
+import { create as createJss } from 'jss';
+import createStyled from 'styled-jss/createStyled';
+
+const jss = createJss();
+
+const Styled = createStyled(jss);
+
+export default Styled();

--- a/packages/benchmarks/src/implementations/styled-jss/Box.js
+++ b/packages/benchmarks/src/implementations/styled-jss/Box.js
@@ -1,0 +1,15 @@
+import styled from 'styled-jss';
+import View from './View';
+
+const COLORS = ['#14171A', '#AAB8C2', '#E6ECF0', '#FFAD1F', '#F45D22', '#E0245E'];
+
+const Box = styled(View)({
+  alignSelf: 'flex-start',
+  flexDirection: props => (props.layout === 'column' ? 'column' : 'row'),
+  padding: props => (props.outer ? 4 : 0),
+  height: props => (props.fixed ? 6 : 'initial'),
+  width: props => (props.fixed ? 6 : 'initial'),
+  backgroundColor: props => COLORS[props.color] || 'transparent'
+});
+
+export default Box;

--- a/packages/benchmarks/src/implementations/styled-jss/Dot.js
+++ b/packages/benchmarks/src/implementations/styled-jss/Dot.js
@@ -1,0 +1,21 @@
+import styled from 'styled-jss';
+
+const Dot = styled('div')({
+  position: 'absolute',
+  cursor: 'pointer',
+  width: 0,
+  height: 0,
+  borderColor: 'transparent',
+  borderStyle: 'solid',
+  borderTopWidth: 0,
+  transform: 'translateX(50%) translateY(50%)',
+
+  borderBottomColor: props => props.color,
+  borderRightWidth: props => props.size / 2,
+  borderBottomWidth: props => props.size / 2,
+  borderLeftWidth: props => props.size / 2,
+  marginLeft: props => props.x,
+  marginTop: props => props.y
+});
+
+export default Dot;

--- a/packages/benchmarks/src/implementations/styled-jss/Provider.js
+++ b/packages/benchmarks/src/implementations/styled-jss/Provider.js
@@ -1,0 +1,2 @@
+import View from './View';
+export default View;

--- a/packages/benchmarks/src/implementations/styled-jss/View.js
+++ b/packages/benchmarks/src/implementations/styled-jss/View.js
@@ -1,0 +1,20 @@
+import styled from 'styled-jss';
+
+const View = styled('div')({
+  alignItems: 'stretch',
+  borderWidth: 0,
+  borderStyle: 'solid',
+  boxSizing: 'border-box',
+  display: 'flex',
+  flexBasis: 'auto',
+  flexDirection: 'column',
+  flexShrink: 0,
+  margin: 0,
+  padding: 0,
+  position: 'relative',
+  // fix flexbox bugs
+  minHeight: 0,
+  minWidth: 0
+});
+
+export default View;

--- a/packages/benchmarks/src/implementations/styled-jss/index.js
+++ b/packages/benchmarks/src/implementations/styled-jss/index.js
@@ -1,0 +1,11 @@
+import Box from './Box';
+import Dot from './Dot';
+import Provider from './Provider';
+import View from './View';
+
+export default {
+  Box,
+  Dot,
+  Provider,
+  View
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -4709,6 +4709,10 @@ is-promise@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
 
+is-react-prop@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-react-prop/-/is-react-prop-1.0.0.tgz#b90040b44bde7c03e990c8d3046f87445577ee3f"
+
 is-redirect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
@@ -5209,15 +5213,15 @@ jss-compose@^5.0.0:
   dependencies:
     warning "^3.0.0"
 
-jss-default-unit@^8.0.0:
+jss-default-unit@^8.0.0, jss-default-unit@^8.0.2:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/jss-default-unit/-/jss-default-unit-8.0.2.tgz#cc1e889bae4c0b9419327b314ab1c8e2826890e6"
 
-jss-expand@^5.0.0:
+jss-expand@^5.0.0, jss-expand@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/jss-expand/-/jss-expand-5.1.0.tgz#b1ad74ec18631f34f65a2124fcfceb6400610e3d"
 
-jss-extend@^6.0.1:
+jss-extend@^6.0.1, jss-extend@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/jss-extend/-/jss-extend-6.1.0.tgz#85f3d39944018e8f44b322c14fa316068aa7bb0b"
   dependencies:
@@ -5232,6 +5236,21 @@ jss-nested@^6.0.1:
   resolved "https://registry.yarnpkg.com/jss-nested/-/jss-nested-6.0.1.tgz#ef992b79d6e8f63d939c4397b9d99b5cbbe824ca"
   dependencies:
     warning "^3.0.0"
+
+jss-preset-default@^4.0.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/jss-preset-default/-/jss-preset-default-4.1.0.tgz#8a07d8de92cb0c55b70dc1919b802aed9cc4ebe9"
+  dependencies:
+    jss-camel-case "^6.0.0"
+    jss-compose "^5.0.0"
+    jss-default-unit "^8.0.2"
+    jss-expand "^5.1.0"
+    jss-extend "^6.1.0"
+    jss-global "^3.0.0"
+    jss-nested "^6.0.1"
+    jss-props-sort "^6.0.0"
+    jss-template "^1.0.1"
+    jss-vendor-prefixer "^7.0.0"
 
 jss-preset-default@^4.0.1:
   version "4.0.1"
@@ -5258,11 +5277,25 @@ jss-template@^1.0.0:
   dependencies:
     warning "^3.0.0"
 
+jss-template@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/jss-template/-/jss-template-1.0.1.tgz#09aed9d86cc547b07f53ef355d7e1777f7da430a"
+  dependencies:
+    warning "^3.0.0"
+
 jss-vendor-prefixer@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/jss-vendor-prefixer/-/jss-vendor-prefixer-7.0.0.tgz#0166729650015ef19d9f02437c73667231605c71"
   dependencies:
     css-vendor "^0.3.8"
+
+jss@^9.0.0:
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/jss/-/jss-9.5.1.tgz#c869f38cdc44a32f4425fe007ea46b8891536326"
+  dependencies:
+    is-in-browser "^1.1.3"
+    symbol-observable "^1.1.0"
+    warning "^3.0.0"
 
 jss@^9.3.2:
   version "9.4.0"
@@ -7949,6 +7982,15 @@ styled-components@2.4.0:
     prop-types "^15.5.4"
     stylis "^3.4.0"
     supports-color "^3.2.3"
+
+styled-jss@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/styled-jss/-/styled-jss-2.1.2.tgz#6a899d56431578d84f219b1dd7652cdfc46dae9c"
+  dependencies:
+    is-observable "^0.2.0"
+    is-react-prop "^1.0.0"
+    jss "^9.0.0"
+    jss-preset-default "^4.0.0"
 
 styletron-client@3.0.2, styletron-client@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
Thank you a lot for this project!

And we would be glad to add [styled-jss](https://github.com/cssinjs/styled-jss) to benchmark list. There are two versions: the **core** and the **default** version with some plugins out of the box, so the core is a bit faster.

<details>
<summary>There are some results on my machine</summary>

![image](https://user-images.githubusercontent.com/11135392/35125150-9faf7654-fcb9-11e7-9f45-104f4f2b6dbb.png)

![image](https://user-images.githubusercontent.com/11135392/35125160-a6230c6c-fcb9-11e7-846c-0709a0845393.png)

![image](https://user-images.githubusercontent.com/11135392/35125165-aa2be3f6-fcb9-11e7-81f9-8f98bd9f5dd0.png)
</details>
&nbsp;

Thanks!