### PR TITLE
Update CONTRIBUTING.md with proper benchmarks instructions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -85,10 +85,18 @@ yarn compile --watch
 
 ## Benchmarks
 
-To run the performance benchmarks in a browser (opening `./packages/benchmarks/index.html`):
+To run the benchmarks locally:
 
 ```
-yarn benchmarks
+yarn benchmark
+open ./packages/benchmarks/dist/index.html
+```
+
+To develop against these benchmarks:
+
+```
+yarn compile --watch
+yarn benchmark --watch
 ```
 
 ### New Features

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -88,7 +88,7 @@ yarn compile --watch
 To run the benchmarks locally:
 
 ```
-yarn benchmark
+yarn benchmarks
 open ./packages/benchmarks/dist/index.html
 ```
 
@@ -96,7 +96,7 @@ To develop against these benchmarks:
 
 ```
 yarn compile --watch
-yarn benchmark --watch
+yarn benchmarks --watch
 ```
 
 ### New Features

--- a/packages/benchmarks/README.md
+++ b/packages/benchmarks/README.md
@@ -5,7 +5,7 @@ Try the [benchmarks app](https://necolas.github.io/react-native-web/benchmarks) 
 To run the benchmarks locally:
 
 ```
-yarn benchmark
+yarn benchmarks
 open ./packages/benchmarks/dist/index.html
 ```
 
@@ -13,7 +13,7 @@ Develop against these benchmarks:
 
 ```
 yarn compile --watch
-yarn benchmark --watch
+yarn benchmarks --watch
 ```
 
 ## Notes


### PR DESCRIPTION
These were just copied from `benchmarks/readme.md`, but the old ones were outdated (need to open `benchmarks/dist/index.html`) and didn't mention how to develop against them.