### PR TITLE
[fix] Update the ImageBackground source link

### DIFF
--- a/website/storybook/1-components/Image/ImageBackgroundScreen.js
+++ b/website/storybook/1-components/Image/ImageBackgroundScreen.js
@@ -9,7 +9,7 @@ import PropChildren from './examples/PropChildren';
 import UIExplorer, { Description, DocItem, Section, storiesOf } from '../../ui-explorer';
 
 const ImageBackgroundScreen = () => (
-  <UIExplorer title="ImageBackground" url="1-components/ImageBackground">
+  <UIExplorer title="ImageBackground" url="1-components/Image">
     <Description>A image component with support for child content.</Description>
 
     <Section title="Props">


### PR DESCRIPTION
Update the `ImageBackground` "view source" link URL to match the
location within repository. The previous URL returned a 404.