### PR TITLE
Make it harder to break out of the string literal

### DIFF
--- a/packages/react-native-web/src/exports/Linking/index.js
+++ b/packages/react-native-web/src/exports/Linking/index.js
@@ -57,7 +57,7 @@ const iframeOpen = url => {
       const openerExpression = noOpener ? 'child.opener = null' : '';
       script.text = `
         window.parent = null; window.top = null; window.frameElement = null;
-        var child = window.open("${url}"); ${openerExpression};
+        var child = window.open(${JSON.stringify(url)}); ${openerExpression};
       `;
       iframeBody.appendChild(script);
     }


### PR DESCRIPTION
This change ensures `Linking` → `openURL` → `iframeOpen` handles URL-unescaped quotes in the `url` parameter correctly.
