### PR TITLE
[fix] Picker default font styles

### DIFF
--- a/packages/react-native-web/src/exports/Picker/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/react-native-web/src/exports/Picker/__tests__/__snapshots__/index-test.js.snap
@@ -10,7 +10,7 @@ exports[`components/Picker prop "children" items 1`] = `
 
 exports[`components/Picker prop "children" renders items 1`] = `
 <select
-  className="rn-fontFamily-poiln3 rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw"
+  className="rn-fontFamily-10u92zi rn-fontSize-7cikom rn-marginTop-1mnahxq rn-marginRight-61z16t rn-marginBottom-p1pxzi rn-marginLeft-11wrixw"
   onChange={[Function]}
 >
   <PickerItem

--- a/packages/react-native-web/src/exports/Picker/index.js
+++ b/packages/react-native-web/src/exports/Picker/index.js
@@ -82,7 +82,7 @@ class Picker extends Component<Props> {
 
 const styles = StyleSheet.create({
   initial: {
-    fontFamily: 'inherit',
+    fontFamily: 'System',
     fontSize: 'inherit',
     margin: 0
   }


### PR DESCRIPTION
**Problem:** Picker was using `Times` as the font-style, because it was using `inherit`.

**Solution:** Same as applied for `TextInput` in b28cbbb37ece3476a40370d359e982b4ba563bbb, set `fontFamily` to `System`