### PR TITLE
ignore tvParallaxProperties prop

### DIFF
--- a/packages/react-native-web/src/exports/Text/index.js
+++ b/packages/react-native-web/src/exports/Text/index.js
@@ -53,6 +53,7 @@ class Text extends Component<*> {
       selectionColor,
       suppressHighlighting,
       textBreakStrategy,
+      tvParallaxProperties,
       /* eslint-enable */
       ...otherProps
     } = this.props;

--- a/packages/react-native-web/src/exports/View/ViewPropTypes.js
+++ b/packages/react-native-web/src/exports/View/ViewPropTypes.js
@@ -12,7 +12,7 @@
 import EdgeInsetsPropType, { type EdgeInsetsProp } from '../EdgeInsetsPropType';
 import StyleSheetPropType from '../../modules/StyleSheetPropType';
 import ViewStylePropTypes from './ViewStylePropTypes';
-import { any, array, bool, func, oneOf, oneOfType, string } from 'prop-types';
+import { any, array, bool, func, object, oneOf, oneOfType, string } from 'prop-types';
 
 const stylePropType = StyleSheetPropType(ViewStylePropTypes);
 
@@ -74,7 +74,8 @@ export type ViewProps = {
   onMagicTap?: Function,
   removeClippedSubviews?: boolean,
   renderToHardwareTextureAndroid?: boolean,
-  shouldRasterizeIOS?: boolean
+  shouldRasterizeIOS?: boolean,
+  tvParallaxProperties?: any
 };
 
 const ViewPropTypes = {
@@ -122,7 +123,8 @@ const ViewPropTypes = {
   onMagicTap: func,
   removeClippedSubviews: bool,
   renderToHardwareTextureAndroid: bool,
-  shouldRasterizeIOS: bool
+  shouldRasterizeIOS: bool,
+  tvParallaxProperties: object
 };
 
 export default ViewPropTypes;

--- a/packages/react-native-web/src/exports/View/index.js
+++ b/packages/react-native-web/src/exports/View/index.js
@@ -49,6 +49,7 @@ class View extends Component<ViewProps> {
       removeClippedSubviews,
       renderToHardwareTextureAndroid,
       shouldRasterizeIOS,
+      tvParallaxProperties,
       /* eslint-enable */
       ...otherProps
     } = this.props;


### PR DESCRIPTION
Based off of #753, this ignores `tvParallaxProperties`, which only applies to AppleTV [per the RN docs](https://facebook.github.io/react-native/docs/touchablehighlight.html#tvparallaxproperties).