### PR TITLE
Add webpack-cli to the required set of packages to get started

### DIFF
--- a/website/guides/getting-started.md
+++ b/website/guides/getting-started.md
@@ -155,7 +155,7 @@ using [Webpack](https://webpack.js.org) and [Babel](https://babeljs.io/).
 Install webpack-related dependencies, for example:
 
 ```
-yarn add --dev babel-loader url-loader webpack webpack-dev-server
+yarn add --dev babel-loader url-loader webpack webpack-cli webpack-dev-server
 ```
 
 Create a `web/webpack.config.js` file:


### PR DESCRIPTION
Small change to avoid webpack requesting the webpack-cli installed before trying to read webpack.config.js.