### PR TITLE
[change] Add key to style element

### DIFF
--- a/packages/react-native-web/src/exports/AppRegistry/renderApplication.js
+++ b/packages/react-native-web/src/exports/AppRegistry/renderApplication.js
@@ -41,7 +41,7 @@ export function getApplication(RootComponent: ComponentType<Object>, initialProp
   // Don't escape CSS text
   const getStyleElement = () => {
     const sheet = styleResolver.getStyleSheet();
-    return <style dangerouslySetInnerHTML={{ __html: sheet.textContent }} id={sheet.id} />;
+    return <style dangerouslySetInnerHTML={{ __html: sheet.textContent }} id={sheet.id} key={sheet.id} />;
   };
   return { element, getStyleElement };
 }


### PR DESCRIPTION
Add a `key` attribute to the style tag returned from `getStyleElement`
to avoid warnings like the following.

```
Warning: Each child in an array or iterator should have a unique "key" prop.

Check the top-level render call using <head>. See https://fb.me/react-warning-keys for more information.
```