### PR TITLE
Use window.open to open URLs on Linking.openURL

### DIFF
--- a/packages/react-native-web/src/exports/Linking/index.js
+++ b/packages/react-native-web/src/exports/Linking/index.js
@@ -33,11 +33,7 @@ const Linking = {
 };
 
 const open = url => {
-  const anchor = document.createElement('a');
-  anchor.target = '_blank'; // :(
-  anchor.rel = 'noopener';
-  anchor.href = url;
-  anchor.click();
+  window.open(url, '_blank')
 };
 
 export default Linking;


### PR DESCRIPTION
Fix #883
Alternative PR: #884 

> Tested on Chrome and Firefox