### PR TITLE
Update Phenomic integration link to official example

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Examples of using React Native for Web with other web tools:
 * [Next.js](https://github.com/zeit/next.js/tree/master/examples/with-react-native-web)
 * [Storybook](https://github.com/necolas/react-native-web/tree/0.5.1/website/storybook/.storybook)
 * [Razzle](https://github.com/jaredpalmer/razzle/tree/master/examples/with-react-native-web)
-* [Phenomic](https://github.com/phenomic/phenomic/tree/v1.0.0-alpha.20/docs)
+* [Phenomic](https://github.com/phenomic/phenomic/tree/master/examples/react-native-web-app)
 * [Styleguidist](https://github.com/styleguidist/react-styleguidist/tree/v6.2.6/examples/react-native)
 
 ## Contributing


### PR DESCRIPTION
I just pushed a minimal example https://github.com/phenomic/phenomic/tree/master/examples/react-native-web-app

[See full (but small) commit](https://github.com/phenomic/phenomic/commit/dd9d19f6e3a5dba60e7262311c8eb060d8661070)

This example use 0.5.0 and is tested (like all our examples, to ensure styles are correctly pre-rendered) to avoid regressions (in case of upgrade etc).

No plugin needed since Phenomic api is flexible enough :)

(I will add a README in this folder soon, but code is light enough to be understand without further explanations ^^)
