### PR TITLE
Fix onPress event accidentally triggered while scrolling the page

### DIFF
--- a/packages/react-native-web/src/exports/TouchableHighlight/index.js
+++ b/packages/react-native-web/src/exports/TouchableHighlight/index.js
@@ -163,7 +163,12 @@ const TouchableHighlight = createReactClass({
     this.clearTimeout(this._hideTimeout);
     this._showUnderlay();
     this._hideTimeout = this.setTimeout(this._hideUnderlay, this.props.delayPressOut || 100);
-    this.props.onPress && this.props.onPress(e);
+    
+    const touchBank = e.touchHistory.touchBank[e.touchHistory.indexOfSingleActiveTouch];
+    const offset = Math.sqrt(Math.pow(touchBank.startPageX - touchBank.currentPageX, 2)
+      + Math.pow(touchBank.startPageY - touchBank.currentPageY, 2));
+    const velocity = (offset / (touchBank.currentTimeStamp - touchBank.startTimeStamp)) * 1000;
+    if (velocity < 100) this.props.onPress && this.props.onPress(e);
   },
 
   touchableHandleLongPress: function(e: Event) {

--- a/packages/react-native-web/src/exports/TouchableOpacity/index.js
+++ b/packages/react-native-web/src/exports/TouchableOpacity/index.js
@@ -113,7 +113,11 @@ const TouchableOpacity = createReactClass({
   },
 
   touchableHandlePress: function(e: Event) {
-    this.props.onPress && this.props.onPress(e);
+    const touchBank = e.touchHistory.touchBank[e.touchHistory.indexOfSingleActiveTouch];
+    const offset = Math.sqrt(Math.pow(touchBank.startPageX - touchBank.currentPageX, 2)
+      + Math.pow(touchBank.startPageY - touchBank.currentPageY, 2));
+    const velocity = (offset / (touchBank.currentTimeStamp - touchBank.startTimeStamp)) * 1000;
+    if (velocity < 100) this.props.onPress && this.props.onPress(e);
   },
 
   touchableHandleLongPress: function(e: Event) {

--- a/packages/react-native-web/src/exports/TouchableWithoutFeedback/index.js
+++ b/packages/react-native-web/src/exports/TouchableWithoutFeedback/index.js
@@ -109,7 +109,11 @@ const TouchableWithoutFeedback = createReactClass({
    * defined on your component.
    */
   touchableHandlePress: function(e: Event) {
-    this.props.onPress && this.props.onPress(e);
+    const touchBank = e.touchHistory.touchBank[e.touchHistory.indexOfSingleActiveTouch];
+    const offset = Math.sqrt(Math.pow(touchBank.startPageX - touchBank.currentPageX, 2)
+      + Math.pow(touchBank.startPageY - touchBank.currentPageY, 2));
+    const velocity = (offset / (touchBank.currentTimeStamp - touchBank.startTimeStamp)) * 1000;
+    if (velocity < 100) this.props.onPress && this.props.onPress(e);
   },
 
   touchableHandleActivePressIn: function(e: Event) {


### PR DESCRIPTION
The touchable components are likely to be miss triggered while scrolling the page. We can fix this issues by judging by touch velocity to make a distinction between press or scroll;