### PR TITLE
Fix 2048 on desktop browsers

### DIFF
--- a/website/storybook/3-demos/Game2048/Game2048.js
+++ b/website/storybook/3-demos/Game2048/Game2048.js
@@ -184,7 +184,7 @@ class Game2048 extends React.Component {
     this.setState({ board: new GameBoard() });
   };
 
-  _handleTouchStart = (event: Object) => {
+  _handleStart = (event: Object) => {
     if (this.state.board.hasWon()) {
       return;
     }
@@ -193,7 +193,7 @@ class Game2048 extends React.Component {
     this.startY = event.nativeEvent.pageY;
   };
 
-  _handleTouchEnd = (event: Object) => {
+  _handleEnd = (event: Object) => {
     if (this.state.board.hasWon()) {
       return;
     }
@@ -220,8 +220,10 @@ class Game2048 extends React.Component {
 
     return (
       <View
-        onTouchEnd={this._handleTouchEnd}
-        onTouchStart={this._handleTouchStart}
+        onMouseDown={this._handleStart}
+        onMouseUp={this._handleEnd}
+        onTouchEnd={this._handleEnd}
+        onTouchStart={this._handleStart}
         style={styles.container}
       >
         <Board>{tiles}</Board>


### PR DESCRIPTION
One thing I found out while working on #908 this is that the 2048 game demo does not work on browsers since it listens for touch events only.

This can be solved by listening to both mouse and touch events - or perhaps there is a more RNW idiomatic way of solving this?