### PR TITLE
Set Switch thumb position to absolute

### DIFF
--- a/packages/react-native-web/src/exports/Switch/index.js
+++ b/packages/react-native-web/src/exports/Switch/index.js
@@ -188,7 +188,7 @@ const styles = StyleSheet.create({
     backgroundColor: '#D5D5D5'
   },
   thumb: {
-    alignSelf: 'flex-start',
+    position: 'absolute',
     borderRadius: '100%',
     boxShadow: thumbDefaultBoxShadow,
     start: '0%',


### PR DESCRIPTION
Thumb positioning breaks in RTL layout because `right: 0%` with relative positioning does nothing. Setting the position to absolute fixes it
