### PR TITLE
Un-deprecate NetInfo.isConnected.fetch()

### DIFF
--- a/packages/react-native-web/src/exports/NetInfo/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/NetInfo/__tests__/index-test.js
@@ -37,6 +37,15 @@ describe('apis/NetInfo', () => {
       } catch (e) {}
     });
 
+    describe('fetch', () => {
+      test('returns a boolean', done => {
+        NetInfo.isConnected.fetch().then(isConnected => {
+          expect(isConnected).toBe(true);
+          done();
+        });
+      });
+    });
+
     describe('addEventListener', () => {
       test('throws if the provided "eventType" is not supported', () => {
         expect(() => NetInfo.isConnected.addEventListener('foo', handler)).toThrow();

--- a/packages/react-native-web/src/exports/NetInfo/index.js
+++ b/packages/react-native-web/src/exports/NetInfo/index.js
@@ -156,11 +156,6 @@ const NetInfo = {
     },
 
     fetch(): Promise<boolean> {
-      console.warn('`fetch` is deprecated. Use `getConnectionInfo` instead.');
-      return NetInfo.isConnected.getConnectionInfo();
-    },
-
-    getConnectionInfo(): Promise<boolean> {
       return new Promise((resolve, reject) => {
         try {
           resolve(window.navigator.onLine);
@@ -168,6 +163,13 @@ const NetInfo = {
           resolve(true);
         }
       });
+    },
+
+    getConnectionInfo(): Promise<boolean> {
+      console.warn(
+        '`isConnected.getConnectionInfo()` is deprecated. Use `isConnected.fetch()` instead.'
+      );
+      return NetInfo.isConnected.fetch();
     }
   }
 };

--- a/website/storybook/2-apis/NetInfo/NetInfoScreen.js
+++ b/website/storybook/2-apis/NetInfo/NetInfoScreen.js
@@ -107,9 +107,9 @@ const NetInfoScreen = () => (
 
     <Section title="Properties">
       <DocItem
-        description="An object with the same methods as above but the listener receives a boolean which represents the internet connectivity. Use this if you are only interested with whether the device has internet connectivity."
+        description="An object with similar methods as above but the listener receives a boolean which represents the internet connectivity. Use this if you are only interested with whether the device has internet connectivity."
         example={{
-          code: `NetInfo.isConnected.getConnectionInfo().then((isConnected) => {
+          code: `NetInfo.isConnected.fetch().then((isConnected) => {
   console.log('Connection status:', (isConnected ? 'online' : 'offline'));
 });`
         }}


### PR DESCRIPTION
React Native does *not* have a `NetInfo.isConnected.getConnectionInfo()` method, so this change makes react-native-web conform to that API.

NetInfo docs: https://facebook.github.io/react-native/docs/netinfo.html#isconnected
