### PR TITLE
[fix] onLayout timing without ResizeObserver 

### DIFF
--- a/packages/react-native-web/src/exports/AppRegistry/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/AppRegistry/__tests__/index-test.js
@@ -39,6 +39,14 @@ describe('AppRegistry', () => {
       expect(styleElement).toMatchSnapshot();
     });
 
+    test('"getStyleElement" adds props to <style>', () => {
+      const nonce = '2Bz9RM/UHvBbmo3jK/PbYZ==';
+      AppRegistry.registerComponent('App', () => RootComponent);
+      const { getStyleElement } = AppRegistry.getApplication('App', {});
+      const styleElement = getStyleElement({ nonce });
+      expect(styleElement.props.nonce).toBe(nonce);
+    });
+
     test('"getStyleElement" produces styles that are a function of rendering "element"', () => {
       const getApplicationStyles = appName => {
         const { element, getStyleElement } = AppRegistry.getApplication(appName, {});

--- a/packages/react-native-web/src/exports/AppRegistry/renderApplication.js
+++ b/packages/react-native-web/src/exports/AppRegistry/renderApplication.js
@@ -46,9 +46,11 @@ export function getApplication(
     </AppContainer>
   );
   // Don't escape CSS text
-  const getStyleElement = () => {
+  const getStyleElement = props => {
     const sheet = styleResolver.getStyleSheet();
-    return <style dangerouslySetInnerHTML={{ __html: sheet.textContent }} id={sheet.id} />;
+    return (
+      <style {...props} dangerouslySetInnerHTML={{ __html: sheet.textContent }} id={sheet.id} />
+    );
   };
   return { element, getStyleElement };
 }

--- a/packages/react-native-web/src/exports/StyleSheet/StyleSheetManager.js
+++ b/packages/react-native-web/src/exports/StyleSheet/StyleSheetManager.js
@@ -69,10 +69,6 @@ export default class StyleSheetManager {
     return className;
   }
 
-  injectKeyframe(): string {
-    // return identifier;
-  }
-
   _addToCache(className, prop, value) {
     const cache = this._cache;
     if (!cache.byProp[prop]) {

--- a/packages/react-native-web/src/exports/StyleSheet/WebStyleSheet.js
+++ b/packages/react-native-web/src/exports/StyleSheet/WebStyleSheet.js
@@ -8,6 +8,7 @@
  */
 
 import { canUseDOM } from 'fbjs/lib/ExecutionEnvironment';
+import modality from './modality';
 
 export default class WebStyleSheet {
   _cssRules = [];
@@ -29,6 +30,7 @@ export default class WebStyleSheet {
       }
 
       if (domStyleElement) {
+        modality(domStyleElement);
         // $FlowFixMe
         this._sheet = domStyleElement.sheet;
         this._textContent = domStyleElement.textContent;

--- a/packages/react-native-web/src/exports/StyleSheet/index.js
+++ b/packages/react-native-web/src/exports/StyleSheet/index.js
@@ -1,8 +1,4 @@
-import modality from '../../modules/modality';
 import StyleSheet from './StyleSheet';
-
-// initialize focus-ring fix
-modality();
 
 // allow component styles to be editable in React Dev Tools
 if (process.env.NODE_ENV !== 'production') {

--- a/packages/react-native-web/src/exports/StyleSheet/modality.js
+++ b/packages/react-native-web/src/exports/StyleSheet/modality.js
@@ -18,12 +18,11 @@
 
 import { canUseDOM } from 'fbjs/lib/ExecutionEnvironment';
 
-const modality = () => {
+const modality = styleElement => {
   if (!canUseDOM) {
     return;
   }
 
-  let styleElement;
   let hadKeyboardEvent = false;
   let keyboardThrottleTimeoutID = 0;
 
@@ -56,21 +55,6 @@ const modality = () => {
   ].join(',');
 
   /**
-   * Disable the focus ring by default
-   */
-  const initialize = () => {
-    // check if the style sheet needs to be created
-    const id = 'react-native-modality';
-    styleElement = document.getElementById(id);
-    if (!styleElement) {
-      // removes focus styles by default
-      const style = `<style id="${id}">:focus { outline: none; }</style>`;
-      document.head.insertAdjacentHTML('afterbegin', style);
-      styleElement = document.getElementById(id);
-    }
-  };
-
-  /**
    * Computes whether the given element should automatically trigger the
    * `focus-ring`.
    */
@@ -83,20 +67,21 @@ const modality = () => {
   };
 
   /**
-   * Add the focus ring to the focused element
+   * Add the focus ring style
    */
   const addFocusRing = () => {
     if (styleElement) {
-      styleElement.disabled = true;
+      styleElement.sheet.deleteRule(0);
     }
   };
 
   /**
-   * Remove the focus ring
+   * Remove the focus ring style
    */
   const removeFocusRing = () => {
     if (styleElement) {
-      styleElement.disabled = false;
+      const rule = ':focus { outline: none; }';
+      styleElement.sheet.insertRule(rule, 0);
     }
   };
 
@@ -136,7 +121,7 @@ const modality = () => {
   };
 
   if (document.body && document.body.addEventListener) {
-    initialize();
+    removeFocusRing();
     document.body.addEventListener('keydown', handleKeyDown, true);
     document.body.addEventListener('focus', handleFocus, true);
     document.body.addEventListener('blur', handleBlur, true);

--- a/packages/react-native-web/src/modules/applyLayout/index.js
+++ b/packages/react-native-web/src/modules/applyLayout/index.js
@@ -55,9 +55,10 @@ const observe = instance => {
     node._onLayoutId = id;
     resizeObserver.observe(node);
   } else {
-    const id = guid();
     instance._onLayoutId = id;
-    instance._handleLayout();
+    setTimeout(() => {
+      instance._handleLayout();
+    }, 0);
   }
 };
 
@@ -105,8 +106,6 @@ const applyLayout = Component => {
         observe(this);
       } else if (!this.props.onLayout && prevProps.onLayout) {
         unobserve(this);
-      } else if (!resizeObserver) {
-        this._handleLayout();
       }
     }
   );
@@ -123,10 +122,8 @@ const applyLayout = Component => {
     const layout = this._layoutState;
     const { onLayout } = this.props;
 
-    if (onLayout) {
+    if (this._isMounted && onLayout) {
       this.measure((x, y, width, height) => {
-        if (!this._isMounted) return;
-
         if (
           layout.x !== x ||
           layout.y !== y ||

--- a/website/storybook/2-apis/AppRegistry/AppRegistryScreen.js
+++ b/website/storybook/2-apis/AppRegistry/AppRegistryScreen.js
@@ -31,10 +31,18 @@ const AppRegistryScreen = () => (
       />
 
       <DocItem
-        description="Use this for server-side rendering to HTML. Returns a object of the given application's element, and a function to get styles once the element is rendered."
+        description={
+          <AppText>
+            Use this for server-side rendering to HTML. Returns an object containing the given
+            application's element and a function to get styles once the element is rendered.
+            Additional props can be passed to the <Code>getStyleElement</Code> function, e.g., your
+            CSP policy may require a <Code>nonce</Code> to be set on <Code>style</Code>
+            elements.
+          </AppText>
+        }
         label="web"
         name="static getApplication"
-        typeInfo="(appKey: string, appParameters: ?object) => { element: ReactElement; getStyleElement: () => ReactElement }"
+        typeInfo="(appKey: string, appParameters: ?object) => { element: ReactElement; getStyleElement: (props) => ReactElement }"
       />
 
       <DocItem


### PR DESCRIPTION
onLayout is called after the component is mounted to the DOM. This makes
both the fallback and ResizeObserver code path behave the same as React
Native.

Fix #911
Fix #941
Close #939