### PR TITLE
Support View Style Props

### DIFF
--- a/packages/react-native-web/package.json
+++ b/packages/react-native-web/package.json
@@ -17,6 +17,7 @@
     "fbjs": "^0.8.16",
     "hyphenate-style-name": "^1.0.2",
     "inline-style-prefixer": "^4.0.0",
+    "lodash": "^4.17.10",
     "normalize-css-color": "^1.0.2",
     "prop-types": "^15.6.0",
     "react-timer-mixin": "^0.13.3"

--- a/packages/react-native-web/src/exports/StyleSheet/StyleSheet.js
+++ b/packages/react-native-web/src/exports/StyleSheet/StyleSheet.js
@@ -23,12 +23,9 @@ const absoluteFill = ReactNativePropRegistry.register(absoluteFillObject);
 const StyleSheet = {
   absoluteFill,
   absoluteFillObject,
-  compose(style1, style2) {
-    if (style1 && style2) {
-      return [style1, style2];
-    } else {
-      return style1 || style2;
-    }
+  compose(...styles) {
+    const _styles = styles.filter(Boolean);
+    return _styles.length > 1 ? _styles : _styles[0];
   },
   create(styles) {
     const result = {};

--- a/packages/react-native-web/src/exports/View/ViewPropTypes.js
+++ b/packages/react-native-web/src/exports/View/ViewPropTypes.js
@@ -29,6 +29,7 @@ export type ViewLayoutEvent = {
 };
 
 export type ViewProps = {
+  ...ViewStylePropTypes,
   accessibilityComponentType?: string,
   accessibilityLabel?: string,
   accessibilityLiveRegion?: 'none' | 'polite' | 'assertive',

--- a/packages/react-native-web/src/exports/View/ViewStylePropTypes.js
+++ b/packages/react-native-web/src/exports/View/ViewStylePropTypes.js
@@ -55,4 +55,6 @@ const ViewStylePropTypes = {
   WebkitOverflowScrolling: oneOf(['auto', 'touch'])
 };
 
+export const ViewStylePropKeys = Object.keys(ViewStylePropTypes);
+
 export default ViewStylePropTypes;

--- a/packages/react-native-web/src/exports/View/index.js
+++ b/packages/react-native-web/src/exports/View/index.js
@@ -6,6 +6,7 @@
  * @flow
  */
 
+import _ from 'lodash';
 import applyLayout from '../../modules/applyLayout';
 import applyNativeMethods from '../../modules/applyNativeMethods';
 import { bool } from 'prop-types';
@@ -13,6 +14,7 @@ import createElement from '../createElement';
 import invariant from 'fbjs/lib/invariant';
 import StyleSheet from '../StyleSheet';
 import ViewPropTypes, { type ViewProps } from './ViewPropTypes';
+import { ViewStylePropKeys } from './ViewStylePropTypes';
 import React, { Component } from 'react';
 
 const calculateHitSlopStyle = hitSlop => {
@@ -50,7 +52,7 @@ class View extends Component<ViewProps> {
       shouldRasterizeIOS,
       tvParallaxProperties,
       /* eslint-enable */
-      ...otherProps
+      ..._otherProps
     } = this.props;
 
     if (process.env.NODE_ENV !== 'production') {
@@ -64,9 +66,13 @@ class View extends Component<ViewProps> {
 
     const { isInAParentText } = this.context;
 
+    const styleProps = _.pick(_otherProps, ViewStylePropKeys);
+    const otherProps = _.omit(_otherProps, ViewStylePropKeys);
+
     otherProps.style = StyleSheet.compose(
       styles.initial,
-      StyleSheet.compose(isInAParentText && styles.inline, this.props.style)
+      StyleSheet.compose(isInAParentText && styles.inline, this.props.style),
+      Object.keys(styleProps).length ? StyleSheet.create({ style: styleProps }).style : undefined
     );
 
     if (hitSlop) {


### PR DESCRIPTION
> I'm opening and closing this PR because it is for feedback purposes, as you don't seem to want to have this feature on this repo (#914). Although, I really think react-native-web should support this syntax, because react-native does and I believe both APIs should be compatible.

Is this the right way to implement it? How could I optimize it?

E.g. what could I use instead of adding lodash? But it worked without adding it so I believe it was already indirectly included anyway.

Do I really need to do this `StyleSheet.create` inside the render method or is there a better way?