### PR TITLE
fix scrollTop issue on Chrome/Firefox

### DIFF
--- a/packages/react-native-web/src/exports/UIManager/index.js
+++ b/packages/react-native-web/src/exports/UIManager/index.js
@@ -17,14 +17,15 @@ const getRect = node => {
   node = node.offsetParent;
 
   while (node && node.nodeType === 1 /* Node.ELEMENT_NODE */) {
-    left += node.offsetLeft;
-    top += node.offsetTop;
+    const scrollTop = node.nodeName === 'BODY' ? window.pageYOffset : node.scrollTop;
+    const scrollLeft = node.nodeName === 'BODY' ? window.pageXOffset : node.scrollLeft;
+
+    top += node.clientTop + node.offsetTop - scrollTop;
+    left += node.clientLeft + node.offsetLeft - scrollLeft;
+
     node = node.offsetParent;
   }
 
-  top -= window.pageYOffset;
-  left -= window.pageXOffset;
-  
   return { height, left, top, width };
 };
 

--- a/packages/react-native-web/src/exports/UIManager/index.js
+++ b/packages/react-native-web/src/exports/UIManager/index.js
@@ -17,10 +17,14 @@ const getRect = node => {
   node = node.offsetParent;
 
   while (node && node.nodeType === 1 /* Node.ELEMENT_NODE */) {
-    left += node.offsetLeft - node.scrollLeft;
-    top += node.offsetTop - node.scrollTop;
+    left += node.offsetLeft;
+    top += node.offsetTop;
     node = node.offsetParent;
   }
+
+  top -= window.pageYOffset;
+  left -= window.pageXOffset;
+  
   return { height, left, top, width };
 };
 


### PR DESCRIPTION
MeasureInWindow returns an incorrect top and left value on Chrome and Firefox because body.scrollTop and scrollLeft return zero on Chrome and Firefox. The current method does work on Safari. This new method works on both Safari and Chrome/Firefox.