### PR TITLE
Add envinfo to github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -20,13 +20,13 @@ Steps to reproduce:
 **Expected behavior**
 A clear and concise description of what you expected to happen.
 
-**Environment (include versions). Did this work in previous versions?**
+**Environment**
+<!-- In your project directory, run the following command:
 
-* OS:
-* Device:
-* Browser:
-* React Native for Web (version):
-* React (version):
+  `npx envinfo@latest --preset react-native-web --clipboard`
+
+Then, paste the automagically copied to clipboard results here. Please also include last known
+working versions, if applicable -->
 
 **Additional context**
 Add any other context about the problem here.


### PR DESCRIPTION
Rather than asking issue reporters to manually find versions, envinfo will do it for you, like this:

`npx envinfo@latest --preset react-native-web --clipboard`

```
  System:
    OS: macOS High Sierra 10.13
    CPU: x64 Intel(R) Core(TM) i7-4870HQ CPU @ 2.50GHz
  Binaries:
    Node: 8.11.0 - ~/.nvm/versions/node/v8.11.0/bin/node
    Yarn: 1.5.1 - ~/.yarn/bin/yarn
    npm: 5.6.0 - ~/.nvm/versions/node/v8.11.0/bin/npm
  Browsers:
    Chrome: 67.0.3396.62
    Firefox: 59.0.2
    Safari: 11.0
  npmPackages:
    react: ^16.4.0 => 16.4.0
    react-native-web: ^0.7.3 => 0.7.3
```

This has already been used to great effect in React Native, Jest, Webpack, Expo and more. Let's make issue reporting suck less!