### PR TITLE
Add object-fit as a valid style prop

### DIFF
--- a/packages/react-native-web/src/exports/StyleSheet/StyleSheetValidation.js
+++ b/packages/react-native-web/src/exports/StyleSheet/StyleSheetValidation.js
@@ -100,6 +100,7 @@ StyleSheetValidation.addValidStylePropTypes({
   fill: string,
   float: oneOf(['end', 'left', 'none', 'right', 'start']),
   listStyle: string,
+  objectFit: string,
   pointerEvents: string,
   tableLayout: string,
   /* @private */


### PR DESCRIPTION
`object-fit` isn't supported as a style prop by react-native-web. [inline-style-prefixer](https://github.com/rofrischmann/inline-style-prefixer/blob/721f552657a4208da7281a1bc7d2e61d7110968d/modules/generator/maps/propertyMap.js#L146) already supports `object-fit`, so this PR adds `objectFit` with a type of `string` for its 5 possible values (fill, contain, cover, scale-down, and none).

`object-fit` isn't in `react-native`, but it's crucial for `video` on the web — there isn't a good way around using the `video` element, especially since `react-native` doesn't have a Video component for it.