### PR TITLE
Correct type of animationIterationCount for 2+ animations

### DIFF
--- a/packages/react-native-web/src/exports/ActivityIndicator/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/react-native-web/src/exports/ActivityIndicator/__tests__/__snapshots__/index-test.js.snap
@@ -15,28 +15,11 @@ exports[`components/ActivityIndicator prop "animating" is "false" 1`] = `
   <View
     style={
       Object {
-        "animationDuration": "0.75s",
-        "animationIterationCount": "infinite",
-        "animationName": Array [
+        "animation": Array [
           Object {
-            "0%": Object {
-              "transform": Array [
-                Object {
-                  "rotate": "0deg",
-                },
-              ],
-            },
-            "100%": Object {
-              "transform": Array [
-                Object {
-                  "rotate": "360deg",
-                },
-              ],
-            },
+            "animationPlayState": "paused",
           },
         ],
-        "animationPlayState": "paused",
-        "animationTimingFunction": "linear",
         "height": 20,
         "visibility": "hidden",
         "width": 20,
@@ -95,27 +78,31 @@ exports[`components/ActivityIndicator prop "animating" is "true" 1`] = `
   <View
     style={
       Object {
-        "animationDuration": "0.75s",
-        "animationIterationCount": "infinite",
-        "animationName": Array [
+        "animation": Array [
           Object {
-            "0%": Object {
-              "transform": Array [
-                Object {
-                  "rotate": "0deg",
+            "animationDuration": "0.75s",
+            "animationIterationCount": "infinite",
+            "animationName": Array [
+              Object {
+                "0%": Object {
+                  "transform": Array [
+                    Object {
+                      "rotate": "0deg",
+                    },
+                  ],
                 },
-              ],
-            },
-            "100%": Object {
-              "transform": Array [
-                Object {
-                  "rotate": "360deg",
+                "100%": Object {
+                  "transform": Array [
+                    Object {
+                      "rotate": "360deg",
+                    },
+                  ],
                 },
-              ],
-            },
+              },
+            ],
+            "animationTimingFunction": "linear",
           },
         ],
-        "animationTimingFunction": "linear",
         "height": 20,
         "width": 20,
       }
@@ -209,28 +196,11 @@ exports[`components/ActivityIndicator prop "hidesWhenStopped" is "false" 1`] = `
   <View
     style={
       Object {
-        "animationDuration": "0.75s",
-        "animationIterationCount": "infinite",
-        "animationName": Array [
+        "animation": Array [
           Object {
-            "0%": Object {
-              "transform": Array [
-                Object {
-                  "rotate": "0deg",
-                },
-              ],
-            },
-            "100%": Object {
-              "transform": Array [
-                Object {
-                  "rotate": "360deg",
-                },
-              ],
-            },
+            "animationPlayState": "paused",
           },
         ],
-        "animationPlayState": "paused",
-        "animationTimingFunction": "linear",
         "height": 20,
         "width": 20,
       }
@@ -288,28 +258,11 @@ exports[`components/ActivityIndicator prop "hidesWhenStopped" is "true" 1`] = `
   <View
     style={
       Object {
-        "animationDuration": "0.75s",
-        "animationIterationCount": "infinite",
-        "animationName": Array [
+        "animation": Array [
           Object {
-            "0%": Object {
-              "transform": Array [
-                Object {
-                  "rotate": "0deg",
-                },
-              ],
-            },
-            "100%": Object {
-              "transform": Array [
-                Object {
-                  "rotate": "360deg",
-                },
-              ],
-            },
+            "animationPlayState": "paused",
           },
         ],
-        "animationPlayState": "paused",
-        "animationTimingFunction": "linear",
         "height": 20,
         "visibility": "hidden",
         "width": 20,
@@ -368,27 +321,31 @@ exports[`components/ActivityIndicator prop "size" is "large" 1`] = `
   <View
     style={
       Object {
-        "animationDuration": "0.75s",
-        "animationIterationCount": "infinite",
-        "animationName": Array [
+        "animation": Array [
           Object {
-            "0%": Object {
-              "transform": Array [
-                Object {
-                  "rotate": "0deg",
+            "animationDuration": "0.75s",
+            "animationIterationCount": "infinite",
+            "animationName": Array [
+              Object {
+                "0%": Object {
+                  "transform": Array [
+                    Object {
+                      "rotate": "0deg",
+                    },
+                  ],
                 },
-              ],
-            },
-            "100%": Object {
-              "transform": Array [
-                Object {
-                  "rotate": "360deg",
+                "100%": Object {
+                  "transform": Array [
+                    Object {
+                      "rotate": "360deg",
+                    },
+                  ],
                 },
-              ],
-            },
+              },
+            ],
+            "animationTimingFunction": "linear",
           },
         ],
-        "animationTimingFunction": "linear",
         "height": 36,
         "width": 36,
       }
@@ -446,27 +403,31 @@ exports[`components/ActivityIndicator prop "size" is a number 1`] = `
   <View
     style={
       Object {
-        "animationDuration": "0.75s",
-        "animationIterationCount": "infinite",
-        "animationName": Array [
+        "animation": Array [
           Object {
-            "0%": Object {
-              "transform": Array [
-                Object {
-                  "rotate": "0deg",
+            "animationDuration": "0.75s",
+            "animationIterationCount": "infinite",
+            "animationName": Array [
+              Object {
+                "0%": Object {
+                  "transform": Array [
+                    Object {
+                      "rotate": "0deg",
+                    },
+                  ],
                 },
-              ],
-            },
-            "100%": Object {
-              "transform": Array [
-                Object {
-                  "rotate": "360deg",
+                "100%": Object {
+                  "transform": Array [
+                    Object {
+                      "rotate": "360deg",
+                    },
+                  ],
                 },
-              ],
-            },
+              },
+            ],
+            "animationTimingFunction": "linear",
           },
         ],
-        "animationTimingFunction": "linear",
         "height": 30,
         "width": 30,
       }

--- a/packages/react-native-web/src/exports/ActivityIndicator/index.js
+++ b/packages/react-native-web/src/exports/ActivityIndicator/index.js
@@ -85,18 +85,26 @@ const styles = StyleSheet.create({
     visibility: 'hidden'
   },
   animation: {
-    animationDuration: '0.75s',
-    animationName: [
+    animation: [
       {
-        '0%': { transform: [{ rotate: '0deg' }] },
-        '100%': { transform: [{ rotate: '360deg' }] }
+        animationDuration: '0.75s',
+        animationName: [
+          {
+            '0%': { transform: [{ rotate: '0deg' }] },
+            '100%': { transform: [{ rotate: '360deg' }] }
+          }
+        ],
+        animationTimingFunction: 'linear',
+        animationIterationCount: 'infinite'
       }
-    ],
-    animationTimingFunction: 'linear',
-    animationIterationCount: 'infinite'
+    ]
   },
   animationPause: {
-    animationPlayState: 'paused'
+    animation: [
+      {
+        animationPlayState: 'paused'
+      }
+    ]
   }
 });
 

--- a/packages/react-native-web/src/exports/ProgressBar/index.js
+++ b/packages/react-native-web/src/exports/ProgressBar/index.js
@@ -93,15 +93,19 @@ const styles = StyleSheet.create({
     zIndex: -1
   },
   animation: {
-    animationDuration: '1s',
-    animationName: [
+    animation: [
       {
-        '0%': { transform: [{ translateX: '-100%' }] },
-        '100%': { transform: [{ translateX: '400%' }] }
+        animationDuration: '1s',
+        animationName: [
+          {
+            '0%': { transform: [{ translateX: '-100%' }] },
+            '100%': { transform: [{ translateX: '400%' }] }
+          }
+        ],
+        animationTimingFunction: 'linear',
+        animationIterationCount: 'infinite'
       }
-    ],
-    animationTimingFunction: 'linear',
-    animationIterationCount: 'infinite'
+    ]
   }
 });
 

--- a/packages/react-native-web/src/modules/AnimationPropTypes/index.js
+++ b/packages/react-native-web/src/modules/AnimationPropTypes/index.js
@@ -7,17 +7,22 @@
  * @flow
  */
 
-import { arrayOf, number, object, oneOf, oneOfType, string } from 'prop-types';
+import { arrayOf, number, object, oneOf, oneOfType, shape, string } from 'prop-types';
+const numberOrString = oneOfType([number, string]);
 
 const AnimationPropTypes = {
-  animationDelay: string,
-  animationDirection: oneOf(['alternate', 'alternate-reverse', 'normal', 'reverse']),
-  animationDuration: string,
-  animationFillMode: oneOf(['none', 'forwards', 'backwards', 'both']),
-  animationIterationCount: oneOfType([number, string]),
-  animationName: oneOfType([string, arrayOf(oneOfType([string, object]))]),
-  animationPlayState: oneOf(['paused', 'running']),
-  animationTimingFunction: string,
+  animation: arrayOf(
+    shape({
+      animationName: oneOfType([string, arrayOf(oneOfType([string, object]))]),
+      animationDuration: string,
+      animationTimingFunction: string,
+      animationDelay: string,
+      animationDirection: oneOf(['alternate', 'alternate-reverse', 'normal', 'reverse']),
+      animationIterationCount: numberOrString,
+      animationFillMode: oneOf(['none', 'forwards', 'backwards', 'both']),
+      animationPlayState: oneOf(['paused', 'running'])
+    })
+  ),
   transitionDelay: string,
   transitionDuration: string,
   transitionProperty: string,

--- a/packages/react-native-web/src/modules/AnimationPropTypes/index.js
+++ b/packages/react-native-web/src/modules/AnimationPropTypes/index.js
@@ -14,7 +14,7 @@ const AnimationPropTypes = {
   animationDirection: oneOf(['alternate', 'alternate-reverse', 'normal', 'reverse']),
   animationDuration: string,
   animationFillMode: oneOf(['none', 'forwards', 'backwards', 'both']),
-  animationIterationCount: oneOfType([number, oneOf(['infinite'])]),
+  animationIterationCount: oneOfType([number, string]),
   animationName: oneOfType([string, arrayOf(oneOfType([string, object]))]),
   animationPlayState: oneOf(['paused', 'running']),
   animationTimingFunction: string,

--- a/packages/website/storybook/1-components/View/ViewScreen.js
+++ b/packages/website/storybook/1-components/View/ViewScreen.js
@@ -320,6 +320,10 @@ const stylePropTypes = [
     typeInfo: 'string'
   },
   {
+    name: 'animation',
+    typeInfo: 'Array<Object>'
+  },
+  {
     label: 'web',
     name: 'animationDelay',
     typeInfo: 'string'
@@ -341,13 +345,13 @@ const stylePropTypes = [
   },
   {
     label: 'web',
-    name: 'animationName',
-    typeInfo: 'string | Array<Object>'
+    name: 'animationIterationCount',
+    typeInfo: 'number | "infinite"'
   },
   {
     label: 'web',
-    name: 'animationIterationCount',
-    typeInfo: 'number | "infinite"'
+    name: 'animationName',
+    typeInfo: 'string | Array<Object>'
   },
   {
     label: 'web',


### PR DESCRIPTION
Fixes #1044.

**Do you want to request a feature or report a bug?**
A bug.

**If the current behavior is a bug, please provide the steps to reproduce and
if a minimal demo of the problem via Glitch or similar (template:
https://glitch.com/edit/#!/react-native-web-playground).**

_Glitch demo code:_ https://glitch.com/edit/#!/zesty-carpenter?path=src/App/index.js:46:2
_Live Glitch demo:_ https://zesty-carpenter.glitch.me/

_Reproduction steps:_
1. Create a component which uses StyleSheet for styling and apply `styles.animation`:
```js
var styles = StyleSheet.create({
  animation: {
    animationDuration: '1s, 2s',
    animationIterationCount: '1, infinite',
    animationName: [
      {
        from: { top: '2em' },
        to: { top: 0 }
      },
      {
        '15%': {
          transform: [{ scale: 2 }],
          backgroundColor: 'red'
        },
        '30%': {
          transform: [{ scale: 1 }]
        }
      }
    ]
  }
})
```
2. Run the project locally and open the Developer Tools console.
3. Realize there's an error: `Warning: Failed prop type: Invalid prop `animationIterationCount` supplied to `View`.`

**What is the expected behavior?**
`animationIterationCount` should accept string values for multiple animations, much in the same way `animationDuration` does. There should be no `Failed prop type` error.

_OS:_ macOS Sierra 10.13.6
_Browser:_ Chrome 67.0.3396.99
_React Native for Web (version):_ 0.8.8
_React (version):_ 16.3.1