### PR TITLE
Fix typo: "inlucde" should be spelled "include"

### DIFF
--- a/packages/website/guides/getting-started.md
+++ b/packages/website/guides/getting-started.md
@@ -178,7 +178,7 @@ Please refer to the Jest documentation for more information.
 module.name_mapper='^react-native$' -> 'react-native-web'
 ```
 
-You may also need to inlucde a custom libdef
+You may also need to include a custom libdef
 ([example](https://gist.github.com/paularmstrong/f60b40d16fc83e1e8e532d483336f9bb))
 in your config.
 


### PR DESCRIPTION
This fixes a single typo in the Getting Started guide "Using Flow" section.