### PR TITLE
Image component throws EncodingError when referencing SVGs

### DIFF
--- a/packages/react-native-web/src/modules/ImageLoader/index.js
+++ b/packages/react-native-web/src/modules/ImageLoader/index.js
@@ -52,12 +52,14 @@ const ImageLoader = {
     image.onerror = onError;
     image.onload = e => {
       // avoid blocking the main thread
+      const onDecode = () => onLoad(e);
       if (typeof image.decode === 'function') {
-        image.decode().then(() => { onLoad(e) });
+        // safari currently throws exceptions when decoding svgs
+        // so we catch that error and allow the load event to be
+        // forwarded to the onLoad handler
+        image.decode().then(onDecode, onDecode);
       } else {
-        setTimeout(() => {
-          onLoad(e);
-        }, 0);
+        setTimeout(onDecode, 0);
       }
     };
     image.src = uri;

--- a/packages/react-native-web/src/modules/ImageLoader/index.js
+++ b/packages/react-native-web/src/modules/ImageLoader/index.js
@@ -54,9 +54,9 @@ const ImageLoader = {
       // avoid blocking the main thread
       const onDecode = () => onLoad(e);
       if (typeof image.decode === 'function') {
-        // safari currently throws exceptions when decoding svgs
-        // so we catch that error and allow the load event to be
-        // forwarded to the onLoad handler
+        // Safari currently throws exceptions when decoding svgs.
+        // We want to catch that error and allow the load handler
+        // to be forwarded to the onLoad handler in this case
         image.decode().then(onDecode, onDecode);
       } else {
         setTimeout(onDecode, 0);


### PR DESCRIPTION
<!--
Thank you for reporting an issue. Please note that an issue must include the
information that is marked as REQUIRED below, or it may be closed.
-->

**The problem**
Using the decode method of an Image instance that references a a SVG url throws and EncodingError exception. Even though the SVG image is being shown correctly, the exception prevents the onLoad handler from being called. 

This PR proposes handling the calling onLoad handler on reject as well as on resolved, to work according to spec. I've also filed an [issue on Webkit's bug tracker](https://bugs.webkit.org/show_bug.cgi?id=188347)

**How to reproduce**

Simplified test case: https://codesandbox.io/s/m1mv5vk2j

<img width="1154" alt="screen shot 2018-08-06 at 15 45 13" src="https://user-images.githubusercontent.com/13637/43720071-bdabaf7e-998f-11e8-9760-63812b8d7280.png">


Steps to reproduce:
1. Create an Image element and reference a svg file by url (with http)

**Expected behavior**
<!--
REQUIRED: A clear and concise description of what you expected to happen.
-->

No error should be thrown, onLoad handler should be called

**Environment (include versions). Did this work in previous versions?**

* React Native for Web (version): 0.8.9
* React (version): 16.3.2
* Browser: iOS 11.4 and macOS Safari 11.1

In Chrome 70 is the issue is not reproducible.

<!--
OPTIONAL:

**Additional context**
Add any other context about the problem here.
-->