### PR TITLE
Adds accessibility label to the picker for 508 Accessibility 

### DIFF
--- a/packages/react-native-web/src/exports/Picker/index.js
+++ b/packages/react-native-web/src/exports/Picker/index.js
@@ -22,6 +22,7 @@ import { arrayOf, bool, func, number, oneOfType, string } from 'prop-types';
 const pickerStyleType = StyleSheetPropType(PickerStylePropTypes);
 
 type Props = {
+  accessibilityLabel?: string,
   children?: PickerItem | Array<typeof PickerItem>,
   enabled?: boolean,
   onValueChange?: Function,
@@ -36,6 +37,7 @@ type Props = {
 
 class Picker extends Component<Props> {
   static propTypes = {
+    accessibilityLabel: string,
     children: oneOfType([PickerItemPropType, arrayOf(PickerItemPropType)]),
     enabled: bool,
     onValueChange: func,
@@ -48,6 +50,7 @@ class Picker extends Component<Props> {
 
   render() {
     const {
+      accessibilityLabel,
       children,
       enabled,
       selectedValue,
@@ -61,6 +64,7 @@ class Picker extends Component<Props> {
     } = this.props;
 
     return createElement('select', {
+      accessibilityLabel,
       children,
       disabled: enabled === false ? true : undefined,
       onChange: this._handleChange,

--- a/packages/react-native-web/src/exports/Picker/index.js
+++ b/packages/react-native-web/src/exports/Picker/index.js
@@ -59,8 +59,9 @@ class Picker extends Component<Props> {
       /* eslint-disable */
       itemStyle,
       mode,
-      prompt
+      prompt,
       /* eslint-enable */
+      ...otherProps
     } = this.props;
 
     return createElement('select', {
@@ -70,7 +71,8 @@ class Picker extends Component<Props> {
       onChange: this._handleChange,
       style: [styles.initial, style],
       testID,
-      value: selectedValue
+      value: selectedValue,
+      ...otherProps
     });
   }
 

--- a/packages/website/storybook/1-components/Picker/PickerScreen.js
+++ b/packages/website/storybook/1-components/Picker/PickerScreen.js
@@ -24,6 +24,15 @@ const PickerScreen = () => (
       </Description>
       <Section title="Props">
         <DocItem
+          name="accessiblityLabel"
+          typeInfo="?string"
+          description="If a string is supplied, the accessibilityLabel is rendered as an aria-label"
+          example={{
+            render: () => <PickerExample accessibilityLabel="Please make a selection:" />
+          }}
+        />
+
+        <DocItem
           name="children"
           typeInfo="?Array<Picker.Item>"
           description="The items to display in the picker."


### PR DESCRIPTION
When using RNW for accessible web sites, it is necessary at times to pass an accessibilityLabel to the `<select />` component.  This small PR simply makes that possible.