### PR TITLE
allow user to override the tabIndex value when explicitly needed

### DIFF
--- a/packages/react-native-web/src/exports/View/filterSupportedProps.js
+++ b/packages/react-native-web/src/exports/View/filterSupportedProps.js
@@ -59,6 +59,7 @@ const whitelist = {
   onClick: true,
   onClickCapture: true,
   rel: true,
+  tabIndex: true,
   target: true
 };
 

--- a/packages/react-native-web/src/modules/createDOMProps/index.js
+++ b/packages/react-native-web/src/modules/createDOMProps/index.js
@@ -134,12 +134,12 @@ const createDOMProps = (component, props, styleResolver) => {
   } else if (role === 'button' || role === 'textbox') {
     if (accessible !== false && focusable) {
       domProps['data-focusable'] = true;
-      domProps.tabIndex = '0';
+      domProps.tabIndex = domProps.tabIndex || '0';
     }
   } else {
     if (accessible === true && focusable) {
       domProps['data-focusable'] = true;
-      domProps.tabIndex = '0';
+      domProps.tabIndex = domProps.tabIndex || '0';
     }
   }
 


### PR DESCRIPTION
There are times when a user needs to explicitly set a tabIndex on an accessible component.  This small patch allows it like:
```
        <TouchableOpacity
          onPress={() => {
            const callback = onPress();
            if (callback) callback();
            else navigation.navigate('Scope');
          }}
          style={Styles.container}
          accessibilityLabel="Select Scope"
          accessibilityRole="button"
          accessibile
          testID="selectScope"
          tabIndex="1"
        >
          <View style={Styles.navBarTitleContainer}>
            <Icon style={Styles.headerIcon} size={20} name="map-marker" />
            <Text
              accessibilityRole="heading"
              aria-level="1"
              style={Styles.navBarTitle}
            >
              {scopeTitle}
            </Text>
          </View>
        </TouchableOpacity>
```