### PR TITLE
`onValueChange` should not be passed to select tag

### DIFF
--- a/packages/react-native-web/src/exports/Picker/index.js
+++ b/packages/react-native-web/src/exports/Picker/index.js
@@ -59,6 +59,7 @@ class Picker extends Component<Props> {
       itemStyle,
       mode,
       prompt,
+      onValueChange,
       /* eslint-enable */
       ...otherProps
     } = this.props;


### PR DESCRIPTION
Closes https://github.com/necolas/react-native-web/issues/1104

### Background

Since https://github.com/necolas/react-native-web/pull/1064, Picker has started to pass `otherProps` to browser's select element. As the element doesn't have such a property, `onValueChange` should be excluded from `otherPropes`. 




