### PR TITLE
Fix sticky header on virtualized lists

### DIFF
--- a/packages/react-native-web/src/vendor/react-native/VirtualizedList/index.js
+++ b/packages/react-native-web/src/vendor/react-native/VirtualizedList/index.js
@@ -1562,6 +1562,7 @@ class CellRenderer extends React.Component<
       renderItem: renderItemType,
     },
     prevCellKey: ?string,
+    style: ?DangerouslyImpreciseStyleProp,
   },
   $FlowFixMeState,
 > {
@@ -1630,6 +1631,7 @@ class CellRenderer extends React.Component<
       index,
       inversionStyle,
       parentProps,
+      style,
     } = this.props;
     const {renderItem, getItemLayout} = parentProps;
     invariant(renderItem, 'no renderItem!');
@@ -1649,9 +1651,9 @@ class CellRenderer extends React.Component<
     );
     const cellStyle = inversionStyle
       ? horizontal
-        ? [{flexDirection: 'row-reverse'}, inversionStyle]
-        : [{flexDirection: 'column-reverse'}, inversionStyle]
-      : horizontal ? [{flexDirection: 'row'}, inversionStyle] : inversionStyle;
+        ? [{flexDirection: 'row-reverse'}, inversionStyle, style]
+        : [{flexDirection: 'column-reverse'}, inversionStyle, style]
+      : horizontal ? [{flexDirection: 'row'}, inversionStyle, style] : [inversionStyle, style];
     if (!CellRendererComponent) {
       return (
         <View style={cellStyle} onLayout={onLayout}>


### PR DESCRIPTION
Fix #1066 

I investigated why sticky headers wasn't working and found out the `style` prop was never used by the default `CellRendererComponent`.

_I don't know how your process of patching vendor code is, so I just changed it directly._

Another idea is passing a default `CellRendererComponent` prop to VirtualizedList that handles this style merging correctly, so vendor code won't need to be changed.

### Reproduction

- CodeSandbox (https://codesandbox.io/s/8yoolj322j)
- Snack (https://snack.expo.io/@brunolemos/sticky-headers)