### PR TITLE
[fix] ignore native-only TextInput props

### DIFF
--- a/packages/react-native-web/src/exports/TextInput/index.js
+++ b/packages/react-native-web/src/exports/TextInput/index.js
@@ -210,6 +210,14 @@ class TextInput extends Component<*> {
       selectionState,
       textBreakStrategy,
       underlineColorAndroid,
+      hitSlop,
+      onAccessibilityTap,
+      onMagicTap,
+      removeClippedSubviews,
+      needsOffscreenAlphaCompositing,
+      renderToHardwareTextureAndroid,
+      accessibilityViewIsModal,
+      shouldRasterizeIOS,
       /* eslint-enable */
       ...otherProps
     } = this.props;


### PR DESCRIPTION
Hi this is my first PR. I've looked at a similar [PR](https://github.com/necolas/react-native-web/pull/753) and I hope everything is alright.
Ref #735 