### PR TITLE
Fix: Add caretColor for inputText style props

### DIFF
--- a/packages/react-native-web/src/exports/TextInput/TextInputStylePropTypes.js
+++ b/packages/react-native-web/src/exports/TextInput/TextInputStylePropTypes.js
@@ -8,12 +8,13 @@
  */
 
 import TextStylePropTypes from '../Text/TextStylePropTypes';
-import { oneOf } from 'prop-types';
+import { oneOf, string } from 'prop-types';
 
 const TextInputStylePropTypes = {
   ...TextStylePropTypes,
   /* @platform web */
-  resize: oneOf(['none', 'vertical', 'horizontal', 'both'])
+  resize: oneOf(['none', 'vertical', 'horizontal', 'both']),
+  caretColor: string
 };
 
 export default TextInputStylePropTypes;


### PR DESCRIPTION
When caretColor css is used in rnw. It throws an error that caretColor is not a valid style prop. To fix this, caretColor is added to the TextInputStylePropTypes