### PR TITLE
[add] clipPath to ViewStylePropTypes

### DIFF
--- a/packages/react-native-web/src/exports/View/ViewStylePropTypes.js
+++ b/packages/react-native-web/src/exports/View/ViewStylePropTypes.js
@@ -45,6 +45,7 @@ const ViewStylePropTypes = {
   backgroundSize: string,
   boxShadow: string,
   clip: string,
+  clipPath: string,
   filter: string,
   outline: string,
   outlineColor: ColorPropType,

--- a/packages/website/storybook/1-components/View/ViewScreen.js
+++ b/packages/website/storybook/1-components/View/ViewScreen.js
@@ -554,6 +554,11 @@ const stylePropTypes = [
   },
   {
     label: 'web',
+    name: 'clipPath',
+    typeInfo: 'string'
+  },
+  {
+    label: 'web',
     name: 'cursor',
     typeInfo: 'string'
   },


### PR DESCRIPTION
Adds `clipPath` to `ViewStylePropTypes` and resolves the following runtime warning:

> Warning: Failed prop type: Invalid props.style key clipPath supplied to View.

**Is your feature request related to a problem? Please describe.**
`ViewStylePropTypes` allows several properties dedicated for platform web, among others: `clip`. As `clip` is deprecated in favor of `clip-path` (see https://developer.mozilla.org/en-US/docs/Web/CSS/clip) and `clip-path` is supported in all major browser engines (except Edge) we should add `clipPath` as allowed `ViewStylePropTypes` to prevent the following runtime error:

Fixes #1141 

