### PR TITLE
[bug] `process.env.NODE` -> `process.env.NODE_ENV`

### DIFF
--- a/packages/react-native-web/src/vendor/react-native/LayoutAnimation/index.js
+++ b/packages/react-native-web/src/vendor/react-native/LayoutAnimation/index.js
@@ -11,7 +11,7 @@
 import PropTypes from 'prop-types';
 import UIManager from '../../../exports/UIManager';
 
-const __DEV__ = process.env.NODE !== 'production';
+const __DEV__ = process.env.NODE_ENV !== 'production';
 const { checkPropTypes } = PropTypes;
 
 const Types = {


### PR DESCRIPTION
Build started failing for me with `Uncaught ReferenceError: process is not defined` when importing `LayoutAnimation`.

My build system only supports `process.env.NODE_ENV`. 

Was going to alias on my end, but checked and it seems everyone uses `process.env.NODE_ENV` (including the rest of this codebase).

Assuming it's a typo.