### PR TITLE
Add NativeId to View supported props filter

### DIFF
--- a/packages/react-native-web/src/exports/View/filterSupportedProps.js
+++ b/packages/react-native-web/src/exports/View/filterSupportedProps.js
@@ -8,6 +8,7 @@ const whitelist = {
   children: true,
   disabled: true,
   importantForAccessibility: true,
+  nativeID: true,
   onBlur: true,
   onContextMenu: true,
   onFocus: true,


### PR DESCRIPTION
Follows up on #1116 and #1130 to let nativeId pass through on View