### PR TITLE
Fix modality performance issues

### DIFF
--- a/packages/react-native-web/src/exports/StyleSheet/modality.js
+++ b/packages/react-native-web/src/exports/StyleSheet/modality.js
@@ -113,9 +113,6 @@ const modality = styleElement => {
    * originally added by the author.
    */
   function removeFocusVisibleClass(el) {
-    if (!el.classList.contains(focusVisibleClass)) {
-      return;
-    }
     el.classList.remove(focusVisibleClass);
   }
 
@@ -125,7 +122,7 @@ const modality = styleElement => {
    * of our keyboard modality state with `hadKeyboardEvent`.
    */
   function onKeyDown(e) {
-    if (e.metaKey || e.altKey || e.ctrlKey) {
+    if (e.metaKey || e.altKey || e.ctrlKey || e.shiftKey) {
       return;
     }
 
@@ -243,7 +240,7 @@ const modality = styleElement => {
   function onInitialPointerMove(e) {
     // Work around a Safari quirk that fires a mousemove on <html> whenever the
     // window blurs, even if you're tabbing out of the page. ¯\_(ツ)_/¯
-    if (e.target.nodeName.toLowerCase() === 'html') {
+    if (e.target.nodeName === 'HTML') {
       return;
     }
 

--- a/packages/react-native-web/src/exports/StyleSheet/modality.js
+++ b/packages/react-native-web/src/exports/StyleSheet/modality.js
@@ -125,6 +125,10 @@ const modality = styleElement => {
    * of our keyboard modality state with `hadKeyboardEvent`.
    */
   function onKeyDown(e) {
+    if (e.metaKey || e.altKey || e.ctrlKey) {
+      return;
+    }
+
     if (isValidFocusTarget(document.activeElement)) {
       addFocusVisibleClass(document.activeElement);
     }


### PR DESCRIPTION
Fixes #1155

Inserting and deleting the modality rule triggers styles recalculation for the entire DOM tree which results in performance degradation on focus or, as the reporter suggests, makes the keyboard very slow to open in iOS.

This commit fixes the issue by integrating the [`:focus-visible` polyfill](https://github.com/WICG/focus-visible) which toggles a scoped `rn-focusVisible` class name on whitelisted elements or elements that get focus via keyboard. We insert a permanent rule to always disable the focus ring except for the elements that not match the class name i.e. `:focus:not(.rn-focusVisible)`. This performs much better since the browser needs to recalculate styles only for the focused element and its small subtree.

* master 
[Modality-master.txt](https://github.com/necolas/react-native-web/files/2569264/Modality-master2.txt)
* this branch 
[Modality-fixed-rev2.txt](https://github.com/necolas/react-native-web/files/2569265/Modality-fixed-rev2.txt)

