### PR TITLE
fix: ListView dumps if no `renderHeader` is provided and sections are used

### DIFF
--- a/packages/react-native-web/src/exports/ScrollView/index.js
+++ b/packages/react-native-web/src/exports/ScrollView/index.js
@@ -167,7 +167,7 @@ const ScrollView = createReactClass({
     const children =
       !horizontal && Array.isArray(stickyHeaderIndices)
         ? React.Children.map(this.props.children, (child, i) => {
-            if (stickyHeaderIndices.indexOf(i) > -1) {
+            if (child && stickyHeaderIndices.indexOf(i) > -1) {
               return React.cloneElement(child, { style: [child.props.style, styles.stickyHeader] });
             } else {
               return child;


### PR DESCRIPTION
You can reproduce it here: https://codesandbox.io/s/38y24nvxvq
Just uncomment line 48 and it should work.