### PR TITLE
fix: respect stickyHeaderIndices in ScrollView

### DIFF
--- a/packages/react-native-web/src/exports/ScrollView/index.js
+++ b/packages/react-native-web/src/exports/ScrollView/index.js
@@ -168,7 +168,7 @@ const ScrollView = createReactClass({
       !horizontal && Array.isArray(stickyHeaderIndices)
         ? React.Children.map(this.props.children, (child, i) => {
             if (stickyHeaderIndices.indexOf(i) > -1) {
-              return React.cloneElement(child, { style: [child.props.style, styles.stickyHeader] });
+              return <View style={styles.stickyHeader}>{child}</View>;
             } else {
               return child;
             }


### PR DESCRIPTION
See example https://codesandbox.io/s/zwx69r6nwl where `stickyHeaderIndices` do not work. The issue is that for rows in a `ListView` the `StaticRenderer` is used. The `StaticRenderer` does not pass on `styles` attribute.