### PR TITLE
Add DataCamp to list of companies using react-native-web in production

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Who is using React Native in production web apps?
 [Twitter](https://mobile.twitter.com), [Major League
 Soccer](https://matchcenter.mlssoccer.com),
 [Flipkart](https://www.flipkart.com/), Uber, [The
-Times](https://github.com/newsuk/times-components).
+Times](https://github.com/newsuk/times-components), [DataCamp](https://www.datacamp.com).
 
 Browser support: Chrome, Firefox, Edge, Safari 7+, IE 10+.
 


### PR DESCRIPTION
Hey! 👋 

We've recently launched an interesting project that uses react-native-web for production. Unfortunately we can't link directly to the app as it requires a login, but hopefully a link to the homepage is allowed.

We've documented our project here: https://www.datacamp.com/community/tech/porting-practice-to-web-part1

Thanks to all the contributors for their hard-work on react-native-web 🎉 