### PR TITLE
Add wordBreak style to Text Component

### DIFF
--- a/packages/react-native-web/src/exports/Text/TextStylePropTypes.js
+++ b/packages/react-native-web/src/exports/Text/TextStylePropTypes.js
@@ -56,6 +56,7 @@ const TextStylePropTypes = {
     'isolate-override',
     'plaintext'
   ]),
+  wordBreak: oneOf(['normal', 'break-all', 'keep-all', 'break-word']),
   whiteSpace: string,
   wordWrap: string,
   MozOsxFontSmoothing: string,

--- a/packages/react-native-web/src/exports/Text/TextStylePropTypes.js
+++ b/packages/react-native-web/src/exports/Text/TextStylePropTypes.js
@@ -56,8 +56,8 @@ const TextStylePropTypes = {
     'isolate-override',
     'plaintext'
   ]),
-  wordBreak: oneOf(['normal', 'break-all', 'keep-all', 'break-word']),
   whiteSpace: string,
+  wordBreak: oneOf(['normal', 'break-all', 'keep-all', 'break-word']),
   wordWrap: string,
   MozOsxFontSmoothing: string,
   WebkitFontSmoothing: string


### PR DESCRIPTION
Usage of wordBreak is throwing a warning. Hence added wordBreak style to Text Component
For reference: https://developer.mozilla.org/en-US/docs/Web/CSS/word-break