### PR TITLE
Use element.scroll method instead of scrollBehavior style property

### DIFF
--- a/packages/react-native-web/src/modules/ScrollResponder/index.js
+++ b/packages/react-native-web/src/modules/ScrollResponder/index.js
@@ -375,7 +375,12 @@ const ScrollResponderMixin = {
       ({ x, y, animated } = x || emptyObject);
     }
     const node = this.scrollResponderGetScrollableNode();
-    node.scroll({ top: y || 0, left: x || 0, behavior: !animated ? 'auto' : 'smooth' });
+    if (typeof node.scroll === 'function') {
+      node.scroll({ top: y || 0, left: x || 0, behavior: !animated ? 'auto' : 'smooth' });
+    } else {
+      node.scrollLeft = x || 0;
+      node.scrollTop = y || 0;
+    }
   },
 
   /**

--- a/packages/react-native-web/src/modules/ScrollResponder/index.js
+++ b/packages/react-native-web/src/modules/ScrollResponder/index.js
@@ -375,9 +375,7 @@ const ScrollResponderMixin = {
       ({ x, y, animated } = x || emptyObject);
     }
     const node = this.scrollResponderGetScrollableNode();
-    UIManager.updateView(node, { style: { scrollBehavior: !animated ? 'auto' : 'smooth' } }, this);
-    node.scrollLeft = x || 0;
-    node.scrollTop = y || 0;
+    node.scroll({ top: y || 0, left: x || 0, behavior: !animated ? 'auto' : 'smooth' });
   },
 
   /**


### PR DESCRIPTION
Use `element.scroll` instead of `scrollBehavior` style property and `element.scrollLeft/element.scrollTop` to scroll.

This makes it possible to polyfill the smooth scroll behavior (https://github.com/iamdustan/smoothscroll).

I tried to find info about the browser support of `element.scroll`, but it seems to me that it would have the same support as `element.scrollIntoView` method, which means that all the browser that are supported by `react-native-web` support it (some without the support for `behavior: smooth`).

https://caniuse.com/#feat=scrollintoview

Closes #1203