### PR TITLE
[fix] CSS animation insertion for Android 5.1 HuaWei browser

### DIFF
--- a/packages/react-native-web/src/exports/AppRegistry/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/react-native-web/src/exports/AppRegistry/__tests__/__snapshots__/index-test.js.snap
@@ -10,12 +10,10 @@ exports[`AppRegistry getApplication "getStyleElement" produces styles that are a
 `;
 
 exports[`AppRegistry getApplication "getStyleElement" produces styles that are a function of rendering "element": CSS for an unstyled app 1`] = `
-"@media all{
-html{-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;-webkit-tap-highlight-color:rgba(0,0,0,0);}
+"html{-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;-webkit-tap-highlight-color:rgba(0,0,0,0);}
 body{margin:0;}
 button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0;}
 input::-webkit-inner-spin-button,input::-webkit-outer-spin-button,input::-webkit-search-cancel-button,input::-webkit-search-decoration,input::-webkit-search-results-button,input::-webkit-search-results-decoration{display:none;}
-}
 .rn-pointerEvents-12vffkv > *{pointer-events:auto}
 .rn-pointerEvents-12vffkv{pointer-events:none !important}
 .rn-alignItems-1oszu61{-ms-flex-align:stretch;-webkit-align-items:stretch;-webkit-box-align:stretch;align-items:stretch}
@@ -59,10 +57,8 @@ exports[`AppRegistry getApplication returns "element" and "getStyleElement" 1`] 
 `;
 
 exports[`AppRegistry getApplication returns "element" and "getStyleElement" 2`] = `
-"<style id=\\"react-native-stylesheet\\">@media all{
-html{-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;-webkit-tap-highlight-color:rgba(0,0,0,0);}
+"<style id=\\"react-native-stylesheet\\">html{-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;-webkit-tap-highlight-color:rgba(0,0,0,0);}
 body{margin:0;}
 button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0;}
-input::-webkit-inner-spin-button,input::-webkit-outer-spin-button,input::-webkit-search-cancel-button,input::-webkit-search-decoration,input::-webkit-search-results-button,input::-webkit-search-results-decoration{display:none;}
-}</style>"
+input::-webkit-inner-spin-button,input::-webkit-outer-spin-button,input::-webkit-search-cancel-button,input::-webkit-search-decoration,input::-webkit-search-results-button,input::-webkit-search-results-decoration{display:none;}</style>"
 `;

--- a/packages/react-native-web/src/exports/StyleSheet/WebStyleSheet.js
+++ b/packages/react-native-web/src/exports/StyleSheet/WebStyleSheet.js
@@ -55,7 +55,15 @@ export default class WebStyleSheet {
       // doesn't include styles injected via 'insertRule')
       if (this._textContent.indexOf(rule) === -1 && this._sheet) {
         const pos = position || this._sheet.cssRules.length;
-        this._sheet.insertRule(rule, pos);
+        try {
+          this._sheet.insertRule(rule, pos);
+        } catch (e) {
+          if (process.env.NODE_ENV !== 'production') {
+            console.warn(
+              `Failed to inject CSS: "${rule}". This is rarely a problem and may be due to the browser rejecting unrecognized vendor prefixes.`
+            );
+          }
+        }
       }
     }
   }

--- a/packages/react-native-web/src/exports/StyleSheet/__tests__/__snapshots__/StyleSheetManager-test.js.snap
+++ b/packages/react-native-web/src/exports/StyleSheet/__tests__/__snapshots__/StyleSheetManager-test.js.snap
@@ -5,12 +5,10 @@ exports[`StyleSheet/StyleSheetManager getClassName 1`] = `undefined`;
 exports[`StyleSheet/StyleSheetManager getStyleSheet 1`] = `
 Object {
   "id": "react-native-stylesheet",
-  "textContent": "@media all{
-html{-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;-webkit-tap-highlight-color:rgba(0,0,0,0);}
+  "textContent": "html{-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;-webkit-tap-highlight-color:rgba(0,0,0,0);}
 body{margin:0;}
 button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0;}
 input::-webkit-inner-spin-button,input::-webkit-outer-spin-button,input::-webkit-search-cancel-button,input::-webkit-search-decoration,input::-webkit-search-results-button,input::-webkit-search-results-decoration{display:none;}
-}
 .rn---test-property-ax3bxi{--test-property:test-value}",
 }
 `;

--- a/packages/react-native-web/src/exports/StyleSheet/__tests__/__snapshots__/createAtomicRules.js.snap
+++ b/packages/react-native-web/src/exports/StyleSheet/__tests__/__snapshots__/createAtomicRules.js.snap
@@ -2,17 +2,20 @@
 
 exports[`StyleSheet/createAtomicRules transforms custom "animationName" declaration 1`] = `
 Array [
-  "@media all {@-webkit-keyframes rn-anim-2k74q5{0%{top:0px}50%{top:5px}100%{top:10px}}}",
-  "@media all {@keyframes rn-anim-2k74q5{0%{top:0px}50%{top:5px}100%{top:10px}}}",
-  "@media all {@-webkit-keyframes rn-anim-zc91cv{from{left:0px}to{left:10px}}}",
-  "@media all {@keyframes rn-anim-zc91cv{from{left:0px}to{left:10px}}}",
+  "@-webkit-keyframes rn-anim-2k74q5{0%{top:0px}50%{top:5px}100%{top:10px}}",
+  "@keyframes rn-anim-2k74q5{0%{top:0px}50%{top:5px}100%{top:10px}}",
+  "@-webkit-keyframes rn-anim-zc91cv{from{left:0px}to{left:10px}}",
+  "@keyframes rn-anim-zc91cv{from{left:0px}to{left:10px}}",
   ".test{-webkit-animation-name:rn-anim-2k74q5,rn-anim-zc91cv;animation-name:rn-anim-2k74q5,rn-anim-zc91cv}",
 ]
 `;
 
 exports[`StyleSheet/createAtomicRules transforms custom "placeholderTextColor" declaration 1`] = `
 Array [
-  "@media all {.test::-webkit-input-placeholder{color:gray;opacity:1}.test::-moz-placeholder{color:gray;opacity:1}.test:-ms-input-placeholder{color:gray;opacity:1}.test::placeholder{color:gray;opacity:1}}",
+  ".test::-webkit-input-placeholder{color:gray;opacity:1}",
+  ".test::-moz-placeholder{color:gray;opacity:1}",
+  ".test:-ms-input-placeholder{color:gray;opacity:1}",
+  ".test::placeholder{color:gray;opacity:1}",
 ]
 `;
 

--- a/packages/react-native-web/src/exports/StyleSheet/createAtomicRules.js
+++ b/packages/react-native-web/src/exports/StyleSheet/createAtomicRules.js
@@ -30,14 +30,10 @@ const createAtomicRules = (selector, prop, value) => {
 
     case 'placeholderTextColor': {
       const block = createRuleBlock({ color: value, opacity: 1 });
-      rules.push(
-        '@media all {' +
-          `${selector}::-webkit-input-placeholder{${block}}` +
-          `${selector}::-moz-placeholder{${block}}` +
-          `${selector}:-ms-input-placeholder{${block}}` +
-          `${selector}::placeholder{${block}}` +
-          '}'
-      );
+      rules.push(`${selector}::-webkit-input-placeholder{${block}}`);
+      rules.push(`${selector}::-moz-placeholder{${block}}`);
+      rules.push(`${selector}:-ms-input-placeholder{${block}}`);
+      rules.push(`${selector}::placeholder{${block}}`);
       break;
     }
 

--- a/packages/react-native-web/src/exports/StyleSheet/createKeyframesRules.js
+++ b/packages/react-native-web/src/exports/StyleSheet/createKeyframesRules.js
@@ -29,7 +29,7 @@ const makeSteps = keyframes =>
 const createKeyframesRules = (keyframes: Object): Array<String> => {
   const identifier = createIdentifier(keyframes);
   const rules = prefixes.map(prefix => {
-    return `@media all {@${prefix}keyframes ${identifier}{${makeSteps(keyframes)}}}`;
+    return `@${prefix}keyframes ${identifier}{${makeSteps(keyframes)}}`;
   });
   return { identifier, rules };
 };

--- a/packages/react-native-web/src/exports/StyleSheet/initialRules.js
+++ b/packages/react-native-web/src/exports/StyleSheet/initialRules.js
@@ -7,9 +7,6 @@
  * @flow
  */
 
-// Prevent browsers throwing parse errors, e.g., on vendor-prefixed pseudo-elements
-const safeRule = rule => `@media all{\n${rule}\n}`;
-
 const resets = [
   // minimal top-level reset
   'html{-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%;-webkit-tap-highlight-color:rgba(0,0,0,0);}',
@@ -21,6 +18,6 @@ const resets = [
     'input::-webkit-search-results-button,input::-webkit-search-results-decoration{display:none;}'
 ];
 
-const reset = [safeRule(resets.join('\n'))];
+const reset = [resets.join('\n')];
 
 export default reset;


### PR DESCRIPTION
Inserting unprefixed CSS keyframes rules causes a `SYNTAX_ERR: DOM Exception
12` error in Android 5.1. A similar issue with inserting rules containing
vendor-prefixed pseudo-selectors was patched by wrapping rule in `@media all
{}` blocks. This patch removes the media query hack and wraps calls to
`CSSStyleSheet::insertRule` in a try-catch block.

Fix #1199