### PR TITLE
Remove Array.join

### DIFF
--- a/packages/react-native-web/src/exports/StyleSheet/ReactNativeStyleResolver.js
+++ b/packages/react-native-web/src/exports/StyleSheet/ReactNativeStyleResolver.js
@@ -84,13 +84,13 @@ export default class ReactNativeStyleResolver {
     // otherwise fallback to resolving
     const flatArray = flattenArray(style);
     let isArrayOfNumbers = true;
-    let cacheKey = "";
+    let cacheKey = '';
     for (let i = 0; i < flatArray.length; i++) {
       const id = flatArray[i];
       if (isArrayOfNumbers && (typeof id !== 'number')) {
         isArrayOfNumbers = false;
       } else {
-        cacheKey += (id + "-");
+        cacheKey += (id + '-');
         this._injectRegisteredStyle(id);
       }
     }

--- a/packages/react-native-web/src/exports/StyleSheet/ReactNativeStyleResolver.js
+++ b/packages/react-native-web/src/exports/StyleSheet/ReactNativeStyleResolver.js
@@ -84,15 +84,17 @@ export default class ReactNativeStyleResolver {
     // otherwise fallback to resolving
     const flatArray = flattenArray(style);
     let isArrayOfNumbers = true;
+    let cacheKey = "";
     for (let i = 0; i < flatArray.length; i++) {
       const id = flatArray[i];
-      if (typeof id !== 'number') {
+      if (isArrayOfNumbers && (typeof id !== 'number')) {
         isArrayOfNumbers = false;
       } else {
+        cacheKey += (id + "-");
         this._injectRegisteredStyle(id);
       }
     }
-    const key = isArrayOfNumbers ? createCacheKey(flatArray.join('-')) : null;
+    const key = isArrayOfNumbers ? createCacheKey(cacheKey) : null;
     return this._resolveStyleIfNeeded(flatArray, key);
   }
 

--- a/packages/react-native-web/src/exports/StyleSheet/ReactNativeStyleResolver.js
+++ b/packages/react-native-web/src/exports/StyleSheet/ReactNativeStyleResolver.js
@@ -87,10 +87,12 @@ export default class ReactNativeStyleResolver {
     let cacheKey = '';
     for (let i = 0; i < flatArray.length; i++) {
       const id = flatArray[i];
-      if (isArrayOfNumbers && (typeof id !== 'number')) {
+      if (typeof id !== 'number') {
         isArrayOfNumbers = false;
       } else {
-        cacheKey += (id + '-');
+        if (isArrayOfNumbers) {
+          cacheKey += (id + '-');
+        }
         this._injectRegisteredStyle(id);
       }
     }


### PR DESCRIPTION
I profiled the Script time in the benchmark by adding console.profile around the timings for Script time in the benchmark code. The only thing that leapt out was this call to Array.join in the resolve function. Since the code iterates over the array just before anyway, I got rid of it. Now I don't see this function in any profiles, and it tests faster here.

I won't make any claims on the performance, but I'll let you check, since I assume you have a more consistent test routine than I do.