### PR TITLE
add rogue.js with-react-native-web example to integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Examples of using React Native for Web with other web tools:
 * [Next.js](https://github.com/zeit/next.js/tree/master/examples/with-react-native-web) (and [example recipes](https://gist.github.com/necolas/f9034091723f1b279be86c7429eb0c96))
 * [Phenomic](https://github.com/phenomic/phenomic/tree/master/examples/react-native-web-app)
 * [Razzle](https://github.com/jaredpalmer/razzle/tree/master/examples/with-react-native-web)
+* [Rogue.js](https://github.com/alidcastano/rogue.js/tree/master/examples/with-react-native-web)
 * [Storybook](https://github.com/necolas/react-native-web/tree/master/packages/website/storybook/.storybook)
 * [Styleguidist](https://github.com/styleguidist/react-styleguidist/tree/master/examples/react-native)
 


### PR DESCRIPTION
Hey @necolas, thanks for all your work on react-native-web

I created [rogue.js](https://github.com/alidcastano/rogue.js), a small library to streamline setting up react ssr applications. I'm going to be using RNW in my project, so I just added built-in support for it in Rogue. 👍 Would be great to add it to the integrations list 

here's a link to the example, in case you'd like to take a look: https://github.com/alidcastano/rogue.js/tree/master/examples/with-react-native-web

quick note:

the actual API is just a few lines of code (see snippet below) but I encounted an issue with server-rendering css, which I'm pretty sure is caused by how webpack resolves caching when application code comes from multiple bundles. (it was brought up here before, regarding nextjs+RNW https://github.com/necolas/react-native-web/issues/1079, and I also created issue in rogue repo https://github.com/alidcastano/rogue.js/issues/78). so for now, the linked example above shows how to setup Rogue+RNW programmatically

```
// server.js
import rogue from '@roguejs/app/server'.native
import App from './App'

const app = rouge(App, process.env.BUNDLE_URL)

// client.js
import hydrate from '@roguejs/app/client.native'
import App from './App'

hydrate(App)
```