### PR TITLE
Implement TextInput prop "onContentSizeChange"

### DIFF
--- a/packages/react-native-web/src/exports/TextInput/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/TextInput/__tests__/index-test.js
@@ -166,6 +166,32 @@ describe('components/TextInput', () => {
     expect(onChangeText).toBeCalledWith(newText);
   });
 
+  describe('prop "onContentSizeChange"', () => {
+    test('without "multiline"', () => {
+      const onContentSizeChange = jest.fn();
+      const input = findNativeInput(mount(<TextInput onContentSizeChange={onContentSizeChange} />));
+      input.simulate('change');
+      expect(onContentSizeChange).toHaveBeenCalledTimes(0);
+    });
+
+    test('with "multiline"', () => {
+      const onContentSizeChange = jest.fn();
+      const input = findNativeTextarea(
+        mount(<TextInput multiline onContentSizeChange={onContentSizeChange} />)
+      );
+      const newText = 'my text';
+      input.simulate('change', { target: { value: newText } });
+      // NOTE: enzyme/jsdom don't support scrollHeight/scrollWidth so we only get 0
+      // That also means we don't know whent the content size has "changed"
+      // In practice we would expect this spy to be called twice, once on mount
+      // and once when the text changes.
+      expect(onContentSizeChange).toHaveBeenCalledTimes(1);
+      expect(onContentSizeChange).toBeCalledWith({
+        nativeEvent: { contentSize: { width: 0, height: 0 } }
+      });
+    });
+  });
+
   test('prop "onFocus"', () => {
     const onFocus = jest.fn();
     const input = findNativeInput(mount(<TextInput onFocus={onFocus} />));

--- a/packages/react-native-web/src/exports/TextInput/index.js
+++ b/packages/react-native-web/src/exports/TextInput/index.js
@@ -68,6 +68,8 @@ const setSelection = (node, selection) => {
 
 class TextInput extends Component<*> {
   _node: HTMLInputElement;
+  _nodeHeight: number;
+  _nodeWidth: number;
 
   static displayName = 'TextInput';
 
@@ -272,9 +274,30 @@ class TextInput extends Component<*> {
     }
   };
 
+  _handleContentSizeChange = () => {
+    const { onContentSizeChange, multiline } = this.props;
+    if (multiline && onContentSizeChange) {
+      const newHeight = this._node.scrollHeight;
+      const newWidth = this._node.scrollWidth;
+      if (newHeight !== this._nodeHeight || newWidth !== this._nodeWidth) {
+        this._nodeHeight = newHeight;
+        this._nodeWidth = newWidth;
+        onContentSizeChange({
+          nativeEvent: {
+            contentSize: {
+              height: this._nodeHeight,
+              width: this._nodeWidth
+            }
+          }
+        });
+      }
+    }
+  };
+
   _handleChange = e => {
     const { onChange, onChangeText } = this.props;
     const { text } = e.nativeEvent;
+    this._handleContentSizeChange();
     if (onChange) {
       onChange(e);
     }
@@ -403,6 +426,9 @@ class TextInput extends Component<*> {
 
   _setNode = component => {
     this._node = findNodeHandle(component);
+    if (this._node) {
+      this._handleContentSizeChange();
+    }
   };
 }
 


### PR DESCRIPTION
This PR adds support for `TextInput`'s `onContentSizeChange`.

A couple of questions / considerations:

1. ~I'm currently called onContentSizeChange when the ref callback fires. In practice, it seems to be nice to get information about the initial layout, but it feels a little weird to fire that on "mount" since it could be argued the initial mount isn't a size "change".~ https://github.com/necolas/react-native-web/pull/1226#issuecomment-453564745
1. enzyme doesn't support scrollHeight and scrollWidth (https://github.com/airbnb/enzyme/issues/1435#issuecomment-357130838) so it makes testing those values a little tricky. Please let me know if there's a better way to go about that. I also left some relevant comments in the corresponding test.

Fixes #793 