### PR TITLE
Re-implement onWheel to fix inverted scrolling

### DIFF
--- a/packages/react-native-web/src/vendor/react-native/VirtualizedList/index.js
+++ b/packages/react-native-web/src/vendor/react-native/VirtualizedList/index.js
@@ -1185,10 +1185,10 @@ class VirtualizedList extends React.PureComponent<Props, State> {
 
     // prepare direction and delta based on scroll orientation
     if (this.props.horizontal) {
-      delta = -e.wheelDeltaX || -e.deltaX
+      delta = -e.deltaX || e.wheelDeltaX
       direction = 'scrollLeft'
     } else {
-      delta = -e.wheelDeltaY || -e.deltaY
+      delta = -e.deltaY || e.wheelDeltaY
       direction = 'scrollTop'
 
       // if deltaMode is 1 (Firefox) then the deltaY is reported in lines, not pixels
@@ -1201,7 +1201,7 @@ class VirtualizedList extends React.PureComponent<Props, State> {
           lineHeight = styles.getPropertyValue('line-height')
         }
 
-        delta *= parseFloat(lineHeight)
+        delta *= (parseFloat(lineHeight) * 2)
       }
     }
 

--- a/packages/react-native-web/src/vendor/react-native/VirtualizedList/index.js
+++ b/packages/react-native-web/src/vendor/react-native/VirtualizedList/index.js
@@ -1290,7 +1290,9 @@ class VirtualizedList extends React.PureComponent<Props, State> {
       const scrollNode = this.getScrollableNode()
       const { delta, direction } = this._selectWheelDelta(e, scrollNode)
 
-      scrollNode[direction] += delta
+      setTimeout(() => {
+        scrollNode[direction] += delta
+      })
 
       e.preventDefault();
     }

--- a/packages/react-native-web/src/vendor/react-native/VirtualizedList/index.js
+++ b/packages/react-native-web/src/vendor/react-native/VirtualizedList/index.js
@@ -1185,10 +1185,10 @@ class VirtualizedList extends React.PureComponent<Props, State> {
 
     // prepare direction and delta based on scroll orientation
     if (this.props.horizontal) {
-      delta = e.wheelDeltaX || -e.deltaX
+      delta = -e.wheelDeltaX || -e.deltaX
       direction = 'scrollLeft'
     } else {
-      delta = e.wheelDeltaY || -e.deltaY
+      delta = -e.wheelDeltaY || -e.deltaY
       direction = 'scrollTop'
 
       // if deltaMode is 1 (Firefox) then the deltaY is reported in lines, not pixels


### PR DESCRIPTION
Beginning with this issue #995 and then this pull request #1137 with it's review, this is my attempt at a fix for inverted scrolling direction.

The original pull request #1137 did a few things differently and did not work properly on Firefox.

This PR:
- Addresses an issue with Firefox using `deltaMode` of `1` which gives you the number of lines, not pixels, in the `deltaY` value of the `onWheel` event. This results in the inverted scroll only scrolling a few pixels at a time.
- Uses the `onWheel` prop that is passed to the underlying ScrollView to listen to the wheel event instead of attaching an additional one. This eliminates the need to attach and detach listeners.
- Dispatches the `onWheel` event to any child lists as well as forwards the `onWheel` prop on just like how it does in `_onScroll` (do we want to do this, is this right?)

How I'm figuring out the number of pixels in a line is interesting, it only applies to events that have their `deltaMode` set to 1 though. I question if we even need this? is just setting it do the default enough for a proper scroll experience?