### PR TITLE
Update flow bin to 0.94

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,5 @@
 [version]
-^0.63.0
+^0.94.0
 
 [ignore]
 <PROJECT_ROOT>/.*/__tests__/.*

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "eslint-config-prettier": "^3.3.0",
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-react": "^7.7.0",
-    "flow-bin": "^0.63.1",
+    "flow-bin": "^0.94.0",
     "glob": "^7.1.2",
     "husky": "^0.14.3",
     "inline-style-prefixer": "^5.0.3",

--- a/packages/react-native-web/src/exports/Picker/index.js
+++ b/packages/react-native-web/src/exports/Picker/index.js
@@ -15,8 +15,7 @@ import PickerItem from './PickerItem';
 import PickerItemPropType from './PickerItemPropType';
 import PickerStylePropTypes from './PickerStylePropTypes';
 import StyleSheetPropType from '../../modules/StyleSheetPropType';
-import StyleSheet from '../StyleSheet';
-import TextPropTypes from '../Text/TextPropTypes';
+import StyleSheet, { type StyleObj } from '../StyleSheet';
 import { arrayOf, bool, func, number, oneOfType, string } from 'prop-types';
 import ViewPropTypes, { type ViewProps } from '../ViewPropTypes';
 
@@ -27,10 +26,10 @@ type Props = ViewProps & {
   enabled?: boolean,
   onValueChange?: Function,
   selectedValue?: number | string,
-  style?: pickerStyleType,
+  style?: StyleObj,
   testID?: string,
   /* compat */
-  itemStyle?: TextPropTypes.style,
+  itemStyle?: StyleObj,
   mode?: string,
   prompt?: string
 };

--- a/packages/react-native-web/src/exports/StyleSheet/flattenStyle.js
+++ b/packages/react-native-web/src/exports/StyleSheet/flattenStyle.js
@@ -10,9 +10,7 @@
 
 import ReactNativePropRegistry from '../../modules/ReactNativePropRegistry';
 import invariant from 'fbjs/lib/invariant';
-
-type Atom = number | boolean | Object | Array<?Atom>;
-type StyleObj = Atom;
+import type { StyleObj } from './StyleSheet';
 
 function getStyle(style) {
   if (typeof style === 'number') {
@@ -31,7 +29,6 @@ function flattenStyle(style: ?StyleObj): ?Object {
   }
 
   if (!Array.isArray(style)) {
-    // $FlowFixMe
     return getStyle(style);
   }
 

--- a/packages/react-native-web/src/exports/StyleSheet/index.js
+++ b/packages/react-native-web/src/exports/StyleSheet/index.js
@@ -1,5 +1,10 @@
+// @flow
+
 import { canUseDOM } from 'fbjs/lib/ExecutionEnvironment';
 import StyleSheet from './StyleSheet';
+
+type Atom = number | boolean | Object | Array<?Atom>;
+export type StyleObj = Atom;
 
 // allow original component styles to be inspected in React Dev Tools
 if (canUseDOM && window.__REACT_DEVTOOLS_GLOBAL_HOOK__) {

--- a/packages/react-native-web/src/exports/View/ViewPropTypes.js
+++ b/packages/react-native-web/src/exports/View/ViewPropTypes.js
@@ -12,6 +12,7 @@ import EdgeInsetsPropType, { type EdgeInsetsProp } from '../EdgeInsetsPropType';
 import StyleSheetPropType from '../../modules/StyleSheetPropType';
 import ViewStylePropTypes from './ViewStylePropTypes';
 import { any, array, arrayOf, bool, func, object, oneOf, oneOfType, string } from 'prop-types';
+import { type StyleObj } from '../StyleSheet';
 
 const stylePropType = StyleSheetPropType(ViewStylePropTypes);
 
@@ -65,7 +66,7 @@ export type ViewProps = {
   onTouchStart?: Function,
   onTouchStartCapture?: Function,
   pointerEvents?: 'box-none' | 'none' | 'box-only' | 'auto',
-  style?: stylePropType,
+  style?: StyleObj,
   testID?: string,
   // compatibility with React Native
   accessibilityViewIsModal?: boolean,
@@ -84,17 +85,19 @@ const ViewPropTypes = {
   accessibilityLabel: string,
   accessibilityLiveRegion: oneOf(['assertive', 'none', 'polite']),
   accessibilityRole: string,
-  accessibilityStates: arrayOf(oneOf([
-    'disabled',
-    'selected',
-    /* web-only */
-    'busy',
-    'checked',
-    'expanded',
-    'grabbed',
-    'invalid',
-    'pressed'
-  ])),
+  accessibilityStates: arrayOf(
+    oneOf([
+      'disabled',
+      'selected',
+      /* web-only */
+      'busy',
+      'checked',
+      'expanded',
+      'grabbed',
+      'invalid',
+      'pressed'
+    ])
+  ),
   accessibilityTraits: oneOfType([array, string]),
   accessible: bool,
   children: any,

--- a/packages/react-native-web/src/vendor/react-native/Animated/nodes/AnimatedInterpolation.js
+++ b/packages/react-native-web/src/vendor/react-native/Animated/nodes/AnimatedInterpolation.js
@@ -346,7 +346,7 @@ class AnimatedInterpolation extends AnimatedWithChildren {
     super.__detach();
   }
 
-  __transformDataType(range: Array<any>) {
+  __transformDataType(range: Array<string>): Array<number> {
     // Change the string array type to number array
     // So we can reuse the same logic in iOS and Android platform
     return range.map(function(value) {

--- a/packages/react-native-web/src/vendor/react-native/Animated/nodes/AnimatedNode.js
+++ b/packages/react-native-web/src/vendor/react-native/Animated/nodes/AnimatedNode.js
@@ -16,6 +16,8 @@ import invariant from 'fbjs/lib/invariant';
 // Note(vjeux): this would be better as an interface but flow doesn't
 // support them yet
 class AnimatedNode {
+  +update: () => void
+  
   __attach(): void {}
   __detach(): void {
     if (this.__isNative && this.__nativeTag != null) {

--- a/packages/react-native-web/src/vendor/react-native/Animated/nodes/AnimatedValue.js
+++ b/packages/react-native-web/src/vendor/react-native/Animated/nodes/AnimatedValue.js
@@ -57,7 +57,6 @@ function _flush(rootNode: AnimatedValue): void {
     }
   }
   findAnimatedStyles(rootNode);
-  /* $FlowFixMe */
   animatedStyles.forEach(animatedStyle => animatedStyle.update());
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4767,9 +4767,10 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flow-bin@^0.63.1:
-  version "0.63.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.63.1.tgz#ab00067c197169a5fb5b4996c8f6927b06694828"
+flow-bin@^0.94.0:
+  version "0.94.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.94.0.tgz#b5d58fe7559705b73a18229f97edfc3ab6ffffcb"
+  integrity sha512-DYF7r9CJ/AksfmmB4+q+TyLMoeQPRnqtF1Pk7KY3zgfkB/nVuA3nXyzqgsIPIvnMSiFEXQcFK4z+iPxSLckZhQ==
 
 flush-write-stream@^1.0.0:
   version "1.0.3"


### PR DESCRIPTION
Flow team has made great improvements on the checking speed and introduced the usage of a LSP since the version 0.75, now by default.

This update is quite a huge bump, but the type fixes are minor.