### PR TITLE
Made NativeEventEmitter work as expected.

### DIFF
--- a/packages/react-native-web/src/vendor/react-native/NativeEventEmitter/RCTDeviceEventEmitter.js
+++ b/packages/react-native-web/src/vendor/react-native/NativeEventEmitter/RCTDeviceEventEmitter.js
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict';
+
+import EventEmitter from '../emitter/EventEmitter';
+import EventSubscriptionVendor from '../emitter/EventSubscriptionVendor';
+
+import type EmitterSubscription from '../emitter/EmitterSubscription';
+
+function checkNativeEventModule(eventType: ?string) {
+  if (eventType) {
+    if (eventType.lastIndexOf('statusBar', 0) === 0) {
+      throw new Error(
+        '`' +
+          eventType +
+          '` event should be registered via the StatusBarIOS module',
+      );
+    }
+    if (eventType.lastIndexOf('keyboard', 0) === 0) {
+      throw new Error(
+        '`' +
+          eventType +
+          '` event should be registered via the Keyboard module',
+      );
+    }
+    if (eventType === 'appStateDidChange' || eventType === 'memoryWarning') {
+      throw new Error(
+        '`' +
+          eventType +
+          '` event should be registered via the AppState module',
+      );
+    }
+  }
+}
+
+/**
+ * Deprecated - subclass NativeEventEmitter to create granular event modules instead of
+ * adding all event listeners directly to RCTDeviceEventEmitter.
+ */
+class RCTDeviceEventEmitter extends EventEmitter {
+  sharedSubscriber: EventSubscriptionVendor;
+
+  constructor() {
+    const sharedSubscriber = new EventSubscriptionVendor();
+    super(sharedSubscriber);
+    this.sharedSubscriber = sharedSubscriber;
+  }
+
+  addListener(
+    eventType: string,
+    listener: Function,
+    context: ?Object,
+  ): EmitterSubscription {
+    if (__DEV__) {
+      checkNativeEventModule(eventType);
+    }
+    return super.addListener(eventType, listener, context);
+  }
+
+  removeAllListeners(eventType: ?string) {
+    if (__DEV__) {
+      checkNativeEventModule(eventType);
+    }
+    super.removeAllListeners(eventType);
+  }
+
+  removeSubscription(subscription: EmitterSubscription) {
+    if (subscription.emitter !== this) {
+      subscription.emitter.removeSubscription(subscription);
+    } else {
+      super.removeSubscription(subscription);
+    }
+  }
+}
+
+export default new RCTDeviceEventEmitter();

--- a/packages/react-native-web/src/vendor/react-native/NativeEventEmitter/RCTDeviceEventEmitter.js
+++ b/packages/react-native-web/src/vendor/react-native/NativeEventEmitter/RCTDeviceEventEmitter.js
@@ -15,6 +15,8 @@ import EventSubscriptionVendor from '../emitter/EventSubscriptionVendor';
 
 import type EmitterSubscription from '../emitter/EmitterSubscription';
 
+const __DEV__ = process.env.NODE_ENV !== 'production';
+
 function checkNativeEventModule(eventType: ?string) {
   if (eventType) {
     if (eventType === 'appStateDidChange' || eventType === 'memoryWarning') {

--- a/packages/react-native-web/src/vendor/react-native/NativeEventEmitter/RCTDeviceEventEmitter.js
+++ b/packages/react-native-web/src/vendor/react-native/NativeEventEmitter/RCTDeviceEventEmitter.js
@@ -17,20 +17,6 @@ import type EmitterSubscription from '../emitter/EmitterSubscription';
 
 function checkNativeEventModule(eventType: ?string) {
   if (eventType) {
-    if (eventType.lastIndexOf('statusBar', 0) === 0) {
-      throw new Error(
-        '`' +
-          eventType +
-          '` event should be registered via the StatusBarIOS module',
-      );
-    }
-    if (eventType.lastIndexOf('keyboard', 0) === 0) {
-      throw new Error(
-        '`' +
-          eventType +
-          '` event should be registered via the Keyboard module',
-      );
-    }
     if (eventType === 'appStateDidChange' || eventType === 'memoryWarning') {
       throw new Error(
         '`' +

--- a/packages/react-native-web/src/vendor/react-native/NativeEventEmitter/index.js
+++ b/packages/react-native-web/src/vendor/react-native/NativeEventEmitter/index.js
@@ -11,6 +11,7 @@
 import invariant from 'fbjs/lib/invariant';
 
 import EventEmitter from '../emitter/EventEmitter';
+import RCTDeviceEventEmitter from './RCTDeviceEventEmitter';
 
 
 import type EmitterSubscription from '../emitter/EmitterSubscription';
@@ -28,7 +29,7 @@ class NativeEventEmitter extends EventEmitter {
   _nativeModule: ?NativeModule;
 
   constructor(nativeModule: ?NativeModule) {
-    super();
+    super(RCTDeviceEventEmitter.sharedSubscriber);
   }
 
   addListener(

--- a/packages/react-native-web/src/vendor/react-native/NativeEventEmitter/index.js
+++ b/packages/react-native-web/src/vendor/react-native/NativeEventEmitter/index.js
@@ -8,11 +8,10 @@
  * @flow
  */
 'use strict';
+import invariant from 'fbjs/lib/invariant';
 
 import EventEmitter from '../emitter/EventEmitter';
-import Platform from '../../../exports/Platform';
 
-import invariant from 'fbjs/lib/invariant';
 
 import type EmitterSubscription from '../emitter/EmitterSubscription';
 
@@ -30,10 +29,6 @@ class NativeEventEmitter extends EventEmitter {
 
   constructor(nativeModule: ?NativeModule) {
     super();
-    if (Platform.OS === 'ios') {
-      invariant(nativeModule, 'Native module cannot be null.');
-      this._nativeModule = nativeModule;
-    }
   }
 
   addListener(


### PR DESCRIPTION
# Why

We want to be able to use the same JS API across iOS, Android, and Web. This will enable that platform functionality. 
With turbo modules, the event system will more than likely change and we should revisit this. Regardless it seems like if you can implement NativeEventEmitter, and emit events, then either something should happen or a warning should be thrown. Otherwise this creates a very hard to track bug in the expected behavior.

I also removed the iOS Platform specific feature as we don't use that in web.