### PR TITLE
[jest-preset] export module to resolve in multi-project jest setups

### DIFF
--- a/packages/react-native-web/jest-preset.js
+++ b/packages/react-native-web/jest-preset.js
@@ -1,0 +1,9 @@
+const path = require('path');
+
+module.exports = {
+  moduleNameMapper: {
+    '^react-native$': path.join(__dirname, 'dist', 'cjs')
+  },
+  setupFiles: [path.join(__dirname, 'jest', 'setup.js')],
+  testEnvironment: require.resolve('jest-environment-jsdom')
+};

--- a/packages/react-native-web/jest-preset.json
+++ b/packages/react-native-web/jest-preset.json
@@ -1,9 +1,0 @@
-{
-  "moduleNameMapper": {
-    "^react-native$": "<rootDir>/node_modules/react-native-web/dist/cjs"
-  },
-  "setupFiles": [
-    "<rootDir>/node_modules/react-native-web/jest/setup.js"
-  ],
-  "testEnvironment": "jsdom"
-}

--- a/packages/react-native-web/package.json
+++ b/packages/react-native-web/package.json
@@ -11,7 +11,7 @@
   "files": [
     "dist",
     "jest",
-    "jest-preset.json",
+    "jest-preset.js",
     "src",
     "!**/__tests__"
   ],


### PR DESCRIPTION
## Problem

In a multi-project jest setup, using the `react-native-web` jest preset option will not work correctly, unless your sub-project sets its root to the repo root instead of the project root.

For example, given the following structure:

```
repo/
├── node_modules/
├── packages/
│   ├── with-react-native-web/
│   │   └── jest.config.js
│   └── other-package
│       └── jest.config.js
└── jest.config.js
```

In `packages/with-react-native-web/jest.config.js`, we add:

```
preset: 'react-native-web',
rootDir: './'
```

Since Yarn will install `react-native-web` at the root `node_modules` folder, the `<rootDir>` in the `jest-preset` will not resolve correctly:

```
$ jest
● Validation Error:

  Module <rootDir>/node_modules/react-native-web/jest/setup.js in the setupFiles option was not found.
         <rootDir> is: /Development/my-app/packages/with-react-native-web

  Configuration Documentation:
  https://jestjs.io/docs/configuration.html
```

## Solution

Convert to a JS module and use `path` and `__dirname` to resolve relative to the config file.