### PR TITLE
[ScrollView] Added `showsHorizontalScrollIndicator` & `showsVerticalScrollIndicator`

### DIFF
--- a/packages/react-native-web/src/exports/ScrollView/ScrollViewBase.js
+++ b/packages/react-native-web/src/exports/ScrollView/ScrollViewBase.js
@@ -132,11 +132,11 @@ export default class ScrollViewBase extends Component<*> {
         onTouchMove={this._createPreventableScrollHandler(this.props.onTouchMove)}
         onWheel={this._createPreventableScrollHandler(this.props.onWheel)}
         ref={this._setViewRef}
-        style={StyleSheet.flatten([
+        style={[
           style,
           !scrollEnabled && styles.scrollDisabled,
           !showScrollIndicator && style.disableScrollIndicator
-        ])}
+        ]}
       />
     );
   }

--- a/packages/react-native-web/src/exports/ScrollView/ScrollViewBase.js
+++ b/packages/react-native-web/src/exports/ScrollView/ScrollViewBase.js
@@ -68,7 +68,9 @@ export default class ScrollViewBase extends Component<*> {
 
   static defaultProps = {
     scrollEnabled: true,
-    scrollEventThrottle: 0
+    scrollEventThrottle: 0,
+    showsHorizontalScrollIndicator: true,
+    showsVerticalScrollIndicator: true
   };
 
   _debouncedOnScrollEnd = debounce(this._handleScrollEnd, 100);
@@ -122,6 +124,7 @@ export default class ScrollViewBase extends Component<*> {
       ...other
     } = this.props;
 
+    const showScrollIndicator = showsHorizontalScrollIndicator && showsVerticalScrollIndicator;
     return (
       <View
         {...other}
@@ -131,7 +134,8 @@ export default class ScrollViewBase extends Component<*> {
         ref={this._setViewRef}
         style={StyleSheet.compose(
           style,
-          !scrollEnabled && styles.scrollDisabled
+          !scrollEnabled && styles.scrollDisabled,
+          !showScrollIndicator && style.disableScrollIndicator
         )}
       />
     );
@@ -204,5 +208,8 @@ export default class ScrollViewBase extends Component<*> {
 const styles = StyleSheet.create({
   scrollDisabled: {
     touchAction: 'none'
+  },
+  disableScrollIndicator: {
+    scrollIndicator: 'none'
   }
 });

--- a/packages/react-native-web/src/exports/ScrollView/ScrollViewBase.js
+++ b/packages/react-native-web/src/exports/ScrollView/ScrollViewBase.js
@@ -132,11 +132,11 @@ export default class ScrollViewBase extends Component<*> {
         onTouchMove={this._createPreventableScrollHandler(this.props.onTouchMove)}
         onWheel={this._createPreventableScrollHandler(this.props.onWheel)}
         ref={this._setViewRef}
-        style={StyleSheet.compose(
+        style={StyleSheet.flatten([
           style,
           !scrollEnabled && styles.scrollDisabled,
           !showScrollIndicator && style.disableScrollIndicator
-        )}
+        ])}
       />
     );
   }

--- a/packages/react-native-web/src/exports/StyleSheet/__tests__/__snapshots__/compile-test.js.snap
+++ b/packages/react-native-web/src/exports/StyleSheet/__tests__/__snapshots__/compile-test.js.snap
@@ -58,6 +58,15 @@ Object {
     ],
     "value": "box-only",
   },
+  "r-scrollIndicator-1j953gk": Object {
+    "identifier": "r-scrollIndicator-1j953gk",
+    "property": "scrollIndicator",
+    "rules": Array [
+      ".r-scrollIndicator-1j953gk::-webkit-scrollbar{display: none;}",
+      ".r-scrollIndicator-1j953gk{overflow: -moz-scrollbars-none;-ms-overflow-style: none;}",
+    ],
+    "value": "none",
+  },
   "r-transform-1ehiua4": Object {
     "identifier": "r-transform-1ehiua4",
     "property": "transform",

--- a/packages/react-native-web/src/exports/StyleSheet/__tests__/compile-test.js
+++ b/packages/react-native-web/src/exports/StyleSheet/__tests__/compile-test.js
@@ -16,6 +16,7 @@ describe('StyleSheet/compile', () => {
         fontFamily: 'System',
         marginHorizontal: 10,
         placeholderTextColor: 'gray',
+        scrollIndicator: 'none',
         pointerEvents: 'box-only',
         transform: [
           {

--- a/packages/react-native-web/src/exports/StyleSheet/compile.js
+++ b/packages/react-native-web/src/exports/StyleSheet/compile.js
@@ -147,7 +147,7 @@ function createAtomicRules(identifier: string, property, value): Rules {
     case 'scrollIndicator': {
       if (value === 'none') {
         rules.push(
-          `${selector}::-webkit-scrollbar{width: 0 !important}`,
+          `${selector}::-webkit-scrollbar{display: none;}`,
           `${selector}{overflow: -moz-scrollbars-none;-ms-overflow-style: none;}`
         );
       }

--- a/packages/react-native-web/src/exports/StyleSheet/compile.js
+++ b/packages/react-native-web/src/exports/StyleSheet/compile.js
@@ -75,7 +75,7 @@ export function atomic(style: Style): CompilerOutput {
 
 /**
  * Compile simple style object to classic CSS rules.
- * No support for 'placeholderTextColor' or 'pointerEvents'.
+ * No support for 'placeholderTextColor', 'scrollIndicator', or 'pointerEvents'.
  */
 export function classic(style: Style, name: string): CompilerOutput {
   const identifier = createIdentifier('css', name, style);
@@ -97,7 +97,7 @@ export function classic(style: Style, name: string): CompilerOutput {
 
 /**
  * Compile simple style object to inline DOM styles.
- * No support for 'animationKeyframes', 'placeholderTextColor', or 'pointerEvents'.
+ * No support for 'animationKeyframes', 'placeholderTextColor', 'scrollIndicator', or 'pointerEvents'.
  */
 export function inline(style: Style) {
   return prefixInlineStyles(createReactDOMStyle(style));
@@ -141,6 +141,16 @@ function createAtomicRules(identifier: string, property, value): Rules {
         `${selector}:-ms-input-placeholder${block}`,
         `${selector}::placeholder${block}`
       );
+      break;
+    }
+
+    case 'scrollIndicator': {
+      if (value === 'none') {
+        rules.push(
+          `${selector}::-webkit-scrollbar{width: 0 !important}`,
+          `${selector}{overflow: -moz-scrollbars-none;-ms-overflow-style: none;}`
+        );
+      }
       break;
     }
 

--- a/packages/react-native-web/src/exports/StyleSheet/createStyleResolver.js
+++ b/packages/react-native-web/src/exports/StyleSheet/createStyleResolver.js
@@ -230,6 +230,7 @@ export default function createStyleResolver() {
               // require more complex transforms into multiple CSS rules. Here we assume that StyleManager
               // can bind these styles to a className, and prevent them becoming invalid inline-styles.
               if (
+                styleProp === 'scrollIndicator' ||
                 styleProp === 'pointerEvents' ||
                 styleProp === 'placeholderTextColor' ||
                 styleProp === 'animationKeyframes'

--- a/packages/react-native-web/src/exports/View/ViewStylePropTypes.js
+++ b/packages/react-native-web/src/exports/View/ViewStylePropTypes.js
@@ -55,7 +55,7 @@ const ViewStylePropTypes = {
   overscrollBehavior: overscrollBehaviorType,
   overscrollBehaviorX: overscrollBehaviorType,
   overscrollBehaviorY: overscrollBehaviorType,
-  scrollIndicator: string,
+  scrollIndicator: oneOf(['none']),
   scrollSnapAlign: string,
   scrollSnapType: string,
   WebkitMaskImage: string,

--- a/packages/react-native-web/src/exports/View/ViewStylePropTypes.js
+++ b/packages/react-native-web/src/exports/View/ViewStylePropTypes.js
@@ -55,6 +55,7 @@ const ViewStylePropTypes = {
   overscrollBehavior: overscrollBehaviorType,
   overscrollBehaviorX: overscrollBehaviorType,
   overscrollBehaviorY: overscrollBehaviorType,
+  scrollIndicator: string,
   scrollSnapAlign: string,
   scrollSnapType: string,
   WebkitMaskImage: string,


### PR DESCRIPTION
Added pseudo support for `showsHorizontalScrollIndicator` and `showsVerticalScrollIndicator` by creating the style property `scrollIndicator` which disables the scroll bars.

Unfortunately this means if either `showsHorizontalScrollIndicator` or `showsVerticalScrollIndicator` are false, then both are hidden.