### PR TITLE
Add maxFontSizeMultiplier

### DIFF
--- a/packages/react-native-web/src/exports/Text/TextPropTypes.js
+++ b/packages/react-native-web/src/exports/Text/TextPropTypes.js
@@ -21,6 +21,7 @@ const TextPropTypes = {
   accessible: bool,
   children: any,
   importantForAccessibility: oneOf(['auto', 'no', 'no-hide-descendants', 'yes']),
+  maxFontSizeMultiplier: number,
   nativeID: string,
   numberOfLines: number,
   onBlur: func,

--- a/packages/react-native-web/src/exports/Text/index.js
+++ b/packages/react-native-web/src/exports/Text/index.js
@@ -47,6 +47,7 @@ class Text extends Component<*> {
       allowFontScaling,
       ellipsizeMode,
       lineBreakMode,
+      maxFontSizeMultiplier,
       minimumFontScale,
       onLayout,
       onLongPress,

--- a/packages/react-native-web/src/exports/TextInput/index.js
+++ b/packages/react-native-web/src/exports/TextInput/index.js
@@ -95,6 +95,7 @@ class TextInput extends Component<*> {
       'url',
       'web-search'
     ]),
+    maxFontSizeMultiplier: number,
     maxLength: number,
     multiline: bool,
     numberOfLines: number,
@@ -202,6 +203,7 @@ class TextInput extends Component<*> {
       inlineImagePadding,
       inputAccessoryViewID,
       keyboardAppearance,
+      maxFontSizeMultiplier,
       needsOffscreenAlphaCompositing,
       onAccessibilityTap,
       onContentSizeChange,


### PR DESCRIPTION
There is no equivalent for this on the web so it does the same thing as `allowFontScaling` and just makes sure it doesn't get forwarded to the dom.

Fixes #1276 