### PR TITLE
Fix border style for Text component

### DIFF
--- a/packages/react-native-web/src/exports/Text/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/react-native-web/src/exports/Text/__tests__/__snapshots__/index-test.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/Text rendered element renders correctly with borderWidth style 1`] = `
+Object {
+  "borderBottomWidth": "1px",
+  "borderLeftWidth": "1px",
+  "borderRightWidth": "1px",
+  "borderTopWidth": "1px",
+}
+`;
+
+exports[`components/Text rendered element renders correctly with borderWidth style 2`] = `"css-text-901oao"`;

--- a/packages/react-native-web/src/exports/Text/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/Text/__tests__/index-test.js
@@ -26,6 +26,13 @@ describe('components/Text', () => {
       const component = shallow(<Text dir="rtl" />);
       expect(component.prop('dir')).toBe('rtl');
     });
+
+    test('renders correctly with borderWidth style', () => {
+      const component = shallow(<Text style={{ borderWidth: 1 }} />);
+      const div = component.find('div');
+      expect(div.prop('style')).toMatchSnapshot();
+      expect(div.prop('className')).toMatchSnapshot();
+    });
   });
 
   test('prop "children"', () => {

--- a/packages/react-native-web/src/exports/Text/index.js
+++ b/packages/react-native-web/src/exports/Text/index.js
@@ -110,7 +110,7 @@ class Text extends Component<*> {
 
 const classes = css.create({
   text: {
-    borderWidth: 0,
+    border: '0 solid black',
     boxSizing: 'border-box',
     color: 'black',
     display: 'inline',


### PR DESCRIPTION
Fixes Issue #1327 
Currently when transpiled for web, Text Component is not rendering with any border when only `borderWidth` is given (renders correctly in Native). The simple fix is to set `border` property to `0 solid black` as default for `Text` component similar to what has been done for most of the other components like `View`, `TextInput` etc.