### PR TITLE
[babel-plugin] Remove default member expression from index require

### DIFF
--- a/packages/babel-plugin-react-native-web/src/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/babel-plugin-react-native-web/src/__tests__/__snapshots__/index-test.js.snap
@@ -92,7 +92,7 @@ const { StyleSheet, TouchableOpacity } = require('react-native');
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-const ReactNative = require('react-native-web/dist/index').default;
+const ReactNative = require('react-native-web/dist/index');
 
 const View = require('react-native-web/dist/exports/View').default;
 
@@ -110,7 +110,7 @@ const { StyleSheet, TouchableOpacity } = require('react-native');
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-const ReactNative = require('react-native-web/dist/cjs/index').default;
+const ReactNative = require('react-native-web/dist/cjs/index');
 
 const View = require('react-native-web/dist/cjs/exports/View').default;
 
@@ -128,7 +128,7 @@ const { ColorPropType, StyleSheet, View, TouchableOpacity, processColor } = requ
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-const ReactNative = require('react-native-web/dist/index').default;
+const ReactNative = require('react-native-web/dist/index');
 
 const createElement = require('react-native-web/dist/exports/createElement').default;
 

--- a/packages/babel-plugin-react-native-web/src/index.js
+++ b/packages/babel-plugin-react-native-web/src/index.js
@@ -118,12 +118,9 @@ module.exports = function({ types: t }) {
             const importIndex = t.variableDeclaration(path.node.kind, [
               t.variableDeclarator(
                 t.identifier(name),
-                t.memberExpression(
-                  t.callExpression(t.identifier('require'), [
-                    t.stringLiteral(getDistLocation('index', state.opts))
-                  ]),
-                  t.identifier('default')
-                )
+                t.callExpression(t.identifier('require'), [
+                  t.stringLiteral(getDistLocation('index', state.opts))
+                ])
               )
             ]);
 


### PR DESCRIPTION
Recently the default export was removed from react-native-web. In some scenarios it is possible to still get to this import path which does not work anymore. Removing the `.default` fixes commonjs imports from index.