### PR TITLE
Image - Don't swap from defaultSource to source until fully loaded

### DIFF
--- a/packages/react-native-web/src/exports/Image/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/Image/__tests__/index-test.js
@@ -21,7 +21,7 @@ describe('components/Image', () => {
     window.Image = originalImage;
   });
 
-  test.only('prop "accessibilityLabel"', () => {
+  test('prop "accessibilityLabel"', () => {
     const defaultSource = { uri: 'https://google.com/favicon.ico' };
     const component = shallow(
       <Image accessibilityLabel="accessibilityLabel" defaultSource={defaultSource} />

--- a/packages/react-native-web/src/exports/Image/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/Image/__tests__/index-test.js
@@ -21,7 +21,7 @@ describe('components/Image', () => {
     window.Image = originalImage;
   });
 
-  test('prop "accessibilityLabel"', () => {
+  test.only('prop "accessibilityLabel"', () => {
     const defaultSource = { uri: 'https://google.com/favicon.ico' };
     const component = shallow(
       <Image accessibilityLabel="accessibilityLabel" defaultSource={defaultSource} />

--- a/packages/react-native-web/src/exports/Image/index.js
+++ b/packages/react-native-web/src/exports/Image/index.js
@@ -377,7 +377,7 @@ class Image extends Component<*, State> {
     this._imageRef = ref;
   };
 
-  _updateImageState(status, hasDefaultSource = false) {
+  _updateImageState(status: ?string, hasDefaultSource: ?boolean = false) {
     this._imageState = status;
     const shouldDisplaySource =
       this._imageState === STATUS_LOADED ||

--- a/packages/react-native-web/src/exports/Image/index.js
+++ b/packages/react-native-web/src/exports/Image/index.js
@@ -167,6 +167,8 @@ class Image extends Component<*, State> {
       const isPreviouslyLoaded = ImageUriCache.has(uri);
       isPreviouslyLoaded && ImageUriCache.add(uri);
       this._updateImageState(getImageState(uri, isPreviouslyLoaded), !!this.props.defaultSource);
+    } else if (!!prevProps.defaultSource !== !!this.props.defaultSource) {
+      this._updateImageState(this._imageState, !!this.props.defaultSource);
     }
     if (this._imageState === STATUS_PENDING) {
       this._createImageLoader();

--- a/packages/react-native-web/src/exports/Image/index.js
+++ b/packages/react-native-web/src/exports/Image/index.js
@@ -166,7 +166,7 @@ class Image extends Component<*, State> {
       ImageUriCache.remove(prevUri);
       const isPreviouslyLoaded = ImageUriCache.has(uri);
       isPreviouslyLoaded && ImageUriCache.add(uri);
-      this._updateImageState(getImageState(uri, isPreviouslyLoaded));
+      this._updateImageState(getImageState(uri, isPreviouslyLoaded), !!this.props.defaultSource);
     }
     if (this._imageState === STATUS_PENDING) {
       this._createImageLoader();
@@ -364,8 +364,8 @@ class Image extends Component<*, State> {
   }
 
   _onLoadStart() {
-    const { onLoadStart } = this.props;
-    this._updateImageState(STATUS_LOADING);
+    const { defaultSource, onLoadStart } = this.props;
+    this._updateImageState(STATUS_LOADING, !!defaultSource);
     if (onLoadStart) {
       onLoadStart();
     }
@@ -375,11 +375,12 @@ class Image extends Component<*, State> {
     this._imageRef = ref;
   };
 
-  _updateImageState(status) {
+  _updateImageState(status, hasDefaultSource = false) {
     this._imageState = status;
     const shouldDisplaySource =
-      this._imageState === STATUS_LOADED || this._imageState === STATUS_LOADING;
-    // only triggers a re-render when the image is loading (to support PJEG), loaded, or failed
+      this._imageState === STATUS_LOADED ||
+      (this._imageState === STATUS_LOADING && !hasDefaultSource);
+    // only triggers a re-render when the image is loading and has no default image (to support PJPEG), loaded, or failed
     if (shouldDisplaySource !== this.state.shouldDisplaySource) {
       if (this._isMounted) {
         this.setState(() => ({ shouldDisplaySource }));

--- a/packages/react-native-web/src/exports/Image/index.js
+++ b/packages/react-native-web/src/exports/Image/index.js
@@ -162,13 +162,14 @@ class Image extends Component<*, State> {
   componentDidUpdate(prevProps) {
     const prevUri = resolveAssetUri(prevProps.source);
     const uri = resolveAssetUri(this.props.source);
+    const hasDefaultSource = this.props.defaultSource !== undefined;
     if (prevUri !== uri) {
       ImageUriCache.remove(prevUri);
       const isPreviouslyLoaded = ImageUriCache.has(uri);
       isPreviouslyLoaded && ImageUriCache.add(uri);
-      this._updateImageState(getImageState(uri, isPreviouslyLoaded), !!this.props.defaultSource);
-    } else if (!!prevProps.defaultSource !== !!this.props.defaultSource) {
-      this._updateImageState(this._imageState, !!this.props.defaultSource);
+      this._updateImageState(getImageState(uri, isPreviouslyLoaded), hasDefaultSource);
+    } else if (hasDefaultSource && prevProps.defaultSource !== this.props.defaultSource) {
+      this._updateImageState(this._imageState, hasDefaultSource);
     }
     if (this._imageState === STATUS_PENDING) {
       this._createImageLoader();


### PR DESCRIPTION
Image provides a mechanism (defaultSource) for showing a loading or
fallback image. Currently, as soon as the source starts loading,
which is immediately after the first render, it's swapped in. The
intention is to support progressive JPEGs.

However, in cases where the user has explicitly given a defaultSource,
I'd argue that should be a better experience than watching the PJPEG load.
In conjunction with my other PR, a dev can now easily manage multiple versions
of an image via RNWs cache. Imagine on Twitter that you view a low-res image
in the timeline. Clicking to the gallery, we can read RNW's cache and provide
the highest variant found in it as the defaultSource. For users offline, or on
slow connections, the image will immediate show up and stay until we are ready
to swap in the full image. It's a roll your own PJPEG.

In addition, Enzyme now runs lifecycle methods on shallow, so I cleaned up
a few other nearby tests.