### PR TITLE
[docs] heading => header for consistency with react-native

### DIFF
--- a/docs/guides/accessibility.md
+++ b/docs/guides/accessibility.md
@@ -76,7 +76,7 @@ The `accessibilityRole` prop is used to infer an [analogous HTML
 element][html-aria-url] and ARIA `role`, where possible. In most cases, both
 the element and ARIA `role` are rendered. While this may contradict some ARIA
 recommendations, it also helps avoid certain browser bugs, HTML5 conformance
-errors, and accessibility anti-patterns (e.g., giving a `heading` role to a
+errors, and accessibility anti-patterns (e.g., giving a `header` role to a
 `button` element). On the Web, `accessibilityRole` supports more values than
 React Native does for [Android and iOS](https://facebook.github.io/react-native/docs/accessibility#accessibilityrole-ios-android).
 
@@ -88,10 +88,10 @@ Straight-forward examples:
 * `<Text accessibilityRole="link" />` => `<a role="link" />`.
 * `<View accessibilityRole="main" />` => `<main role="main" />`.
 
-The `heading` role can be combined with `aria-level`:
+The `header` role can be combined with `aria-level`:
 
-* `<Text accessibilityRole="heading" />` => `<h1 />`.
-* `<Text accessibilityRole="heading" aria-level="3" />` => `<h3 />`.
+* `<Text accessibilityRole="header" />` => `<h1 />`.
+* `<Text accessibilityRole="header" aria-level="3" />` => `<h3 />`.
 
 The `button` role renders an accessible button but is not implemented using the
 native `button` element due to some browsers limiting the use of flexbox layout on


### PR DESCRIPTION
This is a followup to https://github.com/necolas/react-native-web/commit/39d2e18ccfda6e6fd27f01f61198c27d2281107b.

Update the docs to match [the React Native docs](https://facebook.github.io/react-native/docs/accessibility#accessibilityrole-ios-android).

RN uses the term header instead of heading. RNW can accept either one, but we should probably encourage the use of the one that will work across all platforms.

