### PR TITLE
StyleSheet: enhance hairlineWidth

### DIFF
--- a/packages/react-native-web/src/exports/StyleSheet/StyleSheet.js
+++ b/packages/react-native-web/src/exports/StyleSheet/StyleSheet.js
@@ -7,6 +7,7 @@
  * @flow
  */
 
+import PixelRatio from '../PixelRatio';
 import ReactNativePropRegistry from '../../modules/ReactNativePropRegistry';
 import flattenStyle from './flattenStyle';
 
@@ -18,6 +19,11 @@ const absoluteFillObject = {
   bottom: 0
 };
 const absoluteFill = ReactNativePropRegistry.register(absoluteFillObject);
+
+let hairlineWidth = PixelRatio.roundToNearestPixel(0.4);
+if (hairlineWidth === 0) {
+  hairlineWidth = 1 / PixelRatio.get();
+}
 
 const StyleSheet = {
   absoluteFill,
@@ -57,7 +63,7 @@ const StyleSheet = {
     return result;
   },
   flatten: flattenStyle,
-  hairlineWidth: 1
+  hairlineWidth
 };
 
 export default StyleSheet;


### PR DESCRIPTION
This change avoids `hairlineWidth` to look fat on high density screen, which defeat the purpose. 

Note that this can look as a breaking change: with current (RN) implementation, a border-top of 0.33333333px (on a device with a device px ratio to 3) can be invisible (eg: safari ios).

If we want to avoid this, we could just add something like

```js
// some browser render as 0 something like 0.3333333333, instead of 0.34...)
const hairlineWidthMaxPrecision = 6;
const hairlineWidthMaxPrecisionTrick = Math.pow(10, hairlineWidthMaxPrecision)
hairlineWidth = Math.round(hairlineWidth * hairlineWidthMaxPrecisionTrick)/hairlineWidthMaxPrecisionTrick;
```