### PR TITLE
Fix handling of onClick event for accessibilityRole="link"

### DIFF
--- a/packages/react-native-web/src/exports/createElement/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/createElement/__tests__/index-test.js
@@ -24,6 +24,45 @@ describe('modules/createElement', () => {
     });
   });
 
+  test('gracefully handles onClick for links', () => {
+    let wasCalled = false;
+    const component = shallow(
+      createElement('div', {
+        accessibilityRole: 'link',
+        onClick: () => {
+          wasCalled = true;
+        }
+      })
+    );
+    component.find('a').simulate('click', {
+      isDefaultPrevented() {},
+      nativeEvent: {},
+      preventDefault() {}
+    });
+
+    expect(wasCalled).toBe(true);
+  });
+
+  test('gracefully handles onClick for touchable links', () => {
+    let wasCalled = false;
+    const component = shallow(
+      createElement('div', {
+        accessibilityRole: 'link',
+        onResponderRelease: () => {}, // fake touchable
+        onClick: () => {
+          wasCalled = true;
+        }
+      })
+    );
+    component.find('a').simulate('click', {
+      isDefaultPrevented() {},
+      nativeEvent: {},
+      preventDefault() {}
+    });
+
+    expect(wasCalled).toBe(true);
+  });
+
   describe('prop "accessibilityRole"', () => {
     test('and string component type', () => {
       const component = shallow(createElement('span', { accessibilityRole: 'link' }));

--- a/packages/react-native-web/src/exports/createElement/index.js
+++ b/packages/react-native-web/src/exports/createElement/index.js
@@ -70,12 +70,16 @@ const adjustProps = domProps => {
   // element. Click events are not an expected part of the React Native API,
   // and browsers dispatch click events that cannot otherwise be cancelled from
   // preceding mouse events in the responder system.
+  // Handle overrides gracefully if the user provides an onClick method.
+  // If this is provided, the user must make sure to handle the edge cases.
   if (isLinkRole && onResponderRelease) {
-    domProps.onClick = function(e) {
-      if (!e.isDefaultPrevented() && !isModifiedEvent(e.nativeEvent) && !domProps.target) {
-        e.preventDefault();
-      }
-    };
+    domProps.onClick =
+      onClick ||
+      function(e) {
+        if (!e.isDefaultPrevented() && !isModifiedEvent(e.nativeEvent) && !domProps.target) {
+          e.preventDefault();
+        }
+      };
   }
 
   // Button-like roles should trigger 'onClick' if SPACE or ENTER keys are pressed.


### PR DESCRIPTION
This is a separation from #1348 in order to separate the discussion of two separate issues.
By default `onClick` and other DOM based props are passed down to the element like `div`s, but not for links!

This is currently not in the documentation, but used in [this example](https://gist.github.com/necolas/f9034091723f1b279be86c7429eb0c96) and in the [official guides](https://github.com/necolas/react-native-web/blob/master/docs/guides/web-recipes.md) (here: `onMouseEnter/Leave`) from @necholas!

Using `onClick` is crucial when **avoiding** Touchables/ScrollViews in to not inherit issues from #1219. Mobile browsers already solve scroll-based issues if we use regular click events. 
This PR aims to allow just that and fix the link handling, as all other RNW elements support the `onClick`.

This results in problems like:
```jsx
<View
 onClick={() => console.log('called')}
 accessibilityRole="button"
>
```

```jsx
<View
 onClick={() => console.log('never called')}
 accessibilityRole="link" // want to use for accessibility and SEO reasons
>
```