### PR TITLE
Fix InteractionManager runAfterInteractions resolve

### DIFF
--- a/packages/react-native-web/src/exports/InteractionManager/index.js
+++ b/packages/react-native-web/src/exports/InteractionManager/index.js
@@ -27,6 +27,8 @@ const InteractionManager = {
       handle = requestIdleCallback(() => {
         if (task) {
           resolve(task());
+        } else {
+          resolve();
         }
       });
     });


### PR DESCRIPTION
InteractionManager runAfterInteractions does not resolve its promise unless the function is provided with a callback. Using promises, the user of the library should not need to provide a callback. This update adds an else case when there is no callback to call the Promise's resolve function without arguments.