### PR TITLE
Fix Groups Sorting in StyleSheet

### DIFF
--- a/packages/react-native-web/src/exports/StyleSheet/__tests__/__snapshots__/createOrderedCSSStyleSheet-test.js.snap
+++ b/packages/react-native-web/src/exports/StyleSheet/__tests__/__snapshots__/createOrderedCSSStyleSheet-test.js.snap
@@ -24,7 +24,13 @@ exports[`createOrderedCSSStyleSheet #insert insertion order for different groups
 .four-2 {}
 [stylesheet-group=\\"9.9\\"]{}
 .nine-1 {}
-.nine-2 {}"
+.nine-2 {}
+[stylesheet-group=\\"10\\"]{}
+.ten {}
+[stylesheet-group=\\"20\\"]{}
+.twenty {}
+[stylesheet-group=\\"20.2\\"]{}
+.twenty-point2 {}"
 `;
 
 exports[`createOrderedCSSStyleSheet #insert insertion order for same group 1`] = `""`;

--- a/packages/react-native-web/src/exports/StyleSheet/__tests__/createOrderedCSSStyleSheet-test.js
+++ b/packages/react-native-web/src/exports/StyleSheet/__tests__/createOrderedCSSStyleSheet-test.js
@@ -54,6 +54,9 @@ describe('createOrderedCSSStyleSheet', () => {
       sheet.insert('.two {}', 2.2);
       sheet.insert('.four-1 {}', 4);
       sheet.insert('.four-2 {}', 4);
+      sheet.insert('.twenty {}', 20);
+      sheet.insert('.ten {}', 10);
+      sheet.insert('.twenty-point2 {}', 20.2);
 
       expect(sheet.getTextContent()).toMatchSnapshot();
     });

--- a/packages/react-native-web/src/exports/StyleSheet/createOrderedCSSStyleSheet.js
+++ b/packages/react-native-web/src/exports/StyleSheet/createOrderedCSSStyleSheet.js
@@ -148,8 +148,8 @@ function decodeGroupRule(cssRule) {
 
 function getOrderedGroups(obj: { [key: number]: any }) {
   return Object.keys(obj)
-    .sort()
-    .map(k => Number(k));
+    .map(Number)
+    .sort((a, b) => (a > b ? 1 : -1));
 }
 
 const pattern = /\s*([,])\s*/g;


### PR DESCRIPTION
While I was playing with this I found that groups are sorted by key (strings). 
If you have `["10", "1", "2"]` the result is `[1, 10, 2]`. Fixing this with the PR.