### PR TITLE
Do not stringify the app params

### DIFF
--- a/packages/react-native-web/src/exports/AppRegistry/index.js
+++ b/packages/react-native-web/src/exports/AppRegistry/index.js
@@ -96,7 +96,7 @@ export default class AppRegistry {
       params.rootTag = `#${params.rootTag.id}`;
 
       console.log(
-        `Running application "${appKey}" with appParams: ${JSON.stringify(params)}.\n` +
+        `Running application "${appKey}" with appParams: ${params}.\n` +
           `Development-level warnings: ${isDevelopment ? 'ON' : 'OFF'}.\n` +
           `Performance optimizations: ${isDevelopment ? 'OFF' : 'ON'}.`
       );


### PR DESCRIPTION
We have a circular structure in our app params. This trivial console.log therefore causes our app to crash. We have no reason not to want a circular structure, and we also have no reason to log out all the startup params.

IMO, this seems like a console log you don't need.