### PR TITLE
[fix] Hiding scroll support on Firefox ver. 64+

### DIFF
--- a/packages/react-native-web/src/exports/StyleSheet/__tests__/__snapshots__/compile-test.js.snap
+++ b/packages/react-native-web/src/exports/StyleSheet/__tests__/__snapshots__/compile-test.js.snap
@@ -64,6 +64,7 @@ Object {
     "rules": Array [
       ".r-scrollbarWidth-2eszeu::-webkit-scrollbar{display:none}",
       ".r-scrollbarWidth-2eszeu{overflow:-moz-scrollbars-none;-ms-overflow-style:none}",
+      ".r-scrollbarWidth-2eszeu{scrollbar-width:none;}",
     ],
     "value": "none",
   },

--- a/packages/react-native-web/src/exports/StyleSheet/compile.js
+++ b/packages/react-native-web/src/exports/StyleSheet/compile.js
@@ -148,9 +148,11 @@ function createAtomicRules(identifier: string, property, value): Rules {
     // https://drafts.csswg.org/css-scrollbars-1/
     case 'scrollbarWidth': {
       if (value === 'none') {
+        const block = createDeclarationBlock({ [property]: value });
         rules.push(
           `${selector}::-webkit-scrollbar{display:none}`,
-          `${selector}{overflow:-moz-scrollbars-none;-ms-overflow-style:none}`
+          `${selector}{overflow:-moz-scrollbars-none;-ms-overflow-style:none}`,
+          `${selector}${block}`
         );
       }
       break;


### PR DESCRIPTION
Since Firefox ver. 63 we should use scrollbar-width property