### PR TITLE
Re-export DeviceEventEmitter

### DIFF
--- a/packages/babel-plugin-react-native-web/src/moduleMap.js
+++ b/packages/babel-plugin-react-native-web/src/moduleMap.js
@@ -17,6 +17,7 @@ module.exports = {
   ColorPropType: true,
   DatePickerAndroid: true,
   DatePickerIOS: true,
+  DeviceEventEmitter: true,
   DeviceInfo: true,
   Dimensions: true,
   DrawerLayoutAndroid: true,

--- a/packages/react-native-web/src/exports/DeviceEventEmitter/index.js
+++ b/packages/react-native-web/src/exports/DeviceEventEmitter/index.js
@@ -1,0 +1,2 @@
+import RCTDeviceEventEmitter from '../../vendor/react-native/NativeEventEmitter/RCTDeviceEventEmitter';
+export default RCTDeviceEventEmitter;

--- a/packages/react-native-web/src/index.js
+++ b/packages/react-native-web/src/index.js
@@ -104,6 +104,9 @@ import TimePickerAndroid from './exports/TimePickerAndroid';
 import TVEventHandler from './exports/TVEventHandler';
 import VibrationIOS from './exports/VibrationIOS';
 
+// plugins
+import DeviceEventEmitter from './exports/DeviceEventEmitter';
+
 export {
   // top-level API
   createElement,
@@ -207,5 +210,7 @@ export {
   Systrace,
   TimePickerAndroid,
   TVEventHandler,
-  VibrationIOS
+  VibrationIOS,
+  // plugins
+  DeviceEventEmitter
 };


### PR DESCRIPTION
# Why

- [React Native parity](https://github.com/facebook/react-native/blob/83969c26fbc623d65113a77fd89810dc2f03d6c5/Libraries/react-native/react-native-implementation.js#L313)

# TODO
- [Change imports to use direct re-export](https://github.com/expo/expo/blob/52534741973ce88fad15185f7b3f9c431a0e78e1/packages/%40unimodules/react-native-adapter/src/SyntheticPlatformEmitter.ts#L2)
- [Remove alias](https://github.com/expo/expo-cli/blob/0c3a461c186f7e05a56f05dcf36c8717b2a79954/packages/webpack-config/webpack/webpack.common.js#L43)