### PR TITLE
adding missing `autoCompleteType` to `TextInput`

### DIFF
--- a/packages/react-native-web/src/exports/TextInput/index.js
+++ b/packages/react-native-web/src/exports/TextInput/index.js
@@ -193,6 +193,7 @@ class TextInput extends Component<*> {
       /* react-native compat */
       accessibilityViewIsModal,
       allowFontScaling,
+      autoCompleteType,
       caretHidden,
       clearButtonMode,
       dataDetectorTypes,


### PR DESCRIPTION
not used on web, just pull it out so it doesn't end up on the DOM element.