### PR TITLE
Add setNativeProps support for SafeAreaView

### DIFF
--- a/packages/react-native-web/src/exports/SafeAreaView/index.js
+++ b/packages/react-native-web/src/exports/SafeAreaView/index.js
@@ -12,28 +12,24 @@ import { canUseDOM } from 'fbjs/lib/ExecutionEnvironment';
 import React from 'react';
 import StyleSheet from '../StyleSheet';
 import View from '../View';
-import ViewPropTypes, { type ViewProps } from '../ViewPropTypes';
+import { type ViewProps } from '../ViewPropTypes';
 
-class SafeAreaView extends React.Component<ViewProps> {
-  static displayName = 'SafeAreaView';
+const SafeAreaView = React.forwardRef<View, ViewProps>((props: ViewProps, ref) => {
+  const { style, ...rest } = props;
 
-  static propTypes = {
-    ...ViewPropTypes
-  };
+  return (
+    <View
+      {...rest}
+      ref={ref}
+      style={StyleSheet.compose(
+        styles.root,
+        style
+      )}
+    />
+  );
+});
 
-  render() {
-    const { style, ...rest } = this.props;
-    return (
-      <View
-        {...rest}
-        style={StyleSheet.compose(
-          styles.root,
-          style
-        )}
-      />
-    );
-  }
-}
+SafeAreaView.displayName = 'SafeAreaView';
 
 const cssFunction: 'constant' | 'env' = (function() {
   if (


### PR DESCRIPTION
Use `React.forwaredRef` at the `SafeAreaView` component so we can pass a `ref` and call `ref.setNativeProps`. Currently it gives an error saying `setNativeProps is not a function`.

Merged PR: https://github.com/facebook/react-native/pull/24589
Issue: https://github.com/facebook/react-native/issues/24576