### PR TITLE
Link: Allow explicit rel="opener"

### DIFF
--- a/packages/react-native-web/src/modules/createDOMProps/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/react-native-web/src/modules/createDOMProps/__tests__/__snapshots__/index-test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`modules/createDOMProps includes "rel" values for "a" elements (to securely open external links) 1`] = `" noopener noreferrer"`;
+exports[`modules/createDOMProps includes "rel" values for "a" elements (to securely open external links) 1`] = `"noopener noreferrer"`;
 
 exports[`modules/createDOMProps includes base reset style for browser-styled elements 1`] = `"css-reset-4rbku5"`;
 

--- a/packages/react-native-web/src/modules/createDOMProps/__tests__/index-test.js
+++ b/packages/react-native-web/src/modules/createDOMProps/__tests__/index-test.js
@@ -193,6 +193,16 @@ describe('modules/createDOMProps', () => {
     expect(props.rel).toMatchSnapshot();
   });
 
+  test('allow explicit rel="opener" for "a" elements', () => {
+    const props = createDOMProps('a', { target: '_blank', rel: 'opener' });
+    expect(props.rel).toEqual('opener');
+  });
+
+  test('don\'t duplicate "rel" values for "a" elements', () => {
+    const props = createDOMProps('a', { target: '_blank', rel: 'noopener' });
+    expect(props.rel).toEqual('noopener noreferrer');
+  });
+
   test('includes cursor style for pressable roles', () => {
     expect(createDOMProps('span', { accessibilityRole: 'link' }).className).toMatchSnapshot();
     expect(createDOMProps('span', { accessibilityRole: 'button' }).className).toMatchSnapshot();

--- a/packages/react-native-web/src/modules/createDOMProps/index.js
+++ b/packages/react-native-web/src/modules/createDOMProps/index.js
@@ -187,8 +187,12 @@ const createDOMProps = (component, props, styleResolver) => {
   // https://mathiasbynens.github.io/rel-noopener/
   // Note: using "noreferrer" doesn't impact referrer tracking for https
   // transfers (i.e., from https to https).
-  if (component === 'a' && domProps.target === '_blank') {
-    domProps.rel = `${domProps.rel || ''} noopener noreferrer`;
+  // Note: Specifying rel="opener" will explicitly bypass this safeguard.
+  if (component === 'a' && domProps.target === '_blank' && domProps.rel !== 'opener') {
+    const existingRel = domProps.rel ? domProps.rel.split(' ') : [];
+    // Ensure that we don't end up with duplicates.
+    const newRel = new Set([...existingRel, 'noopener', 'noreferrer']);
+    domProps.rel = Array.from(newRel).join(' ');
   }
   // Automated test IDs
   if (testID && testID.constructor === String) {

--- a/packages/react-native-web/src/modules/createDOMProps/index.js
+++ b/packages/react-native-web/src/modules/createDOMProps/index.js
@@ -189,10 +189,14 @@ const createDOMProps = (component, props, styleResolver) => {
   // transfers (i.e., from https to https).
   // Note: Specifying rel="opener" will explicitly bypass this safeguard.
   if (component === 'a' && domProps.target === '_blank' && domProps.rel !== 'opener') {
-    const existingRel = domProps.rel ? domProps.rel.split(' ') : [];
-    // Ensure that we don't end up with duplicates.
-    const newRel = new Set([...existingRel, 'noopener', 'noreferrer']);
-    domProps.rel = Array.from(newRel).join(' ');
+    const relList = domProps.rel ? domProps.rel.split(' ') : [];
+    if (relList.indexOf('noopener') === -1) {
+      relList.push('noopener');
+    }
+    if (relList.indexOf('noreferrer') === -1) {
+      relList.push('noreferrer');
+    }
+    domProps.rel = relList.join(' ');
   }
   // Automated test IDs
   if (testID && testID.constructor === String) {


### PR DESCRIPTION
We shouldn't unconditionally set noopener on all links. There's valid use cases to open a new tab that _can_ communicate back using `postMessage()`

Also, this cleans up the string concatenation so that we don't get extraneous leading space or duplicate values.