### PR TITLE
Link: Allow download attribute

### DIFF
--- a/packages/react-native-web/src/exports/View/filterSupportedProps.js
+++ b/packages/react-native-web/src/exports/View/filterSupportedProps.js
@@ -67,6 +67,7 @@ const supportedProps = {
   // unstable escape-hatches for web
   className: true,
   href: true,
+  download: true,
   itemID: true,
   itemRef: true,
   itemProp: true,

--- a/packages/react-native-web/src/exports/createElement/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/createElement/__tests__/index-test.js
@@ -36,6 +36,36 @@ describe('modules/createElement', () => {
       expect(component.find('div').length).toBe(1);
     });
 
+    test('does prevent default link action', () => {
+      const preventDefault = jest.fn();
+      const component = shallow(
+        createElement('a', { accessibilityRole: 'link', onResponderRelease: () => {} })
+      );
+      component.find('a').simulate('click', {
+        isDefaultPrevented: () => false,
+        nativeEvent: {},
+        preventDefault
+      });
+      expect(preventDefault).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not prevent default if download prop present', () => {
+      const preventDefault = jest.fn();
+      const component = shallow(
+        createElement('a', {
+          accessibilityRole: 'link',
+          download: '',
+          onResponderRelease: () => {}
+        })
+      );
+      component.find('a').simulate('click', {
+        isDefaultPrevented: () => false,
+        nativeEvent: {},
+        preventDefault
+      });
+      expect(preventDefault).toHaveBeenCalledTimes(0);
+    });
+
     const testRole = ({ accessibilityRole, disabled }) => {
       [{ key: 'Enter', which: 13 }, { key: 'Space', which: 32 }].forEach(({ key, which }) => {
         test(`"onClick" is ${disabled ? 'not ' : ''}called when "${key}" key is pressed`, () => {

--- a/packages/react-native-web/src/exports/createElement/index.js
+++ b/packages/react-native-web/src/exports/createElement/index.js
@@ -72,7 +72,12 @@ const adjustProps = domProps => {
   // preceding mouse events in the responder system.
   if (isLinkRole && onResponderRelease) {
     domProps.onClick = function(e) {
-      if (!e.isDefaultPrevented() && !isModifiedEvent(e.nativeEvent) && !domProps.target) {
+      if (
+        !e.isDefaultPrevented() &&
+        !isModifiedEvent(e.nativeEvent) &&
+        !domProps.target &&
+        domProps.download == null
+      ) {
         e.preventDefault();
       }
     };


### PR DESCRIPTION
Hey team, thanks for your awesome work on React Native for Web!

This PR opts out of calling `event.preventDefault()` on a link if it has the "download" attribute set. Calling `preventDefault()` prevents the download completely, making the link useless.

Example:
```jsx
<TouchableOpacity
  accessibilityRole="link"
  href="/images/rnw-rocks.png"
  download="image.png"
/>
```