### PR TITLE
Linking API: Support for New Tab

### DIFF
--- a/packages/react-native-web/src/exports/Linking/index.js
+++ b/packages/react-native-web/src/exports/Linking/index.js
@@ -22,9 +22,13 @@ const Linking = {
   getInitialURL(): Promise<string> {
     return Promise.resolve(initialURL);
   },
-  openURL(url: string, target: string): Promise<Object | void> {
+  openURL(
+    url: string,
+    target: '_blank' | '_self' = '_blank',
+    noopener?: 'noopener'
+  ): Promise<Object | void> {
     try {
-      open(url, target);
+      open(url, target, noopener);
       return Promise.resolve();
     } catch (e) {
       return Promise.reject(e);
@@ -36,16 +40,11 @@ const Linking = {
   }
 };
 
-const open = (url, target) => {
+const open = (url, target, noopener) => {
   if (canUseDOM) {
     const urlToOpen = new URL(url, window.location).toString();
-    const targetToUse = validateTarget(target) ? target : "_blank";
-    window.open(urlToOpen, targetToUse);
+    window.open(urlToOpen, target, noopener);
   }
 };
-
-const validateTarget = target => {
-  return target === "_blank" || target === "_self"
-}
 
 export default Linking;

--- a/packages/react-native-web/src/exports/Linking/index.js
+++ b/packages/react-native-web/src/exports/Linking/index.js
@@ -22,9 +22,9 @@ const Linking = {
   getInitialURL(): Promise<string> {
     return Promise.resolve(initialURL);
   },
-  openURL(url: string): Promise<Object | void> {
+  openURL(url: string, target: string): Promise<Object | void> {
     try {
-      open(url);
+      open(url, target);
       return Promise.resolve();
     } catch (e) {
       return Promise.reject(e);
@@ -36,10 +36,16 @@ const Linking = {
   }
 };
 
-const open = url => {
+const open = (url, target) => {
   if (canUseDOM) {
-    window.location = new URL(url, window.location).toString();
+    const urlToOpen = new URL(url, window.location).toString();
+    const targetToUse = validateTarget(target) ? target : "_blank";
+    window.open(urlToOpen, targetToUse);
   }
 };
+
+const validateTarget = target => {
+  return target === "_blank" || target === "_self"
+}
 
 export default Linking;

--- a/packages/website/storybook/2-apis/Linking/LinkingScreen.js
+++ b/packages/website/storybook/2-apis/Linking/LinkingScreen.js
@@ -11,7 +11,9 @@ import UIExplorer, { Description, DocItem, Section, storiesOf } from '../../ui-e
 const LinkingScreen = () => (
   <UIExplorer title="Linking" url="2-apis/Linking">
     <Description>
-      Linking gives you a general interface for securely opening external URLs from JavaScript.
+      Linking gives you a general interface for securely opening external URLs from JavaScript. As
+      an alternative to the Linking API, &lt;Text&gt; elements may be appended with the "href" and
+      "target" attributes to resemble web hyperlinks.
     </Description>
 
     <Section title="Methods">
@@ -21,8 +23,8 @@ const LinkingScreen = () => (
 
       <DocItem
         name="openURL"
-        typeInfo="(url: string) => Promise<>"
-        description="Try to open the given url in a secure fashion. The method returns a Promise object. If the url opens, the promise is resolved. If not, the promise is rejected."
+        typeInfo="(url: string, target: '_blank' | '_self', noopener?: 'noopener') => Promise<>"
+        description="Try to open the given url in a secure fashion. The method returns a Promise object. If the url opens, the promise is resolved. If not, the promise is rejected. By default, all links are opened in an external window or tab. To open a link in the same window, include the target '_self'. To disable the window.opener object in the new window, include the 'noopener' parameter."
         example={{
           render: () => <OpenURL />
         }}

--- a/packages/website/storybook/2-apis/Linking/examples/OpenURL.js
+++ b/packages/website/storybook/2-apis/Linking/examples/OpenURL.js
@@ -14,11 +14,29 @@ export default class OpenURL extends PureComponent {
     });
   }
 
+  handlePressSelf() {
+    Linking.canOpenURL(url).then(supported => {
+      return Linking.openURL(url, '_self');
+    });
+  }
+
+  handlePressNoOpener() {
+    Linking.canOpenURL(url).then(supported => {
+      return Linking.openURL(url, '_target', 'noopener');
+    });
+  }
+
   render() {
     return (
       <View>
         <Text onPress={this.handlePress} style={styles.text}>
-          Linking.openURL
+          Click this to trigger Linking.openURL('some_url')
+        </Text>
+        <Text onPress={this.handlePressSelf} style={styles.text}>
+          Click this to trigger Linking.openURL('some_url', '_self')
+        </Text>
+        <Text onPress={this.handlePressNoOpener} style={styles.text}>
+          Click this to trigger Linking.openURL('some_url', '_target', 'noopener')
         </Text>
         <Text
           accessibilityRole="link"
@@ -26,7 +44,8 @@ export default class OpenURL extends PureComponent {
           style={styles.text}
           target="_blank"
         >
-          target="_blank"
+          Click this to open a link without using the Linking API{'\n'}
+          &lt;Text href='some_url' target='_blank'&gt;
         </Text>
       </View>
     );


### PR DESCRIPTION
I added support for opening a link in a new tab.

The second parameter "target" can accept the following values:
"_blank" : URL is loaded into a new window or tab (default)
"_self" : URL replaces the current page