### PR TITLE
Adding unused param to fix compatibility

### DIFF
--- a/packages/react-native-web/package.json
+++ b/packages/react-native-web/package.json
@@ -3,7 +3,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "name": "react-native-web",
-  "version": "0.11.7",
+  "version": "1.0.0",
   "description": "React Native for Web",
   "module": "dist/index.js",
   "main": "dist/cjs/index.js",

--- a/packages/react-native-web/src/modules/ResponderEventPlugin/index.js
+++ b/packages/react-native-web/src/modules/ResponderEventPlugin/index.js
@@ -58,7 +58,7 @@ let lastActiveTouchTimestamp = null;
 const EMULATED_MOUSE_THERSHOLD_MS = 1000;
 
 const originalExtractEvents = ResponderEventPlugin.extractEvents;
-ResponderEventPlugin.extractEvents = (topLevelType, targetInst, nativeEvent, nativeEventTarget) => {
+ResponderEventPlugin.extractEvents = (topLevelType, eventSystemFlags, targetInst, nativeEvent, nativeEventTarget) => {
   const hasActiveTouches = ResponderTouchHistoryStore.touchHistory.numberActiveTouches > 0;
   const eventType = nativeEvent.type;
 
@@ -88,6 +88,7 @@ ResponderEventPlugin.extractEvents = (topLevelType, targetInst, nativeEvent, nat
   return originalExtractEvents.call(
     ResponderEventPlugin,
     topLevelType,
+    eventSystemFlags,
     targetInst,
     normalizedEvent,
     nativeEventTarget


### PR DESCRIPTION
Fixes #1443 

It looks like the react-dom library has added a new parameter, causing an incompatibility due to a misalignment. This fixes the issue, but will break for previous versions of react-dom.

I updated the package.json assuming semver.