### PR TITLE
remove redundant keys from STYLE_SHORT_FORM_EXPANSIONS constant

### DIFF
--- a/packages/react-native-web/src/exports/StyleSheet/constants.js
+++ b/packages/react-native-web/src/exports/StyleSheet/constants.js
@@ -35,21 +35,9 @@ export const STYLE_GROUPS = {
 };
 
 export const STYLE_SHORT_FORM_EXPANSIONS = {
-  borderColor: ['borderTopColor', 'borderRightColor', 'borderBottomColor', 'borderLeftColor'],
-  borderRadius: [
-    'borderTopLeftRadius',
-    'borderTopRightRadius',
-    'borderBottomRightRadius',
-    'borderBottomLeftRadius'
-  ],
-  borderStyle: ['borderTopStyle', 'borderRightStyle', 'borderBottomStyle', 'borderLeftStyle'],
-  borderWidth: ['borderTopWidth', 'borderRightWidth', 'borderBottomWidth', 'borderLeftWidth'],
-  margin: ['marginTop', 'marginRight', 'marginBottom', 'marginLeft'],
   marginHorizontal: ['marginRight', 'marginLeft'],
   marginVertical: ['marginTop', 'marginBottom'],
-  overflow: ['overflowX', 'overflowY'],
   overscrollBehavior: ['overscrollBehaviorX', 'overscrollBehaviorY'],
-  padding: ['paddingTop', 'paddingRight', 'paddingBottom', 'paddingLeft'],
   paddingHorizontal: ['paddingRight', 'paddingLeft'],
   paddingVertical: ['paddingTop', 'paddingBottom']
 };


### PR DESCRIPTION
Removing those mapping that are already present in React's comprehensive `shorthandToLonghand` mapping (see [here][1]).

[1]: https://github.com/facebook/react/blob/f6b8d31a76cbbcbbeb2f1d59074dfe72e0c82806/packages/react-dom/src/shared/CSSShorthandProperty.js#L10