### PR TITLE
fix: support image source objects

### DIFF
--- a/packages/react-native-web/src/exports/Image/ImageUriCache.js
+++ b/packages/react-native-web/src/exports/Image/ImageUriCache.js
@@ -7,23 +7,42 @@
  * @flow
  */
 
+import ImageLoader from '../../modules/ImageLoader';
+
+type ImageSource =
+  | string
+  | number
+  | {
+      method: ?string,
+      uri: ?string,
+      headers: ?Object,
+      body: ?string
+    };
+
 export default class ImageUriCache {
   static _maximumEntries: number = 256;
   static _entries = {};
 
-  static has(cacheId: string) {
+  static createCacheId(source: ImageSource) {
+    return JSON.stringify(ImageLoader.resolveSource(source));
+  }
+
+  static has(source: ImageSource) {
     const entries = ImageUriCache._entries;
+    const cacheId = ImageUriCache.createCacheId(source);
     return Boolean(entries[cacheId]);
   }
 
-  static get(cacheId: string) {
+  static get(source: ImageSource) {
     const entries = ImageUriCache._entries;
+    const cacheId = ImageUriCache.createCacheId(source);
     return entries[cacheId];
   }
 
-  static add(cacheId: string, displayImageUri: string) {
+  static add(source: ImageSource, displayImageUri: ?string) {
     const entries = ImageUriCache._entries;
     const lastUsedTimestamp = Date.now();
+    const cacheId = ImageUriCache.createCacheId(source);
     if (entries[cacheId]) {
       entries[cacheId].lastUsedTimestamp = lastUsedTimestamp;
       entries[cacheId].refCount += 1;
@@ -31,13 +50,14 @@ export default class ImageUriCache {
       entries[cacheId] = {
         lastUsedTimestamp,
         refCount: 1,
-        displayImageUri
+        displayImageUri: displayImageUri || ImageLoader.resolveSource(source).uri
       };
     }
   }
 
-  static remove(cacheId: string) {
+  static remove(source: ImageSource) {
     const entries = ImageUriCache._entries;
+    const cacheId = ImageUriCache.createCacheId(source);
     if (entries[cacheId]) {
       entries[cacheId].refCount -= 1;
     }

--- a/packages/react-native-web/src/exports/Image/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/Image/__tests__/index-test.js
@@ -12,15 +12,6 @@ const OriginalImage = window.Image;
 
 const findImageSurfaceStyle = wrapper => StyleSheet.flatten(wrapper.childAt(0).prop('style'));
 
-const createLoadEvent = uri => {
-  const target = new OriginalImage();
-  target.src = uri;
-  const event = new window.Event('load');
-  event.path = [target];
-
-  return event;
-};
-
 describe('components/Image', () => {
   beforeEach(() => {
     ImageUriCache._entries = {};
@@ -106,7 +97,7 @@ describe('components/Image', () => {
       jest.useFakeTimers();
       const uri = 'https://test.com/img.jpg';
       ImageLoader.load = jest.fn().mockImplementation((_, onLoad, onError) => {
-        onLoad(createLoadEvent(uri));
+        onLoad(uri);
       });
       const onLoadStub = jest.fn();
       shallow(<Image onLoad={onLoadStub} source={uri} />);
@@ -119,7 +110,7 @@ describe('components/Image', () => {
       jest.useFakeTimers();
       const uri = 'https://test.com/img.jpg';
       ImageLoader.load = jest.fn().mockImplementation((_, onLoad, onError) => {
-        onLoad(createLoadEvent(uri));
+        onLoad(uri);
       });
       const onLoadStub = jest.fn();
       ImageUriCache.add(uri);
@@ -174,7 +165,7 @@ describe('components/Image', () => {
     test('is set immediately if the image was preloaded', () => {
       const uri = 'https://yahoo.com/favicon.ico';
       ImageLoader.load = jest.fn().mockImplementationOnce((_, onLoad, onError) => {
-        onLoad(createLoadEvent(uri));
+        onLoad(uri);
       });
       return Image.prefetch(uri).then(() => {
         const source = { uri };
@@ -232,7 +223,7 @@ describe('components/Image', () => {
       });
       const component = shallow(<Image defaultSource={{ uri: defaultUri }} source={{ uri }} />);
       expect(component.find('img').prop('src')).toBe(defaultUri);
-      loadCallback(createLoadEvent(uri));
+      loadCallback(uri);
       expect(component.find('img').prop('src')).toBe(uri);
     });
   });

--- a/packages/react-native-web/src/exports/Image/index.js
+++ b/packages/react-native-web/src/exports/Image/index.js
@@ -304,7 +304,8 @@ class Image extends Component<*, State> {
     this._imageRequestId = ImageLoader.load(
       ImageLoader.resolveSource(source),
       this._onLoad,
-      this._onError
+      this._onError,
+      this._onProgress
     );
     this._onLoadStart();
   }
@@ -339,6 +340,15 @@ class Image extends Component<*, State> {
           backgroundSize: `${x}px ${y}px`
         };
       }
+    }
+  };
+
+  _onProgress = event => {
+    const { onProgress } = this.props;
+    if (onProgress) {
+      onProgress({
+        nativeEvent: event
+      });
     }
   };
 

--- a/packages/react-native-web/src/exports/Image/index.js
+++ b/packages/react-native-web/src/exports/Image/index.js
@@ -43,19 +43,6 @@ const resolveAssetDimensions = source => {
   };
 };
 
-const getCacheUrl = e => {
-  if (e.target) {
-    return e.target.src;
-  }
-
-  // Target is not defined at this moment anymore in Chrome and thus we use path
-  if (e.path && e.path[0]) {
-    return e.path[0].src;
-  }
-
-  return undefined;
-};
-
 let filterId = 0;
 
 const createTintColorSVG = (tintColor, id) =>
@@ -112,10 +99,10 @@ class Image extends Component<*, State> {
   }
 
   static prefetch(uri) {
-    return ImageLoader.prefetch(uri).then(e => {
+    return ImageLoader.prefetch(uri).then(displayImageUri => {
       // Add the uri to the cache so it can be immediately displayed when used
       // but also immediately remove it to correctly reflect that it has no active references
-      ImageUriCache.add(uri, getCacheUrl(e));
+      ImageUriCache.add(uri, displayImageUri);
       ImageUriCache.remove(uri);
     });
   }
@@ -160,7 +147,7 @@ class Image extends Component<*, State> {
     if (this._imageState === STATUS_PENDING) {
       this._createImageLoader();
     } else if (this._imageState === STATUS_LOADED) {
-      this._onLoad({ target: this._imageRef });
+      this._onLoad(this.state.displayImageUri, { target: this._imageRef });
     }
   }
 
@@ -365,11 +352,11 @@ class Image extends Component<*, State> {
     this._onLoadEnd();
   };
 
-  _onLoad = e => {
+  _onLoad = (displayImageUri, e) => {
     const { onLoad, source } = this.props;
     const event = { nativeEvent: e };
 
-    ImageUriCache.add(source, getCacheUrl(e));
+    ImageUriCache.add(source, displayImageUri);
     this._updateImageState(STATUS_LOADED);
     if (onLoad) {
       onLoad(event);

--- a/packages/react-native-web/src/modules/ImageLoader/index.js
+++ b/packages/react-native-web/src/modules/ImageLoader/index.js
@@ -50,7 +50,7 @@ const ImageLoader = {
       clearInterval(interval);
     }
   },
-  load(source, onLoad, onError): number {
+  load(source, onLoad, onError, onProgress): number {
     const { uri, method, headers, body } = { uri: '', method: 'GET', headers: {}, ...source };
     id += 1;
 
@@ -109,6 +109,9 @@ const ImageLoader = {
     request.onload = () => {
       image.src = window.URL.createObjectURL(request.response);
     };
+
+    // Track progress
+    request.onprogress = onProgress;
 
     // Send the request
     request.send(body);

--- a/packages/react-native-web/src/modules/ImageLoader/index.js
+++ b/packages/react-native-web/src/modules/ImageLoader/index.js
@@ -59,7 +59,7 @@ const ImageLoader = {
     image.onerror = onError;
     image.onload = e => {
       // avoid blocking the main thread
-      const onDecode = () => onLoad(e);
+      const onDecode = () => onLoad(image.src, e);
 
       if (typeof image.decode === 'function') {
         // Safari currently throws exceptions when decoding svgs.

--- a/packages/website/storybook/1-components/Image/ImageScreen.js
+++ b/packages/website/storybook/1-components/Image/ImageScreen.js
@@ -11,6 +11,7 @@ import PropOnError from './examples/PropOnError';
 import PropOnLoad from './examples/PropOnLoad';
 import PropOnLoadEnd from './examples/PropOnLoadEnd';
 import PropOnLoadStart from './examples/PropOnLoadStart';
+import PropOnProgress from './examples/PropOnProgress';
 import PropResizeMode from './examples/PropResizeMode';
 import PropSource from './examples/PropSource';
 import StaticGetSizeExample from './examples/StaticGetSize';
@@ -102,6 +103,19 @@ const ImageScreen = () => (
         description="Invoked on load start."
         example={{
           render: () => <PropOnLoadStart />
+        }}
+      />
+
+      <DocItem
+        name="onProgress"
+        typeInfo="?function"
+        description={
+          <AppText>
+            Invoked on download progress with <Code>{'{nativeEvent: {loaded, total}}'}</Code>.
+          </AppText>
+        }
+        example={{
+          render: () => <PropOnProgress />
         }}
       />
 

--- a/packages/website/storybook/1-components/Image/examples/NetworkImage.js
+++ b/packages/website/storybook/1-components/Image/examples/NetworkImage.js
@@ -11,11 +11,12 @@ import { ActivityIndicator, Image, Text, View } from 'react-native';
 class NetworkImageExample extends PureComponent {
   state = {
     error: false,
-    loading: false
+    loading: false,
+    messages: []
   };
 
   static propTypes = {
-    logMethod: oneOf(['onError', 'onLoad', 'onLoadEnd', 'onLoadStart']),
+    logMethod: oneOf(['onError', 'onLoad', 'onLoadEnd', 'onLoadStart', 'onProgress']),
     source: Image.propTypes.source
   };
 
@@ -39,44 +40,94 @@ class NetworkImageExample extends PureComponent {
           onLoad={this._handleLoad}
           onLoadEnd={this._handleLoadEnd}
           onLoadStart={this._handleLoadStart}
+          onProgress={this._handleProgress}
           source={this.props.source}
           style={helpers.styles.base}
         />
-        {this.state.message && <Text style={helpers.styles.marginTop}>{this.state.message}</Text>}
+        {this.state.messages.map((message, index) => {
+          return (
+            <Text key={index} style={helpers.styles.marginTop}>
+              {message}
+            </Text>
+          );
+        })}
       </View>
     );
   }
 
   _handleError = e => {
-    const nextState = { loading: false };
-    if (this.props.logMethod === 'onError') {
-      nextState.message = `✘ onError ${JSON.stringify(e.nativeEvent)}`;
-    }
-    this.setState(() => nextState);
+    this.setState(state => {
+      const messages = [...state.messages];
+      if (this.props.logMethod === 'onError') {
+        messages.push(`✘ onError ${JSON.stringify(e.nativeEvent)}`);
+      }
+
+      return {
+        loading: false,
+        messages
+      };
+    });
   };
 
   _handleLoad = () => {
-    const nextState = { loading: false };
-    if (this.props.logMethod === 'onLoad') {
-      nextState.message = '✔ onLoad';
-    }
-    this.setState(() => nextState);
+    this.setState(state => {
+      const messages = [...state.messages];
+      if (this.props.logMethod === 'onLoad') {
+        messages.push('✔ onLoad');
+      }
+
+      return {
+        loading: false,
+        messages
+      };
+    });
   };
 
   _handleLoadEnd = () => {
-    const nextState = { loading: false };
-    if (this.props.logMethod === 'onLoadEnd') {
-      nextState.message = '✔ onLoadEnd';
-    }
-    this.setState(() => nextState);
+    this.setState(state => {
+      const messages = [...state.messages];
+      if (this.props.logMethod === 'onLoadEnd') {
+        messages.push('✔ onLoadEnd');
+      }
+
+      return {
+        loading: false,
+        messages
+      };
+    });
   };
 
   _handleLoadStart = () => {
-    const nextState = { loading: true };
-    if (this.props.logMethod === 'onLoadStart') {
-      nextState.message = '✔ onLoadStart';
-    }
-    this.setState(() => nextState);
+    this.setState(state => {
+      const messages = [...state.messages];
+      if (this.props.logMethod === 'onLoadStart') {
+        messages.push('✔ onLoadStart');
+      }
+
+      return {
+        loading: false,
+        messages
+      };
+    });
+  };
+
+  _handleProgress = e => {
+    this.setState(state => {
+      const messages = [...state.messages];
+      if (this.props.logMethod === 'onProgress') {
+        const { loaded, total } = e.nativeEvent;
+        messages.push(
+          `✔ onProgress ${JSON.stringify({
+            loaded,
+            total
+          })}`
+        );
+      }
+
+      return {
+        messages
+      };
+    });
   };
 }
 

--- a/packages/website/storybook/1-components/Image/examples/PropOnProgress.js
+++ b/packages/website/storybook/1-components/Image/examples/PropOnProgress.js
@@ -1,0 +1,14 @@
+/**
+ * @flow
+ */
+
+import { createUncachedURI } from '../helpers';
+import NetworkImage from './NetworkImage';
+import React from 'react';
+import sources from '../sources';
+
+const ImageOnProgressExample = () => (
+  <NetworkImage logMethod="onProgress" source={createUncachedURI(sources.dynamic)} />
+);
+
+export default ImageOnProgressExample;

--- a/packages/website/storybook/1-components/Image/examples/PropSource.js
+++ b/packages/website/storybook/1-components/Image/examples/PropSource.js
@@ -36,6 +36,20 @@ const ImageSourceExample = () => (
         <Image source={sources.dataSvg} style={styles.image} />
       </View>
     </View>
+    <View style={styles.row}>
+      <View style={styles.column}>
+        <Text style={styles.text}>WebP</Text>
+        <Image source={sources.webP} style={styles.image} />
+      </View>
+      <View style={styles.column}>
+        <Text style={styles.text}>Dynamic (POST)</Text>
+        <Image source={sources.dynamic} style={styles.image} />
+      </View>
+      <View style={styles.column}>
+        <Text style={styles.text}>Redirect</Text>
+        <Image source={sources.redirect} style={styles.image} />
+      </View>
+    </View>
   </React.Fragment>
 );
 

--- a/packages/website/storybook/1-components/Image/sources/index.js
+++ b/packages/website/storybook/1-components/Image/sources/index.js
@@ -44,7 +44,18 @@ const sources = {
   },
   dataSvg,
   dataBase64Png,
-  dataBase64Svg
+  dataBase64Svg,
+  webP: {
+    uri: 'https://www.gstatic.com/webp/gallery/4.sm.webp'
+  },
+  dynamic: {
+    uri: 'https://chart.googleapis.com/chart',
+    method: 'POST',
+    body: 'cht=lc&chtt=Test&chs=300x200&chxt=x&chd=t:40,20,50,20,100'
+  },
+  redirect: {
+    uri: 'https://twitter.com/twitter/profile_image?size=original'
+  }
 };
 
 export default sources;


### PR DESCRIPTION
This PR introduces support for Image source objects (related issue: https://github.com/necolas/react-native-web/issues/1019) which allows you to pass different headers or fetch data via POST method.

In the example I added a dynamic chart from Google Charts. Not directly related but to fill the row I added WebP and the mentioned redirect case in the issue.

![image](https://user-images.githubusercontent.com/5358638/68135005-43539480-ff23-11e9-9a0d-135b1066e0ad.png)

Please let me know if anything is missing.
