### PR TITLE
Allow skipping type checking

### DIFF
--- a/packages/react-native-web/src/modules/createStrictShapeTypeChecker/index.js
+++ b/packages/react-native-web/src/modules/createStrictShapeTypeChecker/index.js
@@ -13,6 +13,9 @@ function createStrictShapeTypeChecker(shapeTypes: {
   [key: string]: ReactPropsCheckType
 }): ReactPropsChainableTypeChecker {
   function checkType(isRequired, props, propName, componentName, location?, ...rest) {
+    if (process.env.NODE_ENV === 'production' || process.env.DELIBERATELY_SKIP_RNW_STYLE_CHECKING) {
+      return;
+    }
     if (!props[propName]) {
       if (isRequired) {
         invariant(


### PR DESCRIPTION
React-native-web can get really slow and resource consuming in development as I mentioned here already: https://github.com/necolas/react-native-web/issues/1390
This change will skip the typeCheck during production and also allow to skip it during development if `DELIBERATELY_SKIP_RNW_STYLE_CHECKING` is enabled. This should result in a huge performance benefit for large codebases.