### PR TITLE
Add useWindowDimensions hook

### DIFF
--- a/packages/babel-plugin-react-native-web/src/moduleMap.js
+++ b/packages/babel-plugin-react-native-web/src/moduleMap.js
@@ -69,5 +69,6 @@ module.exports = {
   findNodeHandle: true,
   processColor: true,
   render: true,
-  unmountComponentAtNode: true
+  unmountComponentAtNode: true,
+  useWindowDimensions: true
 };

--- a/packages/react-native-web/src/exports/DeviceInfo/index.js
+++ b/packages/react-native-web/src/exports/DeviceInfo/index.js
@@ -8,11 +8,11 @@
  */
 
 import { canUseDOM } from 'fbjs/lib/ExecutionEnvironment';
-import Dimensions from '../Dimensions';
+import Dimensions, { type DisplayMetrics } from '../Dimensions';
 
 const DeviceInfo = {
   Dimensions: {
-    get windowPhysicalPixels() {
+    get windowPhysicalPixels(): DisplayMetrics {
       const { width, height, fontScale, scale } = Dimensions.get('window');
       return {
         width: width * scale,
@@ -21,7 +21,7 @@ const DeviceInfo = {
         fontScale
       };
     },
-    get screenPhysicalPixels() {
+    get screenPhysicalPixels(): DisplayMetrics {
       const { width, height, fontScale, scale } = Dimensions.get('screen');
       return {
         width: width * scale,

--- a/packages/react-native-web/src/exports/Dimensions/index.js
+++ b/packages/react-native-web/src/exports/Dimensions/index.js
@@ -12,6 +12,21 @@ import { canUseDOM } from 'fbjs/lib/ExecutionEnvironment';
 import debounce from 'debounce';
 import invariant from 'fbjs/lib/invariant';
 
+type DimensionAcceptedKey = 'window' | 'screen';
+export type DisplayMetrics = {|
+  width: number,
+  height: number,
+  scale: number,
+  fontScale: number
+|};
+
+type DimensionsPayload = {|
+  window: DisplayMetrics,
+  screen: DisplayMetrics
+|};
+
+type DimensionEventListenerType = 'change';
+
 const win = canUseDOM
   ? window
   : {
@@ -28,12 +43,14 @@ const dimensions = {};
 const listeners = {};
 
 export default class Dimensions {
-  static get(dimension: string): Object {
+  // @todo
+  // static get(dimension: DimensionAcceptedKey): DisplayMetrics {
+  static get(dimension: DimensionAcceptedKey): Object {
     invariant(dimensions[dimension], `No dimension set for key ${dimension}`);
     return dimensions[dimension];
   }
 
-  static set(initialDimensions: ?{ [key: string]: any }): void {
+  static set(initialDimensions: ?DimensionsPayload): void {
     if (initialDimensions) {
       if (canUseDOM) {
         invariant(false, 'Dimensions cannot be set in the browser');
@@ -64,12 +81,18 @@ export default class Dimensions {
     }
   }
 
-  static addEventListener(type: string, handler: Function): void {
+  static addEventListener(
+    type: DimensionEventListenerType,
+    handler: DimensionsPayload => void
+  ): void {
     listeners[type] = listeners[type] || [];
     listeners[type].push(handler);
   }
 
-  static removeEventListener(type: string, handler: Function): void {
+  static removeEventListener(
+    type: DimensionEventListenerType,
+    handler: DimensionsPayload => void
+  ): void {
     if (Array.isArray(listeners[type])) {
       listeners[type] = listeners[type].filter(_handler => _handler !== handler);
     }

--- a/packages/react-native-web/src/exports/useWindowDimensions/index.js
+++ b/packages/react-native-web/src/exports/useWindowDimensions/index.js
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow strict-local
+ */
+
+'use strict';
+
+import Dimensions, { type DisplayMetrics } from '../Dimensions';
+import { useEffect, useState } from 'react';
+
+export default function useWindowDimensions(): DisplayMetrics {
+  const [dims, setDims] = useState(() => Dimensions.get('window'));
+  useEffect(() => {
+    function handleChange({ window }) {
+      setDims(window);
+    }
+    Dimensions.addEventListener('change', handleChange);
+    // We might have missed an update between calling `get` in render and
+    // `addEventListener` in this handler, so we set it here. If there was
+    // no change, React will filter out this update as a no-op.
+    setDims(Dimensions.get('window'));
+    return () => {
+      Dimensions.removeEventListener('change', handleChange);
+    };
+  }, []);
+  return dims;
+}

--- a/packages/react-native-web/src/index.js
+++ b/packages/react-native-web/src/index.js
@@ -80,6 +80,9 @@ import TVEventHandler from './exports/TVEventHandler';
 // plugins
 import DeviceEventEmitter from './exports/DeviceEventEmitter';
 
+// hooks
+import useWindowDimensions from './exports/useWindowDimensions';
+
 export {
   // top-level API
   createElement as unstable_createElement,
@@ -158,5 +161,7 @@ export {
   TimePickerAndroid,
   TVEventHandler,
   // plugins
-  DeviceEventEmitter
+  DeviceEventEmitter,
+  // hooks
+  useWindowDimensions
 };


### PR DESCRIPTION
Following #1439 

I tried to add `DisplayMetrics` to improve flow coverage.
This leads me to add `DimensionPayload` somehow. 

I was "stuck" with my current definition since some values (for SSR) are `undefined` but no in the type. So if I uncomment the `@todo` I put, this create an issue on the undefined definition.

If we change the type & accept `?number` instead of a surely defined number, this create issue with some operations that flow doesn't want to accept (eg: undefined * number). In practise I am almost sure this will never happen, but in theory, flow thing it can.

Not sure what the best way to handle that.

We could remove some type & keep `Object` & `Function` but my brain don't like this idea :) 