### PR TITLE
Update LayoutPropTypes to include gridArea

### DIFF
--- a/packages/react-native-web/src/modules/LayoutPropTypes/index.js
+++ b/packages/react-native-web/src/modules/LayoutPropTypes/index.js
@@ -92,6 +92,7 @@ const LayoutPropTypes = {
   /**
    * @platform web
    */
+  gridArea: string,
   gridAutoColumns: string,
   gridAutoFlow: string,
   gridAutoRows: string,


### PR DESCRIPTION
This PR adds `gridArea as a valid key to be passed into style props.

Working on a project using grid we've come across this warning:

```
Warning: Failed prop type: Invalid props.style key `gridArea` supplied to `View`.
Bad object: {
  "gridArea": "2 / 2 / 3 / 3"
}
```
