### PR TITLE
Mark text div as user-select:text by default

### DIFF
--- a/packages/react-native-web/src/exports/Text/index.js
+++ b/packages/react-native-web/src/exports/Text/index.js
@@ -45,7 +45,8 @@ class Text extends React.Component<TextProps> {
     supportedProps.style = [
       style,
       numberOfLines != null && numberOfLines > 1 && { WebkitLineClamp: numberOfLines },
-      selectable !== false ? styles.selectable : styles.notSelectable,
+      selectable === true && styles.selectable,
+      selectable === false && styles.notSelectable,
       onPress && styles.pressable
     ];
 

--- a/packages/react-native-web/src/exports/Text/index.js
+++ b/packages/react-native-web/src/exports/Text/index.js
@@ -45,7 +45,7 @@ class Text extends React.Component<TextProps> {
     supportedProps.style = [
       style,
       numberOfLines != null && numberOfLines > 1 && { WebkitLineClamp: numberOfLines },
-      selectable === false && styles.notSelectable,
+      selectable !== false ? styles.selectable : styles.notSelectable,
       onPress && styles.pressable
     ];
 
@@ -119,6 +119,9 @@ const classes = css.create({
 });
 
 const styles = StyleSheet.create({
+  selectable: {
+    userSelect: 'text'
+  },
   notSelectable: {
     userSelect: 'none'
   },


### PR DESCRIPTION
When building an application with `react-native-web`, for example as an Electron app, we sometimes add a `body { user-select: none; }` CSS rule so that the user selection act like on a native app.

In that case adding the prop `selectable` to `<Text>` has no effect because `react-native-web` makes the assumption that the parent will be selectable.

With this PR, I think `react-native-web` will act more like `react-native` and enforce the text are selectable if the opposite is not specified.