### PR TITLE
fix: add missing assignment in EventEmitter

### DIFF
--- a/packages/react-native-web/src/vendor/react-native/NativeEventEmitter/index.js
+++ b/packages/react-native-web/src/vendor/react-native/NativeEventEmitter/index.js
@@ -31,6 +31,7 @@ class NativeEventEmitter extends EventEmitter {
 
   constructor(nativeModule: ?NativeModule) {
     super(RCTDeviceEventEmitter.sharedSubscriber);
+    this._nativeModule = nativeModule;
   }
 
   addListener(


### PR DESCRIPTION
Currently, the `nativeModule` is ignored in the NativeEventEmitter. This fix will assign it to the instance property so it can be used by addListener etc..