### PR TITLE
fix injectEventPluginsByName throwing when re-evaluating code

### DIFF
--- a/packages/react-native-web/src/exports/createElement/index.js
+++ b/packages/react-native-web/src/exports/createElement/index.js
@@ -16,9 +16,15 @@ import React from 'react';
 import ResponderEventPlugin from '../../modules/ResponderEventPlugin';
 
 if (canUseDOM) {
-  injectEventPluginsByName({
-    ResponderEventPlugin
-  });
+  try {
+    injectEventPluginsByName({
+      ResponderEventPlugin
+    });
+  } catch (error) {
+    // ignore errors caused by repeatedly injecting the same plugin
+    // due to re-evaluating the script that contains this code
+    // while ReactDOM instance is preserved between the re-evaluations
+  }
 }
 
 const isModifiedEvent = event =>


### PR DESCRIPTION
We (framer.com team) ran into this problem when investigating the errors thrown by the projects that were using `react-native-web`. Framer projects have the following setup:

- The project code is bundled with webpack while declaring `ReactDOM` as an external that is provided by Framer X during the evaluation of the produced bundle
- On every change to the user code, we re-bundle and re-evaluate the code but the instance of `ReactDOM` persists between those re-evaluations.
- This makes `injectEventPluginsByName` throw the error: `EventPluginRegistry: Cannot inject two different event plugins using the same name...` 

I'm happy to discuss alternative fixes is this one looks too hacky :)