### PR TITLE
Fix: Remove usages of Object.values, improve older browser compatibility

### DIFF
--- a/packages/react-native-web/src/exports/StyleSheet/createStyleResolver.js
+++ b/packages/react-native-web/src/exports/StyleSheet/createStyleResolver.js
@@ -237,7 +237,8 @@ export default function createStyleResolver() {
                 styleProp === 'scrollbarWidth'
               ) {
                 const a = atomic({ [styleProp]: value });
-                Object.values(a).forEach(({ identifier, rules }) => {
+                Object.keys(a).forEach(key => {
+                  const { identifier, rules } = a[key];
                   props.classList.push(identifier);
                   rules.forEach(rule => {
                     sheet.insert(rule, STYLE_GROUPS.atomic);
@@ -287,7 +288,8 @@ export default function createStyleResolver() {
         const style = rules[name];
         const compiled = classic(style, name);
 
-        Object.values(compiled).forEach(({ identifier, rules }) => {
+        Object.keys(compiled).forEach(key => {
+          const { identifier, rules } = compiled[key];
           resolved.css[identifier] = { group: group || STYLE_GROUPS.classic, rules };
           result[name] = identifier;
         });


### PR DESCRIPTION
Hello. I found an old issue https://github.com/necolas/react-native-web/issues/1334 which had a fix applied _but only partially_ it would appear. This PR simply applies the exact same fix in two other places in the same file.

Replace usages of `Object.values` to ensure compatibility with older browsers (without polyfilling). Ensures that IE10, IE11, Safari 8 etc. won't choke.

Hope this helps :v: