### PR TITLE
Support reason-react

### DIFF
--- a/packages/react-native-web/src/exports/View/filterSupportedProps.js
+++ b/packages/react-native-web/src/exports/View/filterSupportedProps.js
@@ -80,7 +80,7 @@ const filterSupportedProps = props => {
   const safeProps = {};
   for (const prop in props) {
     if (props.hasOwnProperty(prop)) {
-      if (supportedProps[prop] || prop.indexOf('aria-') === 0 || prop.indexOf('data-') === 0) {
+      if (supportedProps[prop] || prop.indexOf('aria') === 0 || prop.indexOf('data-') === 0) {
         safeProps[prop] = props[prop];
       }
     }

--- a/packages/react-native-web/src/modules/AccessibilityUtil/propsToAccessibilityComponent.js
+++ b/packages/react-native-web/src/modules/AccessibilityUtil/propsToAccessibilityComponent.js
@@ -34,7 +34,7 @@ const propsToAccessibilityComponent = (props: Object = emptyObject) => {
   const role = propsToAriaRole(props);
   if (role) {
     if (role === 'heading') {
-      const level = props['aria-level'] || 1;
+      const level = props['aria-level'] || props['ariaLevel'] || 1;
       return `h${level}`;
     }
     return roleComponents[role];


### PR DESCRIPTION
With Reason-React it is not possible to provide props with a "dash" (https://reasonml.github.io/reason-react/docs/en/invalid-prop-name).

This PR will make the `ariaLevel` prop work with react-native-web and `reason-react-native`. 

cc @MoOx 
