### PR TITLE
I18nManager: detect preferred language direction from document.dir

### DIFF
--- a/packages/react-native-web/src/exports/I18nManager/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/I18nManager/__tests__/index-test.js
@@ -3,8 +3,30 @@
 import I18nManager from '..';
 
 const getDocumentDir = () => document.documentElement.getAttribute('dir');
+const setDocumentDir = dir => document.documentElement.setAttribute('dir', dir);
 
 describe('apis/I18nManager', () => {
+  describe('detect preferred language direction from document.dir', () => {
+    const _dir = getDocumentDir();
+    beforeEach(() => {
+      jest.resetModules();
+    });
+
+    afterEach(() => {
+      setDocumentDir(_dir);
+    });
+
+    test('when set to ltr, isRTL is false', () => {
+      setDocumentDir('ltr');
+      expect(require('..').isRTL).toBe(false);
+    });
+
+    test('when set to rtl, isRTL is true', () => {
+      setDocumentDir('rtl');
+      expect(require('..').isRTL).toBe(true);
+    });
+  });
+
   describe('preferred language is LTR', () => {
     beforeEach(() => {
       I18nManager.setPreferredLanguageRTL(false);

--- a/packages/react-native-web/src/exports/I18nManager/index.js
+++ b/packages/react-native-web/src/exports/I18nManager/index.js
@@ -20,7 +20,10 @@ type I18nManagerStatus = {
 };
 
 let doLeftAndRightSwapInRTL = true;
-let isPreferredLanguageRTL = false;
+let isPreferredLanguageRTL =
+  ExecutionEnvironment.canUseDOM &&
+  document.documentElement != null &&
+  document.documentElement.getAttribute('dir') === 'rtl';
 let isRTLAllowed = true;
 let isRTLForced = false;
 


### PR DESCRIPTION
This commit updates I18nManager so it respects existing document.dir, this is useful for pages that contain server loaded RTL content with document.dir set appropriately. Not that its difficult to call `setPreferredLanguageRTL(true)` before `runApplication()` but there's no code like no code 😄