### PR TITLE
Allow compat mode for ViewPropTypes

### DIFF
--- a/packages/react-native-web/src/exports/ViewPropTypes/index.js
+++ b/packages/react-native-web/src/exports/ViewPropTypes/index.js
@@ -1,0 +1,1 @@
+export default {};

--- a/packages/react-native-web/src/index.js
+++ b/packages/react-native-web/src/index.js
@@ -69,6 +69,7 @@ export { default as Settings } from './exports/Settings';
 export { default as Systrace } from './exports/Systrace';
 export { default as TimePickerAndroid } from './exports/TimePickerAndroid';
 export { default as TVEventHandler } from './exports/TVEventHandler';
+export { default as ViewPropTypes } from './exports/ViewPropTypes';
 
 // plugins
 export { default as DeviceEventEmitter } from './exports/DeviceEventEmitter';


### PR DESCRIPTION
Based on your comment in the release notes for 0.12.0 I'm not sure if you 'll be a fan of adding this back strictly for compat with libs that still use it? Just so that it doesn't crash