### PR TITLE
fix Clipboard copy

### DIFF
--- a/packages/react-native-web/src/exports/Clipboard/index.js
+++ b/packages/react-native-web/src/exports/Clipboard/index.js
@@ -35,6 +35,7 @@ export default class Clipboard {
       node.style.opacity = '0';
       node.style.position = 'absolute';
       node.style.whiteSpace = 'pre-wrap';
+      node.style.userSelect = 'auto';
       body.appendChild(node);
 
       // select the text


### PR DESCRIPTION
when spans are non selectable (because of global span css), clipboard won't work without this fix to explicitly change the created node to be selectable.