### PR TITLE
Fix `nativeScrollRef` is not a function

### DIFF
--- a/packages/react-native-web/src/exports/ScrollView/index.js
+++ b/packages/react-native-web/src/exports/ScrollView/index.js
@@ -71,6 +71,10 @@ const ScrollView = ((createReactClass({
   getInnerViewNode(): any {
     return findNodeHandle(this._innerViewRef);
   },
+    
+  getNativeScrollRef(): any {
+    return findNodeHandler(this._scrollViewRef);
+  },
 
   /**
    * Scrolls to a given x, y offset, either immediately or with a smooth animation.

--- a/packages/react-native-web/src/exports/ScrollView/index.js
+++ b/packages/react-native-web/src/exports/ScrollView/index.js
@@ -73,7 +73,7 @@ const ScrollView = ((createReactClass({
   },
     
   getNativeScrollRef(): any {
-    return findNodeHandler(this._scrollViewRef);
+    return findNodeHandle(this._scrollViewRef);
   },
 
   /**


### PR DESCRIPTION
This prevents VirtualizedList from throwing a warning, and fixes scrolling when using nested virtualized lists (FlatList, SectionList).

Proposed fix for #1560 however, this doesn't make any updates to ScrollResponder, I am less sure about what needs to happen there.