### PR TITLE
Update supportedProps to include inputMode

### DIFF
--- a/packages/react-native-web/src/exports/View/filterSupportedProps.js
+++ b/packages/react-native-web/src/exports/View/filterSupportedProps.js
@@ -17,6 +17,7 @@ const supportedProps = {
   children: true,
   disabled: true,
   importantForAccessibility: true,
+  inputMode: true,
   nativeID: true,
   onBlur: true,
   onContextMenu: true,


### PR DESCRIPTION
The inputMode property is exceptionally useful on native apps to render the correct type of keyboard necessary to fill in the type of input you're using. It is a globally supported prop, but gets filtered out at the moment.