### PR TITLE
Deprecate AccessibilityInfo.fetch and add AccessibilityInfo.isScreenReaderEnabled

### DIFF
--- a/packages/react-native-web/src/exports/AccessibilityInfo/index.js
+++ b/packages/react-native-web/src/exports/AccessibilityInfo/index.js
@@ -16,6 +16,17 @@ const AccessibilityInfo = {
    * Returns a promise which resolves to a boolean.
    * The result is `true` when a screen reader is enabled and `false` otherwise.
    */
+  isScreenReaderEnabled: function(): Promise<*> {
+    return new Promise((resolve, reject) => {
+      resolve(true);
+    });
+  },
+  
+   /**
+   * Deprecated
+   *
+   * Same as `isScreenReaderEnabled`
+   */
   fetch: function(): Promise<*> {
     return new Promise((resolve, reject) => {
       resolve(true);


### PR DESCRIPTION
From this commit(https://github.com/facebook/react-native/commit/0090ab32c2aeffed76ff58931930fe40a45e6ebc) which was merged in 0.60.2, the fetch method is deprecated and the isScreenReaderEnabled method provides the same functionality.