### PR TITLE
Fixed nested FlatList errors

### DIFF
--- a/packages/react-native-web/src/vendor/react-native/VirtualizedList/index.js
+++ b/packages/react-native-web/src/vendor/react-native/VirtualizedList/index.js
@@ -1146,11 +1146,7 @@ class VirtualizedList extends React.PureComponent<Props, State> {
       }
       // We are asuming that getOutermostParentListRef().getScrollRef()
       // is a non-null reference to a ScrollView
-      this._scrollRef.measureLayout(
-        this.context.virtualizedList
-          .getOutermostParentListRef()
-          .getScrollRef()
-          .getNativeScrollRef(),
+      this._scrollRef.measureLayout(findNodeHandle(this.context.virtualizedList.getOutermostParentListRef()),
         (x, y, width, height) => {
           this._offsetFromParentVirtualizedList = this._selectOffset({x, y});
           this._scrollMetrics.contentLength = this._selectLength({
@@ -1353,6 +1349,11 @@ class VirtualizedList extends React.PureComponent<Props, State> {
     if (this.props.onScroll) {
       this.props.onScroll(e);
     }
+
+    if (e.nativeEvent.layoutMeasurement) {
+      return;
+    }
+
     const timestamp = e.timeStamp;
     let visibleLength = this._selectLength(e.nativeEvent.layoutMeasurement);
     let contentLength = this._selectLength(e.nativeEvent.contentSize);


### PR DESCRIPTION
We have two nested FlatsLists, and everything was working perfectly with `react-native-web:0.11.7`

With `react-native-web:0.12.2` we have faced following errors in our application:
`this._scrollRef.measureLayout(this.context.virtualizedList.getOutermostParentListRef().getScrollRef().getNativeScrollRef()) getNativeScrollRef is not a function`

This error is related to the new implementation of the `measureLayoutRelativeToContainingList()` [from here](https://github.com/necolas/react-native-web/compare/0.11.7...0.12.2#diff-ac68324687cca207aa8147ed05b3faffR1140)

I have investigated a recent [fix to in the `next` into `FlatList`](https://github.com/necolas/react-native-web/commit/d5335020ba16aa87bffd392aa32983060d4b7b84) but it does not help.

Another error which breaks rendering more than 10 items is `cannot read property height of undefined` which is happening in `VirtualizedList#_onScroll()` because it seems that `setTimeout` which gets modified `scrollEvent` data is not working `quick` enough and returns wrong `native` event which blocks other calculations, but after some time it starts returning the correct event object. 

@necolas Great thanks for your efforts and this awesome project, would love to help and contribute


