### PR TITLE
fix: Image Component  cannot transmit View Props

### DIFF
--- a/packages/react-native-web/src/exports/Image/index.js
+++ b/packages/react-native-web/src/exports/Image/index.js
@@ -206,7 +206,8 @@ class Image extends React.Component<ImageProps, State> {
       pointerEvents,
       resizeMode,
       source,
-      testID
+      testID,
+      ...otherProps
     } = this.props;
 
     if (process.env.NODE_ENV !== 'production') {
@@ -277,6 +278,7 @@ class Image extends React.Component<ImageProps, State> {
         pointerEvents={pointerEvents}
         style={[styles.root, hasTextAncestor && styles.inline, imageSizeStyle, flatStyle]}
         testID={testID}
+        {...otherProps}
       >
         <View
           style={[


### PR DESCRIPTION
When TouchableWithoutFeedback packs the Image component, TouchableWithoutFeedback's onPress props not work.
See [code links](https://codesandbox.io/s/stupefied-tereshkova-k0rwt?file=/src/App.js:421-445) in detail.
And I think Image Component should transmit View Props.
Thanks review my fix code~