### PR TITLE
fix scrollView&List Component press and slide conflict

### DIFF
--- a/packages/react-native-web/src/exports/Touchable/index.js
+++ b/packages/react-native-web/src/exports/Touchable/index.js
@@ -530,6 +530,13 @@ const TouchableMixin = {
         this.pressInLocation.pageX,
         this.pressInLocation.pageY
       );
+
+      // fix scrollView&List Component press and slide conflict
+      if (movedDistance > 2) {
+        this._receiveSignal(Signals.LEAVE_PRESS_RECT, e)
+        this._cancelLongPressDelayTimeout()
+      }
+      
       if (movedDistance > LONG_PRESS_ALLOWED_MOVEMENT) {
         this._cancelLongPressDelayTimeout();
       }


### PR DESCRIPTION
Interrupting an event by determining if the focus has moved farther than 2 is compatible with Touchable in the scroll container to prevent scrolling from simultaneously starting the click event
