### PR TITLE
Reuse pointerEvents in setNativeProps

### DIFF
--- a/packages/react-native-web/src/exports/Text/index.js
+++ b/packages/react-native-web/src/exports/Text/index.js
@@ -95,6 +95,7 @@ const Text = forwardRef<TextProps, *>((props, forwardedRef) => {
     onSelectionChangeShouldSetResponderCapture,
     onStartShouldSetResponder,
     onStartShouldSetResponderCapture,
+    pointerEvents,
     selectable
   } = props;
 
@@ -121,7 +122,7 @@ const Text = forwardRef<TextProps, *>((props, forwardedRef) => {
   ];
 
   useElementLayout(hostRef, onLayout);
-  usePlatformMethods(hostRef, classList, style);
+  usePlatformMethods(hostRef, classList, style, pointerEvents);
   useResponderEvents(hostRef, {
     onMoveShouldSetResponder,
     onMoveShouldSetResponderCapture,

--- a/packages/react-native-web/src/exports/View/index.js
+++ b/packages/react-native-web/src/exports/View/index.js
@@ -89,7 +89,8 @@ const View = forwardRef<ViewProps, *>((props, forwardedRef) => {
     onSelectionChangeShouldSetResponder,
     onSelectionChangeShouldSetResponderCapture,
     onStartShouldSetResponder,
-    onStartShouldSetResponderCapture
+    onStartShouldSetResponderCapture,
+    pointerEvents
   } = props;
 
   if (process.env.NODE_ENV !== 'production') {
@@ -116,7 +117,7 @@ const View = forwardRef<ViewProps, *>((props, forwardedRef) => {
   );
 
   useElementLayout(hostRef, onLayout);
-  usePlatformMethods(hostRef, classList, style);
+  usePlatformMethods(hostRef, classList, style, pointerEvents);
   useResponderEvents(hostRef, {
     onMoveShouldSetResponder,
     onMoveShouldSetResponderCapture,

--- a/packages/react-native-web/src/hooks/usePlatformMethods.js
+++ b/packages/react-native-web/src/hooks/usePlatformMethods.js
@@ -14,9 +14,10 @@ import UIManager from '../exports/UIManager';
 import createDOMProps from '../modules/createDOMProps';
 import { useImperativeHandle, useRef } from 'react';
 
-function setNativeProps(node, nativeProps, classList, style, previousStyleRef) {
+function setNativeProps(node, nativeProps, classList, style, previousStyleRef, pointerEvents) {
   if (node != null && nativeProps) {
     const domProps = createDOMProps(null, {
+      pointerEvents,
       ...nativeProps,
       classList: [nativeProps.className, classList],
       style: [style, nativeProps.style]
@@ -48,7 +49,8 @@ function setNativeProps(node, nativeProps, classList, style, previousStyleRef) {
 export default function usePlatformMethods(
   hostRef: ElementRef<any>,
   classList: Array<boolean | string>,
-  style: GenericStyleProp<any>
+  style: GenericStyleProp<any>,
+  pointerEvents?: string | undefined
 ) {
   const previousStyleRef = useRef(null);
 
@@ -61,9 +63,9 @@ export default function usePlatformMethods(
         UIManager.measureLayout(hostNode, relativeToNode, failure, success);
       hostNode.measureInWindow = callback => UIManager.measureInWindow(hostNode, callback);
       hostNode.setNativeProps = nativeProps =>
-        setNativeProps(hostNode, nativeProps, classList, style, previousStyleRef);
+        setNativeProps(hostNode, nativeProps, classList, style, previousStyleRef, pointerEvents);
       return hostNode;
     },
-    [classList, hostRef, style]
+    [classList, hostRef, style, pointerEvents]
   );
 }


### PR DESCRIPTION
`pointerEvents` styles are currently lost whenever you use `setNativeProps`. This PR makes sure that `pointerEvents` styles are kept.

This PR fixes https://github.com/necolas/react-native-web/issues/1655
