### PR TITLE
Missing accessibilityRole="option"

### DIFF
--- a/packages/react-native-web/src/modules/AccessibilityUtil/propsToAriaRole.js
+++ b/packages/react-native-web/src/modules/AccessibilityUtil/propsToAriaRole.js
@@ -19,7 +19,8 @@ const accessibilityRoleToWebRole = {
   none: 'presentation',
   search: 'search',
   summary: 'region',
-  text: null
+  option: 'option',
+  text: null,
 };
 
 const propsToAriaRole = ({ accessibilityRole }: Object) => {

--- a/packages/react-native-web/src/modules/createDOMProps/index.js
+++ b/packages/react-native-web/src/modules/createDOMProps/index.js
@@ -164,7 +164,7 @@ const createDOMProps = (component, props) => {
     } else {
       domProps['data-focusable'] = true;
     }
-  } else if (role === 'button' || role === 'menuitem' || role === 'textbox') {
+  } else if (role === 'button' || role === 'option' || role === 'menuitem' || role === 'textbox') {
     if (accessible !== false && focusable) {
       domProps['data-focusable'] = true;
       domProps.tabIndex = '0';


### PR DESCRIPTION
I've been building a combobox and found that `react-native-web` is missing the `accessibilityRole="option"` necessary for proper voice over. I might be missing some other changes below as I'm not super familiar with the codebase.

Here's a link to the spec examples detailing the role usage:

https://www.w3.org/TR/wai-aria-practices/examples/combobox/aria1.1pattern/listbox-combo.html