### PR TITLE
Create RN components that relies on different dom elements

### DIFF
--- a/packages/babel-plugin-react-native-web/src/moduleMap.js
+++ b/packages/babel-plugin-react-native-web/src/moduleMap.js
@@ -61,6 +61,7 @@ module.exports = {
   VirtualizedList: true,
   YellowBox: true,
   createElement: true,
+  createRNElement: true,
   findNodeHandle: true,
   processColor: true,
   render: true,

--- a/packages/react-native-web/src/exports/createRNElement/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/react-native-web/src/exports/createRNElement/__tests__/__snapshots__/index-test.js.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`exports/createRNElement prop "href" 1`] = `
+<a
+  class="css-reset-4rbku5 9"
+  data-focusable="true"
+  href="http://mylink.com"
+/>
+`;
+
+exports[`exports/createRNElement renders default style 1`] = `
+<div
+  class="8"
+  style="height: 10px; width: 10px;"
+/>
+`;
+
+exports[`exports/createRNElement renders different DOM elements 1`] = `
+<h3
+  class="6"
+/>
+`;
+
+exports[`exports/createRNElement renders different DOM elements 2`] = `
+<button
+  class="css-reset-4rbku5 7"
+  data-focusable="true"
+/>
+`;

--- a/packages/react-native-web/src/exports/createRNElement/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/createRNElement/__tests__/index-test.js
@@ -40,12 +40,4 @@ describe('exports/createRNElement', () => {
     fireEvent.click(container.firstChild);
     expect(myFn).toHaveBeenCalledTimes(1);
   });
-
-  test('onLayout callback', () => {
-    const myFn = jest.fn();
-    const View = createRNElement('div');
-    const { rerender } = render(<View onLayout={myFn} style={{ height: 10, width: 10 }} />);
-    rerender(<View onLayout={myFn} style={{ height: 15, width: 15 }} />);
-    expect(myFn).toHaveBeenCalledTimes(2);
-  });
 });

--- a/packages/react-native-web/src/exports/createRNElement/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/createRNElement/__tests__/index-test.js
@@ -1,0 +1,51 @@
+/* eslint-env jasmine, jest */
+
+import createRNElement from '../index';
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+
+describe('exports/createRNElement', () => {
+  test('renders different DOM elements', () => {
+    const Text = createRNElement('h3', { ref: true });
+    const { container: h3Container } = render(<Text>test</Text>);
+    expect(h3Container.firstChild).toMatchSnapshot();
+    const Button = createRNElement('button', { ref: true });
+    const { container: btnContainer } = render(<Button />);
+    expect(btnContainer.firstChild).toMatchSnapshot();
+  });
+
+  test('renders default style', () => {
+    const View = createRNElement('div', {}, { backgoundColor: 'red' });
+    const { container } = render(<View style={{ height: 10, width: 10 }} />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('prop "href"', () => {
+    const propList = {
+      ref: true,
+      href: true
+    };
+    const Text = createRNElement('a', propList);
+    const { container } = render(<Text href={'http://mylink.com'}>test</Text>);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  test('onPress callback', () => {
+    const Button = ({ onPress }) => {
+      const Custom = createRNElement('button', { onClick: true });
+      return <Custom onClick={onPress} />;
+    };
+    const myFn = jest.fn();
+    const { container } = render(<Button onPress={myFn} />);
+    fireEvent.click(container.firstChild);
+    expect(myFn).toHaveBeenCalledTimes(1);
+  });
+
+  test('onLayout callback', () => {
+    const myFn = jest.fn();
+    const View = createRNElement('div');
+    const { rerender } = render(<View onLayout={myFn} style={{ height: 10, width: 10 }} />);
+    rerender(<View onLayout={myFn} style={{ height: 15, width: 15 }} />);
+    expect(myFn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/react-native-web/src/exports/createRNElement/index.js
+++ b/packages/react-native-web/src/exports/createRNElement/index.js
@@ -8,15 +8,16 @@
  */
 
 import React from 'react';
-import { unstable_createElement as createElement } from '../createElement';
+import createElement from '../createElement';
+import StyleSheet from '../StyleSheet';
 import useElementLayout from '../../hooks/useElementLayout';
 import usePlatformMethods from '../../hooks/usePlatformMethods';
 import useResponderEvents from '../../hooks/useResponderEvents';
 import setAndForwardRef from '../..//modules/setAndForwardRef';
 import pick from '../../modules/pick';
 
-const createRNElement = (tagname, forwardPropsList, defaultStyle) => {
-  return React.forwardRef((props, ref) => {
+const createRNElement = (tagname, forwardPropsList = {}, defaultStyle = {}) => {
+  const Element = React.forwardRef((props, ref) => {
     const {
       onLayout,
       onMoveShouldSetResponder,
@@ -41,7 +42,7 @@ const createRNElement = (tagname, forwardPropsList, defaultStyle) => {
       }
     });
 
-    const classList = [defaultStyle];
+    const classList = [StyleSheet.create({ default: defaultStyle }).default];
     useElementLayout(hostRef, onLayout);
     usePlatformMethods(hostRef, { classList, style });
     useResponderEvents(hostRef, {
@@ -67,6 +68,7 @@ const createRNElement = (tagname, forwardPropsList, defaultStyle) => {
     }, [props, classList, setRef, style]);
     return createElement(tagname, supportedProps);
   });
+  return Element;
 };
 
 export default createRNElement;

--- a/packages/react-native-web/src/exports/createRNElement/index.js
+++ b/packages/react-native-web/src/exports/createRNElement/index.js
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) Nicolas Gallagher.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @noflow
+ */
+
+import React from 'react';
+import { unstable_createElement as createElement } from '../createElement';
+import useElementLayout from '../../hooks/useElementLayout';
+import usePlatformMethods from '../../hooks/usePlatformMethods';
+import useResponderEvents from '../../hooks/useResponderEvents';
+import setAndForwardRef from '../..//modules/setAndForwardRef';
+import pick from '../../modules/pick';
+
+const createRNElement = (tagname, forwardPropsList, defaultStyle) => {
+  return React.forwardRef((props, ref) => {
+    const {
+      onLayout,
+      onMoveShouldSetResponder,
+      onMoveShouldSetResponderCapture,
+      onResponderEnd,
+      onResponderGrant,
+      onResponderMove,
+      onResponderReject,
+      onResponderRelease,
+      onResponderStart,
+      onResponderTerminate,
+      onResponderTerminationRequest,
+      onStartShouldSetResponder,
+      onStartShouldSetResponderCapture,
+      style
+    } = props;
+    const hostRef = React.useRef(null);
+    const setRef = setAndForwardRef({
+      getForwardedRef: () => ref,
+      setLocalRef: hostNode => {
+        hostRef.current = hostNode;
+      }
+    });
+
+    const classList = [defaultStyle];
+    useElementLayout(hostRef, onLayout);
+    usePlatformMethods(hostRef, { classList, style });
+    useResponderEvents(hostRef, {
+      onMoveShouldSetResponder,
+      onMoveShouldSetResponderCapture,
+      onResponderEnd,
+      onResponderGrant,
+      onResponderMove,
+      onResponderReject,
+      onResponderRelease,
+      onResponderStart,
+      onResponderTerminate,
+      onResponderTerminationRequest,
+      onStartShouldSetResponder,
+      onStartShouldSetResponderCapture
+    });
+    const supportedProps = React.useMemo(() => {
+      const finalProps = pick(props, forwardPropsList);
+      finalProps.classList = classList;
+      finalProps.ref = setRef;
+      finalProps.style = style;
+      return finalProps;
+    }, [props, classList, setRef, style]);
+    return createElement(tagname, supportedProps);
+  });
+};
+
+export default createRNElement;

--- a/packages/react-native-web/src/index.js
+++ b/packages/react-native-web/src/index.js
@@ -3,6 +3,7 @@ export { default as findNodeHandle } from './exports/findNodeHandle';
 export { default as processColor } from './exports/processColor';
 export { default as render } from './exports/render';
 export { default as unmountComponentAtNode } from './exports/unmountComponentAtNode';
+export { default as createRNElement } from './exports/createRNElement';
 export { default as NativeModules } from './exports/NativeModules';
 
 // APIs


### PR DESCRIPTION
This PR contains the implementation of createRNElement.
Now the developers are able to create ReactNative elements like Text that relies on ```<span>```, ```<a>```, ```<h1>```, ```<h2>``` or a Button that relies on ```<button>```. So whatever is the needing the developer will be able to adapt the web behavior of the RN elements.
There are a lot of possible combinations.