### PR TITLE
add 'title' prop support to View and Text components

### DIFF
--- a/packages/react-native-web/src/exports/Text/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/react-native-web/src/exports/Text/__tests__/__snapshots__/index-test.js.snap
@@ -26,3 +26,11 @@ exports[`components/Text nested 1`] = `
   />
 </div>
 `;
+
+exports[`components/Text prop "title" 1`] = `
+<div
+  class="css-text-901oao"
+  dir="auto"
+  title="I like the hover!"
+/>
+`;

--- a/packages/react-native-web/src/exports/Text/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/Text/__tests__/index-test.js
@@ -22,4 +22,9 @@ describe('components/Text', () => {
   });
 
   test('prop "numberOfLines"', () => {});
+
+  test('prop "title"', () => {
+    const { container } = render(<Text title="I like the hover!" />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
 });

--- a/packages/react-native-web/src/exports/Text/index.js
+++ b/packages/react-native-web/src/exports/Text/index.js
@@ -67,7 +67,8 @@ const forwardPropsList = {
   onWheel: true,
   href: true,
   rel: true,
-  target: true
+  target: true,
+  title: true
 };
 
 const pickProps = props => pick(props, forwardPropsList);

--- a/packages/react-native-web/src/exports/View/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/react-native-web/src/exports/View/__tests__/__snapshots__/index-test.js.snap
@@ -22,3 +22,10 @@ exports[`components/View prop "pointerEvents" 1`] = `
   class="css-view-1dbjc4n r-pointerEvents-ah5dr5"
 />
 `;
+
+exports[`components/View prop "title" 1`] = `
+<div
+  class="css-view-1dbjc4n"
+  title="I like the hover!"
+/>
+`;

--- a/packages/react-native-web/src/exports/View/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/View/__tests__/index-test.js
@@ -47,4 +47,9 @@ describe('components/View', () => {
     const { container } = render(<View pointerEvents="box-only" />);
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  test('prop "title"', () => {
+    const { container } = render(<View title="I like the hover!" />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
 });

--- a/packages/react-native-web/src/exports/View/index.js
+++ b/packages/react-native-web/src/exports/View/index.js
@@ -66,7 +66,8 @@ const forwardPropsList = {
   onWheel: true,
   href: true,
   rel: true,
-  target: true
+  target: true,
+  title: true
 };
 
 const pickProps = props => pick(props, forwardPropsList);

--- a/packages/react-native-web/src/exports/View/types.js
+++ b/packages/react-native-web/src/exports/View/types.js
@@ -134,5 +134,6 @@ export type ViewProps = {
   onWheel?: (e: any) => void,
   href?: ?string,
   rel?: ?string,
-  target?: ?string
+  target?: ?string,
+  title?: ?string
 };


### PR DESCRIPTION
Currently when the [`title`](https://www.w3schools.com/tags/att_title.asp) property is used the attribute and value is being ignored. This prevents from adding typical for the web platform hint appearing on element hover. 

This PR adds `title` to the property picker `forwarProp` list in View and Text components, test for both components and extends also the TS types. As a result `title` prop is forwarded correctly and defined hint appears on the screen.

### Preview
![demo](https://user-images.githubusercontent.com/719641/88864695-0690a180-d206-11ea-9809-0e671dc12525.gif)
