### PR TITLE
fix: createAnimatedComponent calls getScrollableNode on null component

### DIFF
--- a/packages/react-native-web/src/vendor/react-native/Animated/createAnimatedComponent.js
+++ b/packages/react-native-web/src/vendor/react-native/Animated/createAnimatedComponent.js
@@ -58,7 +58,7 @@ function createAnimatedComponent(Component: any, defaultProps: any): any {
     _attachNativeEvents() {
       // Make sure to get the scrollable node for components that implement
       // `ScrollResponder.Mixin`.
-      const scrollableNode = this._component.getScrollableNode
+      const scrollableNode = this._component && this._component.getScrollableNode
         ? this._component.getScrollableNode()
         : this._component;
 


### PR DESCRIPTION
Checks for component's existence before calling getScrollableNode. Not sure if this is the right solution, but it passes the test case provided in issue #1680 
