### PR TITLE
Check for window availability in ResponderSystem

### DIFF
--- a/packages/react-native-web/src/hooks/useResponderEvents/ResponderSystem.js
+++ b/packages/react-native-web/src/hooks/useResponderEvents/ResponderSystem.js
@@ -580,7 +580,7 @@ const documentEventsBubblePhase = [
   'selectionchange'
 ];
 export function attachListeners() {
-  if (window.__reactResponderSystemActive == null) {
+  if (typeof window !== 'undefined' && window.__reactResponderSystemActive == null) {
     window.addEventListener('blur', eventListener);
     documentEventsBubblePhase.forEach(eventType => {
       document.addEventListener(eventType, eventListener);


### PR DESCRIPTION
Views being rendered in node environments are failing when rendered in a node environment (`react-native-web@~0.13.0`).
- Test failure in Expo (expo-gl enzyme tests): https://github.com/expo/expo/runs/970636065
- Related code https://github.com/expo/expo/blob/master/packages/expo-gl/src/Canvas.tsx
  - Opening a PR to guard against `findDOMNode` in node environments as well.