### PR TITLE
Fix enterKeyHint dom prop

### DIFF
--- a/packages/react-native-web/src/exports/TextInput/index.js
+++ b/packages/react-native-web/src/exports/TextInput/index.js
@@ -356,7 +356,7 @@ const TextInput = forwardRef<TextInputProps, *>((props, forwardedRef) => {
   supportedProps.classList = classList;
   // 'auto' by default allows browsers to infer writing direction
   supportedProps.dir = dir !== undefined ? dir : 'auto';
-  supportedProps.enterkeyhint = returnKeyType;
+  supportedProps.enterKeyHint = returnKeyType;
   supportedProps.onBlur = handleBlur;
   supportedProps.onChange = handleChange;
   supportedProps.onFocus = handleFocus;


### PR DESCRIPTION
React warns about this prop since it should be `enterKeyHint` instead of the DOM capitalization `enterkeyhint`.

![image](https://user-images.githubusercontent.com/2677334/90447361-21da2880-e0b1-11ea-8668-4ea6bb499ad1.png)

Tested that the prop is properly set in the DOM after this change.

![image](https://user-images.githubusercontent.com/2677334/90447482-6a91e180-e0b1-11ea-98be-d6f0cc331a6e.png)
