### PR TITLE
Support css animation events

### DIFF
--- a/packages/react-native-web/src/exports/View/index.js
+++ b/packages/react-native-web/src/exports/View/index.js
@@ -64,6 +64,10 @@ const forwardPropsList = {
   onMouseUp: true,
   onScroll: true,
   onWheel: true,
+  onTransitionEnd: true,
+  onAnimationStart: true,
+  onAnimationEnd: true,
+  onAnimationIteration: true,
   href: true,
   rel: true,
   target: true


### PR DESCRIPTION
Since react-native-web does have CSS animation support I would like to subscribe to these event's since I'm improving the ripple effect for react-native-paper I need the onAnimationEnd property.

React-native-web will also use this event internally in the Modal PR.