### PR TITLE
Add event parameter into Image.onLoad callback

### DIFF
--- a/packages/react-native-web/src/exports/Image/index.js
+++ b/packages/react-native-web/src/exports/Image/index.js
@@ -236,10 +236,10 @@ const Image = forwardRef<ImageProps, *>((props, ref) => {
         function load(e) {
           updateState(LOADED);
           if (onLoad) {
-            onLoad();
+            onLoad(e);
           }
           if (onLoadEnd) {
-            onLoadEnd();
+            onLoadEnd(e);
           }
         },
         function error() {

--- a/packages/react-native-web/src/exports/Image/index.js
+++ b/packages/react-native-web/src/exports/Image/index.js
@@ -239,7 +239,7 @@ const Image = forwardRef<ImageProps, *>((props, ref) => {
             onLoad(e);
           }
           if (onLoadEnd) {
-            onLoadEnd(e);
+            onLoadEnd();
           }
         },
         function error() {

--- a/packages/react-native-web/src/modules/ImageLoader/index.js
+++ b/packages/react-native-web/src/modules/ImageLoader/index.js
@@ -119,7 +119,7 @@ const ImageLoader = {
     image.onerror = onError;
     image.onload = e => {
       // avoid blocking the main thread
-      const onDecode = () => onLoad();
+      const onDecode = () => onLoad(e);
       if (typeof image.decode === 'function') {
         // Safari currently throws exceptions when decoding svgs.
         // We want to catch that error and allow the load handler

--- a/packages/react-native-web/src/modules/ImageLoader/index.js
+++ b/packages/react-native-web/src/modules/ImageLoader/index.js
@@ -119,7 +119,7 @@ const ImageLoader = {
     image.onerror = onError;
     image.onload = e => {
       // avoid blocking the main thread
-      const onDecode = () => onLoad(e);
+      const onDecode = () => onLoad({ nativeEvent: e });
       if (typeof image.decode === 'function') {
         // Safari currently throws exceptions when decoding svgs.
         // We want to catch that error and allow the load handler


### PR DESCRIPTION
![Screen Shot 2020-09-03 at 13 57 00](https://user-images.githubusercontent.com/557598/92144649-62de7680-eded-11ea-8882-42a06755c9f4.png)


It's missing the event parameter into onLoad callback from Image.

This PR just preserve the original event param and flow through the functions.

This is useful, for example, to catch the image dimensions when it's fully loaded with `e.path[0].width`