### PR TITLE
[chore]: remove useless code

### DIFF
--- a/packages/react-native-web/src/vendor/react-dom/setValueForStyles/index.js
+++ b/packages/react-native-web/src/vendor/react-dom/setValueForStyles/index.js
@@ -11,7 +11,6 @@
  */
 
 import dangerousStyleValue from '../dangerousStyleValue';
-import hyphenateStyleName from 'hyphenate-style-name';
 
 /**
  * Sets the value for multiple styles on a node.  If a value is specified as
@@ -32,8 +31,7 @@ function setValueForStyles(node, styles) {
       styleName = 'cssFloat';
     }
     if (isCustomProperty) {
-      const name = isCustomProperty ? styleName : hyphenateStyleName(styleName);
-      style.setProperty(name, styleValue);
+      style.setProperty(styleName, styleValue);
     } else {
       style[styleName] = styleValue;
     }


### PR DESCRIPTION
In this PR I removed a code that was never running.
```js
if (isCustomProperty) {
      const name = isCustomProperty ? styleName : hyphenateStyleName(styleName);
``` 
This condition always assign styleName to name, because above this code you defined a condition which says isCustomProperty is true.