### PR TITLE
Implement BackHandler for web

### DIFF
--- a/packages/react-native-web/src/exports/BackHandler/index.js
+++ b/packages/react-native-web/src/exports/BackHandler/index.js
@@ -8,16 +8,22 @@
  * @flow
  */
 
-function emptyFunction() {}
-
 const BackHandler = {
-  exitApp: emptyFunction,
-  addEventListener() {
+  listeners: [],
+  exitApp: history.previous,
+  addEventListener: (listener) => {
+    listeners.push(listener)
     return {
-      remove: emptyFunction
+      remove: this.removeEventListener(listener)
     };
   },
-  removeEventListener: emptyFunction
+  removeEventListener: (listener) => this.listeners.splice(this.listeners.indexOf(listener), 1)
 };
+
+history.pushState(null, '', window.location.href)
+window.addEventListener('popstate', (event) => {
+  if(!BackHandler.listeners.find(callback => callback()) history.previous()
+  else history.pushState(null, '', window.location.href)
+})
 
 export default BackHandler;

--- a/packages/react-native-web/src/exports/BackHandler/index.js
+++ b/packages/react-native-web/src/exports/BackHandler/index.js
@@ -36,6 +36,6 @@ const exitApp: () => {
 
 export default {
   addEventListener,
-  exitApp: history.previous,
+  exitApp,
   removeEventListener
 };

--- a/packages/react-native-web/src/exports/BackHandler/index.js
+++ b/packages/react-native-web/src/exports/BackHandler/index.js
@@ -7,7 +7,7 @@
  *
  * @flow
  */
-const listeners: Array<() => boolean | null | undefined)> = []
+const listeners: Array<() => boolean | null | undefined> = []
 const addEventListener = (event: 'hardwareBackPress', listener: () => boolean | null | undefined) => {
   listeners.unshift(listener);
 };

--- a/packages/react-native-web/src/exports/BackHandler/index.js
+++ b/packages/react-native-web/src/exports/BackHandler/index.js
@@ -30,7 +30,7 @@ window.addEventListener('popstate', (e) => {
 });
 
 const exitApp: () => {
-  listeners = [];
+  listeners.length = 0;
   history.previous();
 };
 

--- a/packages/react-native-web/src/exports/BackHandler/index.js
+++ b/packages/react-native-web/src/exports/BackHandler/index.js
@@ -7,35 +7,35 @@
  *
  * @flow
  */
-const listeners = [] as (() => boolean | null | undefined)[]
+const listeners: Array<() => boolean | null | undefined)> = []
 const addEventListener = (event: 'hardwareBackPress', listener: () => boolean | null | undefined) => {
-  listeners.unshift(listener)
-}
+  listeners.unshift(listener);
+};
 
 const removeEventListener = (event: 'hardwareBackPress', listener: () => boolean | null | undefined) => {
-  listeners.splice(listeners.indexOf(listener), 1)
-}
+  listeners.splice(listeners.indexOf(listener), 1);
+};
 
 // Hack for Chrome. See this issue: https://stackoverflow.com/questions/64001278/history-pushstate-on-chrome-is-being-ignored?noredirect=1#comment113174647_64001278
 const onFirstPress = () => {
   history.pushState(null, '', window.location.href)
   window.removeEventListener('focusin', onFirstPress)
-}
-window.addEventListener('focusin', onFirstPress)
+};
+window.addEventListener('focusin', onFirstPress);
 
 // Detect pressing back key on web browsers
 window.addEventListener('popstate', (e) => {
-  const handled = listeners.find(l => l())
-  if (handled) e.preventDefault()
-})
+  const handled = listeners.find(l => l());
+  if (handled) e.preventDefault();
+});
 
 const exitApp: () => {
-  listeners = []
-  history.previous()
-}
+  listeners = [];
+  history.previous();
+};
 
 export default {
   addEventListener,
   exitApp: history.previous,
   removeEventListener
-}
+};

--- a/packages/react-native-web/src/exports/BackHandler/index.js
+++ b/packages/react-native-web/src/exports/BackHandler/index.js
@@ -29,7 +29,7 @@ window.addEventListener('popstate', (e) => {
   if (handled) e.preventDefault();
 });
 
-const exitApp: () => {
+const exitApp = () => {
   listeners.length = 0;
   history.previous();
 };


### PR DESCRIPTION
I got that idea while working on a problem a bit similar in my RN + RNW app.

I don't know if this can be useful to other people.

I let it as a draft as I didn't test this exact version of the code, but I can do it if it has a chance to be accepted.

The idea is to push a fake duplicate of the app url on load, so that when we press "back", we detect that the history has changed, and we can take actions.
