### PR TITLE
Provide better API for opening in new tab

### DIFF
--- a/packages/react-native-web/src/exports/Linking/index.js
+++ b/packages/react-native-web/src/exports/Linking/index.js
@@ -22,9 +22,9 @@ const Linking = {
   getInitialURL(): Promise<string> {
     return Promise.resolve(initialURL);
   },
-  openURL(url: string): Promise<Object | void> {
+  openURL(url: string, target?: '_blank'): Promise<Object | void> {
     try {
-      open(url);
+      open(url, target);
       return Promise.resolve();
     } catch (e) {
       return Promise.reject(e);
@@ -36,9 +36,9 @@ const Linking = {
   }
 };
 
-const open = url => {
+const open = (url: string, target?: '_blank') => {
   if (canUseDOM) {
-    window.location = new URL(url, window.location).toString();
+    window.open(url, target).focus();
   }
 };
 


### PR DESCRIPTION
Opening link in a new tab is something quite common on web nowadays. This use case should be handled by react-native-web.

Currently, the only solution is [described here](https://github.com/necolas/react-native-web/issues/162). I think that we can all agree that this is not very satisfying.

Here is my proposal. It should be transparent for native and provide the ability for web.