### PR TITLE
fix: Prevent `ref` function from being being called more frequently than needed

### DIFF
--- a/packages/react-native-web/src/exports/Picker/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/Picker/__tests__/index-test.js
@@ -83,5 +83,36 @@ describe('components/Picker', () => {
       const { container } = render(picker);
       expect(findSelect(container).value).toBe('22');
     });
+
+    test('ref function is called when ref changes', () => {
+      const refMock = jest.fn();
+      const otherRefMock = jest.fn();
+
+      const { rerender } = render(<Picker ref={refMock} />);
+      expect(refMock).toHaveBeenCalled();
+
+      rerender(<Picker ref={otherRefMock} />)
+      expect(otherRefMock).toHaveBeenCalled();
+    });
+
+    test('ref function is not called every render', () => {
+      const refMock = jest.fn();
+
+      const { rerender } = render(<Picker ref={refMock} />);
+      expect(refMock).toHaveBeenCalledTimes(1);
+
+      rerender(<Picker ref={refMock} />);
+      expect(refMock).toHaveBeenCalledTimes(1);
+    });
+
+    test('ref function is not called on prop changes', () => {
+      const refMock = jest.fn();
+
+      const { rerender } = render(<Picker ref={refMock} testID={'foo'} />);
+      expect(refMock).toHaveBeenCalledTimes(1);
+
+      rerender(<Picker ref={refMock} testID={'bar'} />);
+      expect(refMock).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/react-native-web/src/exports/Picker/index.js
+++ b/packages/react-native-web/src/exports/Picker/index.js
@@ -15,7 +15,7 @@ import setAndForwardRef from '../../modules/setAndForwardRef';
 import usePlatformMethods from '../../hooks/usePlatformMethods';
 import PickerItem from './PickerItem';
 import StyleSheet, { type StyleObj } from '../StyleSheet';
-import { forwardRef, useRef } from 'react';
+import { forwardRef, useMemo, useRef } from 'react';
 
 type PickerProps = {
   ...ViewProps,
@@ -47,12 +47,15 @@ const Picker = forwardRef<PickerProps, *>((props, forwardedRef) => {
   } = props;
 
   const hostRef = useRef(null);
-  const setRef = setAndForwardRef({
-    getForwardedRef: () => forwardedRef,
-    setLocalRef: hostNode => {
-      hostRef.current = hostNode;
-    }
-  });
+  const setRef = useMemo(
+    () => setAndForwardRef({
+      getForwardedRef: () => forwardedRef,
+      setLocalRef: hostNode => {
+        hostRef.current = hostNode;
+      },
+    }),
+    [forwardedRef]
+  );
 
   function handleChange(e: Object) {
     const { selectedIndex, value } = e.target;

--- a/packages/react-native-web/src/exports/Pressable/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/Pressable/__tests__/index-test.js
@@ -1,0 +1,39 @@
+/* eslint-env jasmine, jest */
+/* eslint-disable react/jsx-no-bind */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import TouchableOpacity from '../';
+
+describe('components/Pressable', () => {
+  test('ref function is called when ref changes', () => {
+    const refMock = jest.fn();
+    const otherRefMock = jest.fn();
+
+    const { rerender } = render(<TouchableOpacity ref={refMock} />);
+    expect(refMock).toHaveBeenCalled();
+
+    rerender(<TouchableOpacity ref={otherRefMock} />)
+    expect(otherRefMock).toHaveBeenCalled();
+  });
+
+  test('ref function is not called every render', () => {
+    const refMock = jest.fn();
+
+    const { rerender } = render(<TouchableOpacity ref={refMock} />);
+    expect(refMock).toHaveBeenCalledTimes(1);
+
+    rerender(<TouchableOpacity ref={refMock} />);
+    expect(refMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('ref function is not called on prop changes', () => {
+    const refMock = jest.fn();
+
+    const { rerender } = render(<TouchableOpacity ref={refMock} testID={'foo'} />);
+    expect(refMock).toHaveBeenCalledTimes(1);
+
+    rerender(<TouchableOpacity ref={refMock} testID={'bar'} />);
+    expect(refMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react-native-web/src/exports/Pressable/index.js
+++ b/packages/react-native-web/src/exports/Pressable/index.js
@@ -97,12 +97,15 @@ function Pressable(props: Props, forwardedRef): React.Node {
   const [pressed, setPressed] = useForceableState(testOnly_pressed === true);
 
   const hostRef = useRef(null);
-  const setRef = setAndForwardRef({
-    getForwardedRef: () => forwardedRef,
-    setLocalRef: hostNode => {
-      hostRef.current = hostNode;
-    }
-  });
+  const setRef = useMemo(
+    () => setAndForwardRef({
+      getForwardedRef: () => forwardedRef,
+      setLocalRef: hostNode => {
+        hostRef.current = hostNode;
+      }
+    }),
+    [forwardedRef]
+  );
 
   const pressConfig = useMemo(
     () => ({

--- a/packages/react-native-web/src/exports/Text/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/Text/__tests__/index-test.js
@@ -22,4 +22,35 @@ describe('components/Text', () => {
   });
 
   test('prop "numberOfLines"', () => {});
+
+  test('ref function is called when ref changes', () => {
+    const refMock = jest.fn();
+    const otherRefMock = jest.fn();
+
+    const { rerender } = render(<Text ref={refMock} />);
+    expect(refMock).toHaveBeenCalled();
+
+    rerender(<Text ref={otherRefMock} />)
+    expect(otherRefMock).toHaveBeenCalled();
+  });
+
+  test('ref function is not called every render', () => {
+    const refMock = jest.fn();
+
+    const { rerender } = render(<Text ref={refMock} />);
+    expect(refMock).toHaveBeenCalledTimes(1);
+
+    rerender(<Text ref={refMock} />);
+    expect(refMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('ref function is not called on prop changes', () => {
+    const refMock = jest.fn();
+
+    const { rerender } = render(<Text ref={refMock} testID={'foo'} />);
+    expect(refMock).toHaveBeenCalledTimes(1);
+
+    rerender(<Text ref={refMock} testID={'bar'} />);
+    expect(refMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/react-native-web/src/exports/Text/index.js
+++ b/packages/react-native-web/src/exports/Text/index.js
@@ -11,7 +11,7 @@
 import type { TextProps } from './types';
 
 import * as React from 'react';
-import { forwardRef, useContext, useRef } from 'react';
+import { forwardRef, useContext, useMemo, useRef } from 'react';
 import createElement from '../createElement';
 import css from '../StyleSheet/css';
 import pick from '../../modules/pick';
@@ -100,12 +100,15 @@ const Text = forwardRef<TextProps, *>((props, forwardedRef) => {
 
   const hasTextAncestor = useContext(TextAncestorContext);
   const hostRef = useRef(null);
-  const setRef = setAndForwardRef({
-    getForwardedRef: () => forwardedRef,
-    setLocalRef: hostNode => {
-      hostRef.current = hostNode;
-    }
-  });
+  const setRef = useMemo(
+    () => setAndForwardRef({
+      getForwardedRef: () => forwardedRef,
+      setLocalRef: hostNode => {
+        hostRef.current = hostNode;
+      }
+    }),
+    [forwardedRef]
+  );
 
   const classList = [
     classes.text,

--- a/packages/react-native-web/src/exports/TextInput/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/TextInput/__tests__/index-test.js
@@ -633,4 +633,35 @@ describe('components/TextInput', () => {
     const input = findInput(container);
     expect(input.value).toEqual(value);
   });
+
+  test('ref function is called when ref changes', () => {
+    const refMock = jest.fn();
+    const otherRefMock = jest.fn();
+
+    const { rerender } = render(<TextInput ref={refMock} />);
+    expect(refMock).toHaveBeenCalled();
+
+    rerender(<TextInput ref={otherRefMock} />)
+    expect(otherRefMock).toHaveBeenCalled();
+  });
+
+  test('ref function is not called every render', () => {
+    const refMock = jest.fn();
+
+    const { rerender } = render(<TextInput ref={refMock} />);
+    expect(refMock).toHaveBeenCalledTimes(1);
+
+    rerender(<TextInput ref={refMock} />);
+    expect(refMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('ref function is not called on prop changes', () => {
+    const refMock = jest.fn();
+
+    const { rerender } = render(<TextInput ref={refMock} testID={'foo'} />);
+    expect(refMock).toHaveBeenCalledTimes(1);
+
+    rerender(<TextInput ref={refMock} testID={'bar'} />);
+    expect(refMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/react-native-web/src/exports/TouchableHighlight/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/TouchableHighlight/__tests__/index-test.js
@@ -1,0 +1,40 @@
+/* eslint-env jasmine, jest */
+/* eslint-disable react/jsx-no-bind */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import TouchableHighlight from '../';
+import View from '../../View';
+
+describe('components/TouchableHighlight', () => {
+  test('ref function is called when ref changes', () => {
+    const refMock = jest.fn();
+    const otherRefMock = jest.fn();
+
+    const { rerender } = render(<TouchableHighlight ref={refMock}><View /></TouchableHighlight>);
+    expect(refMock).toHaveBeenCalled();
+
+    rerender(<TouchableHighlight ref={otherRefMock}><View /></TouchableHighlight>)
+    expect(otherRefMock).toHaveBeenCalled();
+  });
+
+  test('ref function is not called every render', () => {
+    const refMock = jest.fn();
+
+    const { rerender } = render(<TouchableHighlight ref={refMock}><View /></TouchableHighlight>);
+    expect(refMock).toHaveBeenCalledTimes(1);
+
+    rerender(<TouchableHighlight ref={refMock}><View /></TouchableHighlight>);
+    expect(refMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('ref function is not called on prop changes', () => {
+    const refMock = jest.fn();
+
+    const { rerender } = render(<TouchableHighlight ref={refMock} testID={'foo'}><View /></TouchableHighlight>);
+    expect(refMock).toHaveBeenCalledTimes(1);
+
+    rerender(<TouchableHighlight ref={refMock} testID={'bar'}><View /></TouchableHighlight>);
+    expect(refMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react-native-web/src/exports/TouchableHighlight/index.js
+++ b/packages/react-native-web/src/exports/TouchableHighlight/index.js
@@ -93,12 +93,15 @@ function TouchableHighlight(props: Props, forwardedRef): React.Node {
   } = props;
 
   const hostRef = useRef(null);
-  const setRef = setAndForwardRef({
-    getForwardedRef: () => forwardedRef,
-    setLocalRef: hostNode => {
-      hostRef.current = hostNode;
-    }
-  });
+  const setRef = useMemo(
+    () => setAndForwardRef({
+      getForwardedRef: () => forwardedRef,
+      setLocalRef: hostNode => {
+        hostRef.current = hostNode;
+      }
+    }),
+    [forwardedRef]
+  );
 
   const [extraStyles, setExtraStyles] = useState(
     testOnly_pressed === true ? createExtraStyles(activeOpacity, underlayColor) : null

--- a/packages/react-native-web/src/exports/TouchableOpacity/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/TouchableOpacity/__tests__/index-test.js
@@ -1,0 +1,39 @@
+/* eslint-env jasmine, jest */
+/* eslint-disable react/jsx-no-bind */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import TouchableOpacity from '../';
+
+describe('components/TouchableOpacity', () => {
+  test('ref function is called when ref changes', () => {
+    const refMock = jest.fn();
+    const otherRefMock = jest.fn();
+
+    const { rerender } = render(<TouchableOpacity ref={refMock} />);
+    expect(refMock).toHaveBeenCalled();
+
+    rerender(<TouchableOpacity ref={otherRefMock} />)
+    expect(otherRefMock).toHaveBeenCalled();
+  });
+
+  test('ref function is not called every render', () => {
+    const refMock = jest.fn();
+
+    const { rerender } = render(<TouchableOpacity ref={refMock} />);
+    expect(refMock).toHaveBeenCalledTimes(1);
+
+    rerender(<TouchableOpacity ref={refMock} />);
+    expect(refMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('ref function is not called on prop changes', () => {
+    const refMock = jest.fn();
+
+    const { rerender } = render(<TouchableOpacity ref={refMock} testID={'foo'} />);
+    expect(refMock).toHaveBeenCalledTimes(1);
+
+    rerender(<TouchableOpacity ref={refMock} testID={'bar'} />);
+    expect(refMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react-native-web/src/exports/TouchableOpacity/index.js
+++ b/packages/react-native-web/src/exports/TouchableOpacity/index.js
@@ -51,12 +51,15 @@ function TouchableOpacity(props: Props, forwardedRef): React.Node {
   } = props;
 
   const hostRef = useRef(null);
-  const setRef = setAndForwardRef({
-    getForwardedRef: () => forwardedRef,
-    setLocalRef: hostNode => {
-      hostRef.current = hostNode;
-    }
-  });
+  const setRef = useMemo(
+    () => setAndForwardRef({
+      getForwardedRef: () => forwardedRef,
+      setLocalRef: hostNode => {
+        hostRef.current = hostNode;
+      }
+    }),
+    [forwardedRef]
+  );
 
   const [duration, setDuration] = useState('0s');
   const [opacityOverride, setOpacityOverride] = useState(null);

--- a/packages/react-native-web/src/exports/TouchableWithoutFeedback/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/TouchableWithoutFeedback/__tests__/index-test.js
@@ -1,0 +1,40 @@
+/* eslint-env jasmine, jest */
+/* eslint-disable react/jsx-no-bind */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import TouchableWithoutFeedback from '../';
+import View from '../../View';
+
+describe('components/TouchableWithoutFeedback', () => {
+  test('ref function is called when ref changes', () => {
+    const refMock = jest.fn();
+    const otherRefMock = jest.fn();
+
+    const { rerender } = render(<TouchableWithoutFeedback ref={refMock}><View /></TouchableWithoutFeedback>);
+    expect(refMock).toHaveBeenCalled();
+
+    rerender(<TouchableWithoutFeedback ref={otherRefMock}><View /></TouchableWithoutFeedback>)
+    expect(otherRefMock).toHaveBeenCalled();
+  });
+
+  test('ref function is not called every render', () => {
+    const refMock = jest.fn();
+
+    const { rerender } = render(<TouchableWithoutFeedback ref={refMock}><View /></TouchableWithoutFeedback>);
+    expect(refMock).toHaveBeenCalledTimes(1);
+
+    rerender(<TouchableWithoutFeedback ref={refMock}><View /></TouchableWithoutFeedback>);
+    expect(refMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('ref function is not called on prop changes', () => {
+    const refMock = jest.fn();
+
+    const { rerender } = render(<TouchableWithoutFeedback ref={refMock} testID={'foo'}><View /></TouchableWithoutFeedback>);
+    expect(refMock).toHaveBeenCalledTimes(1);
+
+    rerender(<TouchableWithoutFeedback ref={refMock} testID={'bar'}><View /></TouchableWithoutFeedback>);
+    expect(refMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react-native-web/src/exports/TouchableWithoutFeedback/index.js
+++ b/packages/react-native-web/src/exports/TouchableWithoutFeedback/index.js
@@ -115,20 +115,25 @@ function TouchableWithoutFeedback(props: Props, forwardedRef): React.Node {
   supportedProps.accessible = accessible !== false;
   supportedProps.accessibilityState = { disabled, ...props.accessibilityState };
   supportedProps.focusable = focusable !== false && onPress !== undefined;
-  supportedProps.ref = setAndForwardRef({
-    getForwardedRef: () => forwardedRef,
-    setLocalRef: hostNode => {
-      const { ref } = element;
-      if (ref != null) {
-        if (typeof ref === 'function') {
-          ref(hostNode);
-        } else {
-          ref.current = hostNode;
+
+  const { ref } = element;
+
+  supportedProps.ref = useMemo(
+    () => setAndForwardRef({
+      getForwardedRef: () => forwardedRef,
+      setLocalRef: hostNode => {
+        if (ref != null) {
+          if (typeof ref === 'function') {
+            ref(hostNode);
+          } else {
+            ref.current = hostNode;
+          }
         }
+        hostRef.current = hostNode;
       }
-      hostRef.current = hostNode;
-    }
-  });
+    }),
+    [ref, forwardedRef]
+  );
 
   const elementProps = Object.assign(supportedProps, pressEventHandlers);
 

--- a/packages/react-native-web/src/exports/View/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/View/__tests__/index-test.js
@@ -41,6 +41,37 @@ describe('components/View', () => {
       );
       expect(console.error).toBeCalled();
     });
+
+    test('ref function is called when ref changes', () => {
+      const refMock = jest.fn();
+      const otherRefMock = jest.fn();
+
+      const { rerender } = render(<View ref={refMock} />);
+      expect(refMock).toHaveBeenCalled();
+
+      rerender(<View ref={otherRefMock} />)
+      expect(otherRefMock).toHaveBeenCalled();
+    });
+
+    test('ref function is not called every render', () => {
+      const refMock = jest.fn();
+
+      const { rerender } = render(<View ref={refMock} />);
+      expect(refMock).toHaveBeenCalledTimes(1);
+
+      rerender(<View ref={refMock} />);
+      expect(refMock).toHaveBeenCalledTimes(1);
+    });
+
+    test('ref function is not called on prop changes', () => {
+      const refMock = jest.fn();
+
+      const { rerender } = render(<View ref={refMock} testID={'foo'} />);
+      expect(refMock).toHaveBeenCalledTimes(1);
+
+      rerender(<View ref={refMock} testID={'bar'} />);
+      expect(refMock).toHaveBeenCalledTimes(1);
+    });
   });
 
   test('prop "pointerEvents"', () => {

--- a/packages/react-native-web/src/exports/View/index.js
+++ b/packages/react-native-web/src/exports/View/index.js
@@ -11,7 +11,7 @@
 import type { ViewProps } from './types';
 
 import * as React from 'react';
-import { forwardRef, useContext, useRef } from 'react';
+import { forwardRef, useContext, useRef, useMemo } from 'react';
 import createElement from '../createElement';
 import css from '../StyleSheet/css';
 import pick from '../../modules/pick';
@@ -102,12 +102,15 @@ const View = forwardRef<ViewProps, *>((props, forwardedRef) => {
 
   const hasTextAncestor = useContext(TextAncestorContext);
   const hostRef = useRef(null);
-  const setRef = setAndForwardRef({
-    getForwardedRef: () => forwardedRef,
-    setLocalRef: hostNode => {
-      hostRef.current = hostNode;
-    }
-  });
+  const setRef = useMemo(
+    () => setAndForwardRef({
+      getForwardedRef: () => forwardedRef,
+      setLocalRef: hostNode => {
+        hostRef.current = hostNode;
+      },
+    }),
+    [forwardedRef]
+  );
 
   const classList = [classes.view];
   const style = StyleSheet.compose(


### PR DESCRIPTION
In the `Picker`, `Pressable`, `Text`, `TextInput`, `TouchableHighlight`, `TouchableOpacity`, `TouchableWithoutFeedback`, and `View` component - when the `ref` prop is a function it will be called once per render of the component.  This is a new regression as of `0.13.0` - it was not present in `0.12.x` and was a side effect of the refactor to functional components.

Fixes #1665