### PR TITLE
Update the preset to use metro-react-native-babel-preset

### DIFF
--- a/packages/docs/src/guides/multi-platform-apps.stories.mdx
+++ b/packages/docs/src/guides/multi-platform-apps.stories.mdx
@@ -94,8 +94,8 @@ const babelLoaderConfiguration = {
     loader: 'babel-loader',
     options: {
       cacheDirectory: true,
-      // The 'react-native' preset is recommended to match React Native's packager
-      presets: ['react-native'],
+      // The 'metro-react-native-babel-preset' preset is recommended to match React Native's packager
+      presets: ['module:metro-react-native-babel-preset'],
       // Re-write paths to import only the modules needed by the app
       plugins: ['react-native-web']
     }


### PR DESCRIPTION
Updating the document as `babel-preset-react-native` is deprecated in favor for `metro-react-native-babel-preset`.
More info here - https://www.npmjs.com/package/babel-preset-react-native.