### PR TITLE
Skip ResizeObserver warning during SSR

### DIFF
--- a/packages/react-native-web/src/hooks/useElementLayout.js
+++ b/packages/react-native-web/src/hooks/useElementLayout.js
@@ -16,7 +16,7 @@ import UIManager from '../exports/UIManager';
 
 const DOM_LAYOUT_HANDLER_NAME = '__reactLayoutHandler';
 
-let didWarn = false;
+let didWarn = !canUseDOM;
 let resizeObserver = null;
 
 function getResizeObserver(): ?ResizeObserver {


### PR DESCRIPTION
The ResizeObserver is not available when using `react-native-web` during a server side render, however the warning of a missing polyfill still triggers.

This PR skips the warning when `react-native-web` is used during SSR.