### PR TITLE
fix: Callback ref less on Views by making classList constant

### DIFF
--- a/packages/react-native-web/src/exports/View/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/View/__tests__/index-test.js
@@ -127,6 +127,19 @@ describe('components/View', () => {
       expect(ref).toBeCalled();
     });
 
+    test('is memoized on ref changes', () => {
+      const ref = jest.fn();
+      let rerender;
+      act(() => {
+        ({ rerender } = render(<View ref={ref} testID="123" />));
+      });
+      expect(ref).toHaveBeenCalledTimes(1);
+      act(() => {
+        rerender(<View ref={ref} testID="1234" />);
+      });
+      expect(ref).toHaveBeenCalledTimes(1);
+    });
+
     test('node has imperative methods', () => {
       const ref = React.createRef();
       act(() => {

--- a/packages/react-native-web/src/exports/View/index.js
+++ b/packages/react-native-web/src/exports/View/index.js
@@ -103,12 +103,6 @@ const View = forwardRef<ViewProps, *>((props, forwardedRef) => {
   const hasTextAncestor = useContext(TextAncestorContext);
   const hostRef = useRef(null);
 
-  const classList = [classes.view];
-  const style = StyleSheet.compose(
-    hasTextAncestor && styles.inline,
-    props.style
-  );
-
   useElementLayout(hostRef, onLayout);
   useResponderEvents(hostRef, {
     onMoveShouldSetResponder,
@@ -128,6 +122,11 @@ const View = forwardRef<ViewProps, *>((props, forwardedRef) => {
     onStartShouldSetResponder,
     onStartShouldSetResponderCapture
   });
+
+  const style = StyleSheet.compose(
+    hasTextAncestor && styles.inline,
+    props.style
+  );
 
   const supportedProps = pickProps(props);
   supportedProps.classList = classList;
@@ -160,6 +159,8 @@ const classes = css.create({
     zIndex: 0
   }
 });
+
+const classList = [classes.view];
 
 const styles = StyleSheet.create({
   inline: {

--- a/packages/react-native-web/src/modules/useMergeRefs/__tests__/index-test.js
+++ b/packages/react-native-web/src/modules/useMergeRefs/__tests__/index-test.js
@@ -58,7 +58,7 @@ describe('modules/useMergeRefs', () => {
     expect(nextRef).toHaveBeenCalled();
   });
 
-  test.skip('ref is not called for each rerender', () => {
+  test('ref is not called for each rerender', () => {
     const ref = jest.fn();
     let rerender;
 
@@ -72,7 +72,7 @@ describe('modules/useMergeRefs', () => {
     expect(ref).toHaveBeenCalledTimes(1);
   });
 
-  test.skip('ref is not called for props changes', () => {
+  test('ref is not called for props changes', () => {
     const ref = jest.fn();
     let rerender;
 


### PR DESCRIPTION
**Problem**
In Twitter's code, I was seeing our ref callbacks being called on every render (sometimes twice), despite ref memoization being recently added in 583e16fa8d6f53fd8234944cb2beb94a9c2293b8.

After debugging the memo hook arguments, I found that the usePlatformMethods was changing on every render. This is caused by creating an array inside the render method. Since useMemo uses strict equality, this will defeat memoization.

**Solution**
Since classList is not dynamic, we can pull it outside the render path and thus make it constant. As the new test shows, this fixes the behavior.

> NOTE: `StyleSheet.compose` also potentially has this issue, however it will only affect Views with `hasTextAncestor`. This could be further fixed for such nodes by adding some form of memoization around this function too if desired.