### PR TITLE
Remove collapsable from createAnimatedComponent.js

### DIFF
--- a/packages/react-native-web/src/vendor/react-native/Animated/createAnimatedComponent.js
+++ b/packages/react-native-web/src/vendor/react-native/Animated/createAnimatedComponent.js
@@ -169,7 +169,7 @@ function createAnimatedComponent(Component: any, defaultProps: any): any {
           // have to make sure the view doesn't get optimized away because it cannot
           // go through the NativeViewHierarchyManager since it operates on the shadow
           // thread.
-          collapsable={false}
+          collapsable={undefined}
         />
       );
     }


### PR DESCRIPTION
Sending `false` to `collapsable` causes the browser to complain that it is not a valid value. Suggest change to `undefined` as per error in browser.