### PR TITLE
fix: Pressable disabled cursor state

### DIFF
--- a/packages/react-native-web/src/exports/Pressable/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/react-native-web/src/exports/Pressable/__tests__/__snapshots__/index-test.js.snap
@@ -146,7 +146,7 @@ exports[`components/Pressable prop "accessibilityRole" value is set 1`] = `
 exports[`components/Pressable prop "disabled" 1`] = `
 <div
   aria-disabled="true"
-  class="css-view-1dbjc4n r-cursor-1loqt21 r-touchAction-1otgn73"
+  class="css-view-1dbjc4n"
   disabled=""
 />
 `;

--- a/packages/react-native-web/src/exports/Pressable/index.js
+++ b/packages/react-native-web/src/exports/Pressable/index.js
@@ -158,7 +158,10 @@ function Pressable(props: Props, forwardedRef): React.Node {
       onBlur={createFocusHandler(onBlur, false)}
       onFocus={createFocusHandler(onFocus, true)}
       ref={setRef}
-      style={[styles.root, typeof style === 'function' ? style(interactionState) : style]}
+      style={[
+        !disabled && styles.root,
+        typeof style === 'function' ? style(interactionState) : style
+      ]}
     >
       {typeof children === 'function' ? children(interactionState) : children}
     </View>


### PR DESCRIPTION
This PR sets cursor "auto/initial" value if Pressable have a disabled prop. I copied the logic from TouchableOpacity, so now they have exactly same cursor logic.