### PR TITLE
fix: re-fix enter key handling for components explicitly given accessible prop

### DIFF
--- a/packages/react-native-web/src/modules/createDOMProps/__tests__/index-test.js
+++ b/packages/react-native-web/src/modules/createDOMProps/__tests__/index-test.js
@@ -232,6 +232,18 @@ describe('modules/createDOMProps', () => {
       expect(respondsToEnter('div', 'bogus')).toBe(false);
     });
 
+    test('emulates "onClick" for "Enter" for items marked accessible', () => {
+      const onClick = jest.fn();
+      const event = { key: 'Enter', preventDefault: jest.fn() };
+      const finalProps = createDOMProps('div', {
+        accessible: true,
+        accessibilityRole: 'article',
+        onClick
+      });
+      finalProps.onKeyDown(event);
+      expect(onClick).toHaveBeenCalled();
+    });
+
     test('emulates "onClick" for "Space" for certain roles', () => {
       expect(respondsToSpace('div', 'button')).toBe(true);
       expect(respondsToSpace('div', 'menuitem')).toBe(true);

--- a/packages/react-native-web/src/modules/createDOMProps/index.js
+++ b/packages/react-native-web/src/modules/createDOMProps/index.js
@@ -225,7 +225,12 @@ const createDOMProps = (component, props) => {
   // Keyboard accessibility
   // Button-like roles should trigger 'onClick' if SPACE key is pressed.
   // Button-like roles should not trigger 'onClick' if they are disabled.
-  if (isNativeInteractiveElement || role === 'button' || role === 'menuitem') {
+  if (
+    isNativeInteractiveElement ||
+    role === 'button' ||
+    role === 'menuitem' ||
+    (accessible === true && focusable)
+  ) {
     const onClick = domProps.onClick;
     if (onClick != null) {
       if (disabled) {


### PR DESCRIPTION
**Problem**
In #1780, I missed one case where we set `data-focusable` which was previously used to true. This is when a component is explicitly marked accessible even though it's not normally an accessible role.

**Solution**
Add that case in. I'm not happy that the logic is kind of a big boolean blob, and I see what we were going for originally when relying on `data-focusable` to try and have the logic in one place, but I couldn't come up with a better expression of it. At least there's more tests now so that if we do refactor we might have a little more certainty.