### PR TITLE
fix: react interKeyHint is pascalCase

### DIFF
--- a/packages/docs/src/components/TextInput/TextInput.stories.mdx
+++ b/packages/docs/src/components/TextInput/TextInput.stories.mdx
@@ -244,7 +244,7 @@ The text color of the placeholder string.
 Possible values: `'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send'`.
 
 Specifies what action label (or icon) to present for the enter key on virtual
-keyboards. Maps to the `enterkeyhint` attribute on web.
+keyboards. Maps to the `enterKeyHint` attribute on web.
 
 ### secureTextEntry
 

--- a/packages/react-native-web/src/exports/TextInput/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/TextInput/__tests__/index-test.js
@@ -546,7 +546,7 @@ describe('components/TextInput', () => {
     const returnKeyType = 'previous';
     const { container } = render(<TextInput returnKeyType={returnKeyType} />);
     const input = findInput(container);
-    expect(input.getAttribute('enterkeyhint')).toEqual(returnKeyType);
+    expect(input.getAttribute('enterKeyHint')).toEqual(returnKeyType);
   });
 
   test('prop "secureTextEntry"', () => {

--- a/packages/react-native-web/src/exports/TextInput/index.js
+++ b/packages/react-native-web/src/exports/TextInput/index.js
@@ -356,7 +356,7 @@ const TextInput = forwardRef<TextInputProps, *>((props, forwardedRef) => {
   supportedProps.classList = classList;
   // 'auto' by default allows browsers to infer writing direction
   supportedProps.dir = dir !== undefined ? dir : 'auto';
-  supportedProps.enterkeyhint = returnKeyType;
+  supportedProps.enterKeyHint = returnKeyType;
   supportedProps.onBlur = handleBlur;
   supportedProps.onChange = handleChange;
   supportedProps.onFocus = handleFocus;


### PR DESCRIPTION
Warning: Invalid DOM property `enterkeyhint`. Did you mean `enterKeyHint`?
![Screen Shot 2020-10-28 at 12 30 42 PM](https://user-images.githubusercontent.com/45505767/97415022-f463f380-1919-11eb-9e1a-5f23cadc0c18.png)
