### PR TITLE
Fix TextInput selectTextOnFocus prop (Safari)

### DIFF
--- a/packages/react-native-web/src/exports/TextInput/index.js
+++ b/packages/react-native-web/src/exports/TextInput/index.js
@@ -261,7 +261,11 @@ const TextInput = forwardRef<TextInputProps, *>((props, forwardedRef) => {
         node.value = '';
       }
       if (selectTextOnFocus) {
-        node.select();
+        // selection on focus doesn't work on Safari
+        // if not wrapped in setTimeout
+        setTimeout(() => {
+          node.select();
+        }, 1);
       }
     }
   }


### PR DESCRIPTION
**Minimal repro**: https://codesandbox.io/s/awesome-khorana-f4jl8?file=/src/App.js

**Browser**: Safari Version 14.0 (15610.1.28.1.9, 15610) - MacOS Catalina 10.15.7

## Test plan
1. Compile code & run docs (open it on Safari)
```
yarn compile
yarn docs
```
2. Go to selectTextOnFocus docs

## Before

<img src="http://g.recordit.co/zOiZiRqnkT.gif" />

## After

<img src="http://g.recordit.co/Cs4apHM2fY.gif" />


