### PR TITLE
feat: implement refocusing trigger-element after closing modal

### DIFF
--- a/packages/react-native-web/src/exports/Modal/ModalFocusTrap.js
+++ b/packages/react-native-web/src/exports/Modal/ModalFocusTrap.js
@@ -131,7 +131,7 @@ const ModalFocusTrap = ({ active, children }: ModalFocusTrapProps) => {
       lastFocusedElementOutsideTrap.current = document.activeElement;
       return () => {
         if (lastFocusedElementOutsideTrap.current) {
-          lastFocusedElementOutsideTrap.current.focus();
+          UIManager.focus(lastFocusedElementOutsideTrap.current);
         }
       };
     }

--- a/packages/react-native-web/src/exports/Modal/ModalFocusTrap.js
+++ b/packages/react-native-web/src/exports/Modal/ModalFocusTrap.js
@@ -71,6 +71,7 @@ export type ModalFocusTrapProps = {|
 |};
 
 const ModalFocusTrap = ({ active, children }: ModalFocusTrapProps) => {
+  const lastFocusedElementOutsideTrap = useRef<?HTMLElement>();
   const trapElementRef = useRef<?HTMLElement>();
   const focusRef = useRef<{ trapFocusInProgress: boolean, lastFocusedElement: ?HTMLElement }>({
     trapFocusInProgress: false,
@@ -122,6 +123,19 @@ const ModalFocusTrap = ({ active, children }: ModalFocusTrapProps) => {
       return () => document.removeEventListener('focus', trapFocus, true);
     }
   }, [active]);
+
+  // To be fully compliant with WCAG we need to refocus element that triggered opening modal
+  // after closing it
+  useEffect(() => {
+    if (canUseDOM) {
+      lastFocusedElementOutsideTrap.current = document.activeElement;
+      return () => {
+        if (lastFocusedElementOutsideTrap.current) {
+          lastFocusedElementOutsideTrap.current.focus();
+        }
+      };
+    }
+  }, []);
 
   return (
     <>

--- a/packages/react-native-web/src/exports/Modal/ModalFocusTrap.js
+++ b/packages/react-native-web/src/exports/Modal/ModalFocusTrap.js
@@ -71,7 +71,6 @@ export type ModalFocusTrapProps = {|
 |};
 
 const ModalFocusTrap = ({ active, children }: ModalFocusTrapProps) => {
-  const lastFocusedElementOutsideTrap = useRef<?HTMLElement>();
   const trapElementRef = useRef<?HTMLElement>();
   const focusRef = useRef<{ trapFocusInProgress: boolean, lastFocusedElement: ?HTMLElement }>({
     trapFocusInProgress: false,
@@ -126,12 +125,12 @@ const ModalFocusTrap = ({ active, children }: ModalFocusTrapProps) => {
 
   // To be fully compliant with WCAG we need to refocus element that triggered opening modal
   // after closing it
-  useEffect(() => {
+  useEffect(function() {
     if (canUseDOM) {
-      lastFocusedElementOutsideTrap.current = document.activeElement;
-      return () => {
-        if (lastFocusedElementOutsideTrap.current) {
-          UIManager.focus(lastFocusedElementOutsideTrap.current);
+      const lastFocusedElementOutsideTrap = document.activeElement;
+      return function() {
+        if (lastFocusedElementOutsideTrap) {
+          UIManager.focus(lastFocusedElementOutsideTrap);
         }
       };
     }

--- a/packages/react-native-web/src/exports/Modal/ModalFocusTrap.js
+++ b/packages/react-native-web/src/exports/Modal/ModalFocusTrap.js
@@ -129,7 +129,7 @@ const ModalFocusTrap = ({ active, children }: ModalFocusTrapProps) => {
     if (canUseDOM) {
       const lastFocusedElementOutsideTrap = document.activeElement;
       return function() {
-        if (lastFocusedElementOutsideTrap) {
+        if (lastFocusedElementOutsideTrap && document.contains(lastFocusedElementOutsideTrap)) {
           UIManager.focus(lastFocusedElementOutsideTrap);
         }
       };

--- a/packages/react-native-web/src/exports/Modal/__tests__/index.js
+++ b/packages/react-native-web/src/exports/Modal/__tests__/index.js
@@ -280,6 +280,121 @@ describe('components/Modal', () => {
     expect(document.activeElement).toBe(insideElement);
   });
 
+  test('focus is brought back to the element that triggered modal after closing', () => {
+    const { rerender } = render(
+      <>
+        <a data-testid={'outside'} href={'#outside'}>
+          Outside
+        </a>
+        <Modal visible={false}>
+          <a data-testid={'inside'} href={'#hello'}>
+            Hello
+          </a>
+        </Modal>
+        <a data-testid={'modal-trigger'} href={'#modal-trigger'}>
+          Outside
+        </a>
+      </>
+    );
+
+    const modalTrigger = document.querySelector('[data-testid="modal-trigger"]');
+    modalTrigger.focus();
+    expect(document.activeElement).toBe(modalTrigger);
+
+    rerender(
+      <>
+        <a data-testid={'outside'} href={'#outside'}>
+          Outside
+        </a>
+        <Modal visible={true}>
+          <a data-testid={'inside'} href={'#hello'}>
+            Hello
+          </a>
+        </Modal>
+        <a data-testid={'modal-trigger'} href={'#modal-trigger'}>
+          Outside
+        </a>
+      </>
+    );
+
+    const insideElement = document.querySelector('[data-testid="inside"]');
+    expect(document.activeElement).toBe(insideElement);
+
+    rerender(
+      <>
+        <a data-testid={'outside'} href={'#outside'}>
+          Outside
+        </a>
+        <Modal visible={false}>
+          <a data-testid={'inside'} href={'#hello'}>
+            Hello
+          </a>
+        </Modal>
+        <a data-testid={'modal-trigger'} href={'#modal-trigger'}>
+          Outside
+        </a>
+      </>
+    );
+
+    expect(document.activeElement).toBe(modalTrigger);
+  });
+
+  test('focus is brought back to the body when element that triggered modal is removed from the DOM after closing modal', () => {
+    const { rerender } = render(
+      <>
+        <a data-testid={'outside'} href={'#outside'}>
+          Outside
+        </a>
+        <Modal visible={false}>
+          <a data-testid={'inside'} href={'#hello'}>
+            Hello
+          </a>
+        </Modal>
+        <a data-testid={'modal-trigger'} href={'#modal-trigger'}>
+          Outside
+        </a>
+      </>
+    );
+
+    const modalTrigger = document.querySelector('[data-testid="modal-trigger"]');
+    modalTrigger.focus();
+    expect(document.activeElement).toBe(modalTrigger);
+
+    rerender(
+      <>
+        <a data-testid={'outside'} href={'#outside'}>
+          Outside
+        </a>
+        <Modal visible={true}>
+          <a data-testid={'inside'} href={'#hello'}>
+            Hello
+          </a>
+        </Modal>
+        <a data-testid={'modal-trigger'} href={'#modal-trigger'}>
+          Outside
+        </a>
+      </>
+    );
+
+    const insideElement = document.querySelector('[data-testid="inside"]');
+    expect(document.activeElement).toBe(insideElement);
+
+    rerender(
+      <>
+        <a data-testid={'outside'} href={'#outside'}>
+          Outside
+        </a>
+        <Modal visible={false}>
+          <a data-testid={'inside'} href={'#hello'}>
+            Hello
+          </a>
+        </Modal>
+      </>
+    );
+
+    expect(document.activeElement).toBe(document.body);
+  });
+
   test('focus is trapped when active', () => {
     render(
       <>
@@ -418,10 +533,14 @@ describe('components/Modal', () => {
 
     function TestComponent() {
       React.useEffect(() => spy('mount'), []);
-      return <Modal visible={true}><a ref={(ref) => ref ? spy('ref') : spy('noref')} /></Modal>;
+      return (
+        <Modal visible={true}>
+          <a ref={ref => (ref ? spy('ref') : spy('noref'))} />
+        </Modal>
+      );
     }
 
-    render(<TestComponent />)
+    render(<TestComponent />);
 
     expect(spy).toHaveBeenNthCalledWith(1, 'ref');
     expect(spy).toHaveBeenNthCalledWith(2, 'mount');


### PR DESCRIPTION
In a project which I'm part of right now we're working towards compatibility with WCAG spec. When using current implementation of the `<Modal />` component I've seen that you've handled focus trap problem in very clean manner but there's one more thing that I believe that should be implemented to be even more compliant with the spec.

> A Web page implements modal dialogs via scripting. When the trigger button is activated, a dialog opens and focus is set to the first interactive element in the dialog. As long as the dialog is open, focus is limited to the elements of the dialog. **When the dialog is dismissed, focus returns to the button or the element following the button.**

source: https://www.w3.org/WAI/WCAG21/Understanding/focus-order Examples point 3

Right now after closing modal, focus is set to the `<body>` element. User relaying solely on keyboard for navigation now needs to _tab_ his/hers way to the button once more which is frustrating and definitely not a good UX.

This PR is implementing _refocus element that triggered modal after closing it_ mechanism.