### PR TITLE
Fix AccessibilityInfo.addEventListener("reduceMotionChanged", listener)

### DIFF
--- a/packages/react-native-web/src/exports/AccessibilityInfo/index.js
+++ b/packages/react-native-web/src/exports/AccessibilityInfo/index.js
@@ -61,7 +61,13 @@ const AccessibilityInfo = {
       const listener = event => {
         handler(event.matches);
       };
-      prefersReducedMotionMedia.addEventListener('change', listener);
+
+      //Prior to Safari 14, addListener() and removeListener() must be used for MediaQueryList
+      if (prefersReducedMotionMedia.addEventListener) {
+        prefersReducedMotionMedia.addEventListener('change', listener);
+      } else {
+        prefersReducedMotionMedia.addListener(listener);
+      }
       handlers[handler] = listener;
     }
 
@@ -90,7 +96,11 @@ const AccessibilityInfo = {
         return;
       }
 
-      prefersReducedMotionMedia.removeEventListener('change', listener);
+      if (prefersReducedMotionMedia.addEventListener) {
+        prefersReducedMotionMedia.removeEventListener('change', listener);
+      } else {
+        prefersReducedMotionMedia.removeListener(listener);
+      }
     }
 
     return;


### PR DESCRIPTION
`AccessibilityInfo.addEventListener('reduceMotionChanged')` internally uses `MediaQueryList` returned by `window.matchMedia`.
https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList
 addEventListener prop is only available if `MediaQueryList` inherits `EventTarget`, which means for Safari we need to fallback to addListener to prevent crash.

I have received quite a few reports from Sentry indicating this code caused issues on iOS users. React Native Paper and other libraries already rely on this functionality on the web. 
```
  async componentDidMount() {
    AccessibilityInfo.addEventListener(
      'reduceMotionChanged',
      this.updateReduceMotionSettingsInfo
    );
}
```

