### PR TITLE
[fix]: styled-components dynamic benchmark

### DIFF
--- a/packages/benchmarks/src/implementations/styled-components/Dot.js
+++ b/packages/benchmarks/src/implementations/styled-components/Dot.js
@@ -1,16 +1,16 @@
 import styled from 'styled-components';
 import View from './View';
 
-const Dot = styled(View).attrs({
-  style: props => ({
+const Dot = styled(View).attrs(props => ({
+  style: {
     marginLeft: `${props.x}px`,
     marginTop: `${props.y}px`,
     borderRightWidth: `${props.size / 2}px`,
     borderBottomWidth: `${props.size / 2}px`,
     borderLeftWidth: `${props.size / 2}px`,
     borderBottomColor: `${props.color}`
-  })
-})`
+  }
+}))`
   position: absolute;
   cursor: pointer;
   width: 0;


### PR DESCRIPTION
It throws an error during dynamic styles benchmark if function is passed into `styles` attribute. It should be a styles map.