### PR TITLE
[feat]: styled-components/native benchmark

### DIFF
--- a/packages/benchmarks/src/implementations/styled-components-native/Box.js
+++ b/packages/benchmarks/src/implementations/styled-components-native/Box.js
@@ -1,0 +1,31 @@
+import styled from 'styled-components/native';
+import View from './View';
+
+const getColor = color => {
+  switch (color) {
+    case 0:
+      return '#14171A';
+    case 1:
+      return '#AAB8C2';
+    case 2:
+      return '#E6ECF0';
+    case 3:
+      return '#FFAD1F';
+    case 4:
+      return '#F45D22';
+    case 5:
+      return '#E0245E';
+    default:
+      return 'transparent';
+  }
+};
+
+const Box = styled(View)`
+  align-self: flex-start;
+  flex-direction: ${props => (props.layout === 'column' ? 'column' : 'row')};
+  padding: ${props => (props.outer ? '4px' : '0')};
+  ${props => props.fixed && 'height:6px;'} ${props =>
+  props.fixed && 'width:6px;'} background-color: ${props => getColor(props.color)};
+`;
+
+export default Box;

--- a/packages/benchmarks/src/implementations/styled-components-native/Dot.js
+++ b/packages/benchmarks/src/implementations/styled-components-native/Dot.js
@@ -1,0 +1,23 @@
+import styled from 'styled-components/native';
+import View from './View';
+
+const Dot = styled(View).attrs({
+  style: {
+    transform: [{ translateX: '50%' }, { translateY: '50%' }]
+  }
+})`
+  position: absolute;
+  cursor: pointer;
+  width: 0;
+  height: 0;
+  border-color: transparent;
+  border-style: solid;
+  border-top-width: 0;
+  margin-left: ${props => props.x}
+  margin-top: ${props => props.y}
+  border-right-width: ${props => props.size / 2};
+  border-bottom-width: ${props => props.size / 2};
+  border-bottom-color: ${props => props.color};
+`;
+
+export default Dot;

--- a/packages/benchmarks/src/implementations/styled-components-native/Provider.js
+++ b/packages/benchmarks/src/implementations/styled-components-native/Provider.js
@@ -1,0 +1,2 @@
+import View from './View';
+export default View;

--- a/packages/benchmarks/src/implementations/styled-components-native/View.js
+++ b/packages/benchmarks/src/implementations/styled-components-native/View.js
@@ -1,0 +1,19 @@
+import styled from 'styled-components/native';
+
+const View = styled.View`
+  align-items: stretch;
+  border-width: 0;
+  border-style: solid;
+  box-sizing: border-box;
+  display: flex;
+  flex-basis: auto;
+  flex-direction: column;
+  flex-shrink: 0;
+  margin: 0;
+  padding: 0;
+  position: relative;
+  min-height: 0;
+  min-width: 0;
+`;
+
+export default View;

--- a/packages/benchmarks/src/implementations/styled-components-native/index.js
+++ b/packages/benchmarks/src/implementations/styled-components-native/index.js
@@ -1,0 +1,11 @@
+import Box from './Box';
+import Dot from './Dot';
+import Provider from './Provider';
+import View from './View';
+
+export default {
+  Box,
+  Dot,
+  Provider,
+  View
+};


### PR DESCRIPTION
I've implemented a `styled-components/native` benchmark.

Useful to ensure that this approach, despite it's more convenient than using `StyleSheet`, brings a real overhead to web.

![image](https://user-images.githubusercontent.com/5102818/101279154-bb9d2100-37d9-11eb-8b25-1da4d761549b.png)
