### PR TITLE
Add role="switch" in Switch component

### DIFF
--- a/packages/react-native-web/src/exports/Switch/index.js
+++ b/packages/react-native-web/src/exports/Switch/index.js
@@ -116,7 +116,8 @@ const Switch = forwardRef<SwitchProps, *>((props, forwardedRef) => {
     onFocus: handleFocusState,
     ref: forwardedRef,
     style: [styles.nativeControl, styles.cursorInherit],
-    type: 'checkbox'
+    type: 'checkbox',
+    role: "switch"
   });
 
   return (

--- a/packages/react-native-web/src/exports/Switch/index.js
+++ b/packages/react-native-web/src/exports/Switch/index.js
@@ -117,7 +117,7 @@ const Switch = forwardRef<SwitchProps, *>((props, forwardedRef) => {
     ref: forwardedRef,
     style: [styles.nativeControl, styles.cursorInherit],
     type: 'checkbox',
-    role: "switch"
+    role: 'switch'
   });
 
   return (


### PR DESCRIPTION
Issue - #1856 
Putting role="switch" will make screenreader read it as a Switch rather than a checkbox. (Tested on VoiceOver).


https://www.w3.org/TR/wai-aria-1.1/#switch