### PR TITLE
Fix getting the sheet of the styleResolver

### DIFF
--- a/packages/react-native-web/src/exports/StyleSheet/__tests__/createStyleResolver-test.js
+++ b/packages/react-native-web/src/exports/StyleSheet/__tests__/createStyleResolver-test.js
@@ -1,9 +1,11 @@
 /* eslint-env jasmine, jest */
 
+import ExecutionEnvironment from 'fbjs/lib/ExecutionEnvironment';
 import I18nManager from '../../I18nManager';
 import ReactNativePropRegistry from '../ReactNativePropRegistry';
 import createStyleResolver from '../createStyleResolver';
 
+const canUseDOM = ExecutionEnvironment.canUseDOM;
 let styleResolver;
 
 describe('StyleSheet/createStyleResolver', () => {
@@ -73,6 +75,25 @@ describe('StyleSheet/createStyleResolver', () => {
 
     test('resolves inline-style pointerEvents to classname', () => {
       expect(styleResolver.resolve({ pointerEvents: 'box-none' })).toMatchSnapshot();
+    });
+
+    describe('sheet', () => {
+      beforeEach(() => {
+        ExecutionEnvironment.canUseDOM = false;
+      });
+
+      afterEach(() => {
+        ExecutionEnvironment.canUseDOM = canUseDOM;
+      });
+
+      test('returns the new sheet once re-initialized', () => {
+        const sheet = styleResolver.sheet;
+
+        // re-initialize the sheet
+        styleResolver.getStyleSheet();
+
+        expect(styleResolver.sheet).not.toBe(sheet);
+      });
     });
   });
 });

--- a/packages/react-native-web/src/exports/StyleSheet/createStyleResolver.js
+++ b/packages/react-native-web/src/exports/StyleSheet/createStyleResolver.js
@@ -237,7 +237,9 @@ export default function createStyleResolver() {
       return result;
     },
     resolve,
-    sheet
+    get sheet() {
+      return sheet;
+    }
   };
 }
 


### PR DESCRIPTION
Without a getter, an outdated version of `sheet` is returned after `getStyleSheet` is called
as shown in this small reproducible example:

```js
function createObject() {
  let ref
  let i = 1
  function init() {
    ref = {
      id: i++
    }
  }
  init()
  return {
    ref,
    getContent() {
      const content = ref.id
      init()
      return content
    }
  }
}
var object = createObject()
object.ref // {id: 1}
object.getContent() // 1

object.ref // {id: 1}
object.getContent() // 2
```