### PR TITLE
[fix] Fordward classList to DOM elements

### DIFF
--- a/packages/react-native-web/src/exports/Text/index.js
+++ b/packages/react-native-web/src/exports/Text/index.js
@@ -147,7 +147,9 @@ const Text = forwardRef<TextProps, *>((props, forwardedRef) => {
 
   const component = hasTextAncestor ? 'span' : 'div';
   const supportedProps = pickProps(props);
-  supportedProps.classList = classList;
+  supportedProps.classList = supportedProps.classList
+    ? supportedProps.classList.concat(classList)
+    : classList;
   supportedProps.dir = dir;
   // 'auto' by default allows browsers to infer writing direction (root elements only)
   if (!hasTextAncestor) {

--- a/packages/react-native-web/src/exports/TextInput/index.js
+++ b/packages/react-native-web/src/exports/TextInput/index.js
@@ -358,7 +358,9 @@ const TextInput = forwardRef<TextInputProps, *>((props, forwardedRef) => {
   supportedProps.autoCapitalize = autoCapitalize;
   supportedProps.autoComplete = autoComplete || autoCompleteType || 'on';
   supportedProps.autoCorrect = autoCorrect ? 'on' : 'off';
-  supportedProps.classList = classList;
+  supportedProps.classList = supportedProps.classList
+    ? supportedProps.classList.concat(classList)
+    : classList;
   // 'auto' by default allows browsers to infer writing direction
   supportedProps.dir = dir !== undefined ? dir : 'auto';
   supportedProps.enterkeyhint = returnKeyType;

--- a/packages/react-native-web/src/exports/View/index.js
+++ b/packages/react-native-web/src/exports/View/index.js
@@ -129,7 +129,9 @@ const View = forwardRef<ViewProps, *>((props, forwardedRef) => {
   );
 
   const supportedProps = pickProps(props);
-  supportedProps.classList = classList;
+  supportedProps.classList = supportedProps.classList
+    ? supportedProps.classList.concat(classList)
+    : classList;
   supportedProps.style = style;
 
   const platformMethodsRef = usePlatformMethods(supportedProps);


### PR DESCRIPTION
This changes it so that the `classList` generated in `View`, `Text` and `TextInput` are appended to any existing classList from the props.

Close: #1881