### PR TITLE
feat: enabling ReactPackage as an export from React Native fo…

### DIFF
--- a/packages/babel-plugin-react-native-web/src/moduleMap.js
+++ b/packages/babel-plugin-react-native-web/src/moduleMap.js
@@ -37,6 +37,7 @@ module.exports = {
   Platform: true,
   Pressable: true,
   ProgressBar: true,
+  ReactPackage: true,
   RefreshControl: true,
   SafeAreaView: true,
   ScrollView: true,

--- a/packages/react-native-web/src/exports/NativeModuleRegistry/index.js
+++ b/packages/react-native-web/src/exports/NativeModuleRegistry/index.js
@@ -20,7 +20,7 @@ class NativeModulesRegistry {
    * instances of modules and not just the class
    */
   registerNativeModules(nativeModulesToRegister) {
-    nativeModulesToRegister.map((module) => {
+    nativeModulesToRegister.map(module => {
       const nativeModuleName = module.getName();
       if (!this.nativeModules[nativeModuleName]) {
         throw new Error(`Native Module with name ${nativeModuleName} is duplicated`);
@@ -28,7 +28,7 @@ class NativeModulesRegistry {
       Object.defineProperty(this.nativeModules, nativeModuleName, {
         get: () => {
           return module;
-        },
+        }
       });
     });
   }

--- a/packages/react-native-web/src/exports/NativeModuleRegistry/index.js
+++ b/packages/react-native-web/src/exports/NativeModuleRegistry/index.js
@@ -1,0 +1,38 @@
+/**
+ * The registry will be exported from React Native for Web to allow library users to
+ * register nativeModules which are then available out NativeModules namespace in React Native
+ * This needs to be called before the Native Module has been accessed. We can minimise the registration to
+ * initial setup time to save polluting the namespace all too frequently
+ * but if we don't, we can support dynamic registration of native modules, which goes in line with the new
+ * JSI/Fabric/Turbo Modules architecture decisions
+ */
+class NativeModulesRegistry {
+  constructor() {
+    this.nativeModules = {};
+  }
+
+  /**
+   *
+   * @param {Array} nativeModulesToRegister
+   * this function takes in modules as an array and defines it under the name(which is accessible using getName method of the module)
+   * in the this.nativeModules map. this map is then exposed for the NativeModule exports to use and export
+   * This assumes that the module passed to register will have a getName() method, which means that we will be sending array of
+   * instances of modules and not just the class
+   */
+  registerNativeModules(nativeModulesToRegister) {
+    nativeModulesToRegister.map((module) => {
+      const nativeModuleName = module.getName();
+      if (!this.nativeModules[nativeModuleName]) {
+        throw new Error(`Native Module with name ${nativeModuleName} is duplicated`);
+      }
+      Object.defineProperty(this.nativeModules, nativeModuleName, {
+        get: () => {
+          return module;
+        },
+      });
+    });
+  }
+}
+
+export const nativeModulesRegistry = new NativeModulesRegistry();
+export default nativeModulesRegistry.registerNativeModules.bind(nativeModulesRegistry);

--- a/packages/react-native-web/src/exports/NativeModules/index.js
+++ b/packages/react-native-web/src/exports/NativeModules/index.js
@@ -8,10 +8,10 @@
  */
 
 import UIManager from '../UIManager';
-
-// NativeModules shim
+import { nativeModulesRegistry } from './../NativeModuleRegistry';
 const NativeModules = {
-  UIManager
+  ...nativeModulesRegistry.nativeModules,
+  UIManager,
 };
 
 export default NativeModules;

--- a/packages/react-native-web/src/exports/NativeModules/index.js
+++ b/packages/react-native-web/src/exports/NativeModules/index.js
@@ -8,9 +8,9 @@
  */
 
 import UIManager from '../UIManager';
-import { nativeModulesRegistry } from './../NativeModuleRegistry';
+import { ReactPackageRegistry } from '../ReactPackage';
 const NativeModules = {
-  ...nativeModulesRegistry.nativeModules,
+  ...ReactPackageRegistry.nativeModules,
   UIManager
 };
 

--- a/packages/react-native-web/src/exports/NativeModules/index.js
+++ b/packages/react-native-web/src/exports/NativeModules/index.js
@@ -11,7 +11,7 @@ import UIManager from '../UIManager';
 import { nativeModulesRegistry } from './../NativeModuleRegistry';
 const NativeModules = {
   ...nativeModulesRegistry.nativeModules,
-  UIManager,
+  UIManager
 };
 
 export default NativeModules;

--- a/packages/react-native-web/src/exports/ReactPackage/index.js
+++ b/packages/react-native-web/src/exports/ReactPackage/index.js
@@ -6,7 +6,7 @@
  * but if we don't, we can support dynamic registration of native modules, which goes in line with the new
  * JSI/Fabric/Turbo Modules architecture decisions
  */
-class NativeModulesRegistry {
+class ReactPackage {
   constructor() {
     this.nativeModules = {};
   }
@@ -34,5 +34,5 @@ class NativeModulesRegistry {
   }
 }
 
-export const nativeModulesRegistry = new NativeModulesRegistry();
-export default nativeModulesRegistry.registerNativeModules.bind(nativeModulesRegistry);
+export const ReactPackageRegistry = new ReactPackage();
+export default ReactPackageRegistry.registerNativeModules.bind(ReactPackageRegistry);

--- a/packages/react-native-web/src/index.js
+++ b/packages/react-native-web/src/index.js
@@ -23,6 +23,7 @@ export { default as InteractionManager } from './exports/InteractionManager';
 export { default as LayoutAnimation } from './exports/LayoutAnimation';
 export { default as Linking } from './exports/Linking';
 export { default as NativeEventEmitter } from './exports/NativeEventEmitter';
+export { default as NativeModuleRegistry } from './exports/NativeModuleRegistry';
 export { default as PanResponder } from './exports/PanResponder';
 export { default as PixelRatio } from './exports/PixelRatio';
 export { default as Platform } from './exports/Platform';

--- a/packages/react-native-web/src/index.js
+++ b/packages/react-native-web/src/index.js
@@ -23,7 +23,7 @@ export { default as InteractionManager } from './exports/InteractionManager';
 export { default as LayoutAnimation } from './exports/LayoutAnimation';
 export { default as Linking } from './exports/Linking';
 export { default as NativeEventEmitter } from './exports/NativeEventEmitter';
-export { default as NativeModuleRegistry } from './exports/NativeModuleRegistry';
+export { default as ReactPackage } from './exports/ReactPackage';
 export { default as PanResponder } from './exports/PanResponder';
 export { default as PixelRatio } from './exports/PixelRatio';
 export { default as Platform } from './exports/Platform';


### PR DESCRIPTION
…r Web to allow developers to register instances of their native modules to then be available for use across the app under the Native Module import

this change is, however, far from complete and just introduces one layer of change to get an understanding from the community as to how they view this and then take it forward from there. similar work can be done to get instances for components and run requireNativeComponent as well.

initial draft for [adding native module support to rnw](https://github.com/necolas/react-native-web/issues/1785)