### PR TITLE
Update AppState documentation to match RN 0.63

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -71,7 +71,7 @@ yarn compile --watch
 To run the documentation website:
 
 ```
-yarn docs:dev
+yarn docs
 ```
 
 ## Examples
@@ -79,7 +79,7 @@ yarn docs:dev
 To run the examples app:
 
 ```
-yarn examples:dev
+yarn examples
 ```
 
 When you're also making changes to the 'react-native-web' source files, run this command in another process:
@@ -93,7 +93,7 @@ yarn compile --watch
 To run the benchmarks locally:
 
 ```
-yarn benchmarks:dev
+yarn benchmarks
 open ./packages/benchmarks/dist/index.html
 ```
 

--- a/packages/examples/pages/app-state/index.js
+++ b/packages/examples/pages/app-state/index.js
@@ -3,10 +3,11 @@ import { AppState, Text } from 'react-native';
 import Example from '../../shared/example';
 
 export default function AppStatePage() {
+  const appState = React.useRef(AppState.currentState);
   const [state, setState] = React.useState({
     active: 0,
     background: 0,
-    currentState: AppState.currentState
+    currentState: appState.current
   });
 
   React.useEffect(() => {


### PR DESCRIPTION
To fix this issue: [App state does not show state going from 'background' to 'active'](https://github.com/facebook/react-native/issues/29218) that affect at least RN 0.62.2 and up.

The documentation was updated with a workaround: https://reactnative.dev/docs/appstate from 0.63

Was added:
`const appState = useRef(AppState.currentState);`
