### PR TITLE
[fix] Documentation footer link

### DIFF
--- a/packages/docs/src/includes/fragments/footer.html
+++ b/packages/docs/src/includes/fragments/footer.html
@@ -6,7 +6,7 @@
   {% endif %}
 
   <div class="text text-sm text-color-faint">
-    <a class="no-underline" href="/">{{ site.name }}</a> –
+    <a class="no-underline" href="{{ "/" | url }}">{{ site.name }}</a> –
     {% if site.footer %}
       <span>{{ site.footer | safe }}</span>
     {% endif %}


### PR DESCRIPTION
Leverage Eleventy's [`url` filter](https://www.11ty.dev/docs/filters/url/) so that the `pathPrefix` is applied to
the footer link. Previously navigating to the footer link resulted in a
404 because the documentation site is deployed to a subdirectory on
GitHub Pages.
