### PR TITLE
Pass target unmodified

### DIFF
--- a/packages/react-native-web/src/exports/View/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/View/__tests__/index-test.js
@@ -110,7 +110,7 @@ describe('components/View', () => {
       const hrefAttrs = {
         download: 'filename.jpg',
         rel: 'nofollow',
-        target: 'blank'
+        target: '_blank'
       };
       const { container } = render(<View href="https://example.com" hrefAttrs={hrefAttrs} />);
       expect(container.firstChild).toMatchSnapshot();

--- a/packages/react-native-web/src/exports/View/index.js
+++ b/packages/react-native-web/src/exports/View/index.js
@@ -107,8 +107,8 @@ const View = forwardRef<ViewProps, *>((props, forwardedRef) => {
     if (rel != null) {
       supportedProps.rel = rel;
     }
-    if (typeof target === 'string' && target.charAt(0) !== '_') {
-      supportedProps.target = '_' + target;
+    if (target != null) {
+      supportedProps.target = target;
     }
   }
 


### PR DESCRIPTION
I'm not sure why the target attribute is handled in this special way but I think it's causing confusion since it's different than the normal browser behavior. Moreover, if you pass `hrefAttrs={{ target: '_blank' }}`, it doesn't pass the `if` and isn't set at all. Since the browser allows any string (which would use an existing window if opened repeatedly with the same target name), or the special `_self`, `_parent`, `_root`, and `_blank`, I think it's best to just pass it unmodified.