### PR TITLE
Add support for "menuitemcheckbox" and "menuitemradio" roles

### DIFF
--- a/packages/react-native-web/src/modules/AccessibilityUtil/buttonLikeRoles.js
+++ b/packages/react-native-web/src/modules/AccessibilityUtil/buttonLikeRoles.js
@@ -13,7 +13,13 @@ const buttonLikeRoles: { [string]: boolean } = {
   // ARIA menuitem responds to Enter/Space like a button. Spec requires AT to
   // ignore ARIA roles of any children.
   // https://www.w3.org/WAI/GL/wiki/Using_ARIA_menus
-  menuitem: true
+  menuitem: true,
+  menuitemcheckbox: true,
+  menuitemradio: true
 };
 
 export default buttonLikeRoles;
+
+export function isButtonLikeRole(role: string) {
+  return !!buttonLikeRoles[role];
+}

--- a/packages/react-native-web/src/modules/AccessibilityUtil/index.js
+++ b/packages/react-native-web/src/modules/AccessibilityUtil/index.js
@@ -7,13 +7,14 @@
  * @flow
  */
 
-import buttonLikeRoles from './buttonLikeRoles';
+import buttonLikeRoles, { isButtonLikeRole } from './buttonLikeRoles';
 import isDisabled from './isDisabled';
 import propsToAccessibilityComponent from './propsToAccessibilityComponent';
 import propsToAriaRole from './propsToAriaRole';
 
 const AccessibilityUtil = {
   buttonLikeRoles,
+  isButtonLikeRole,
   isDisabled,
   propsToAccessibilityComponent,
   propsToAriaRole

--- a/packages/react-native-web/src/modules/createDOMProps/__tests__/index-test.js
+++ b/packages/react-native-web/src/modules/createDOMProps/__tests__/index-test.js
@@ -84,6 +84,14 @@ describe('modules/createDOMProps', () => {
       testFocusableRole('menuitem');
     });
 
+    describe('"accessibilityRole" of "menuitemcheckbox"', () => {
+      testFocusableRole('menuitemcheckbox');
+    });
+
+    describe('"accessibilityRole" of "menuitemradio"', () => {
+      testFocusableRole('menuitemradio');
+    });
+
     describe('with unfocusable accessibilityRole', () => {
       test('when "focusable" is true', () => {
         expect(createProps({ focusable: true })).toEqual(
@@ -115,6 +123,8 @@ describe('modules/createDOMProps', () => {
       expect(callsOnClick('div', 'button')).toBe(true);
       expect(callsOnClick('div', 'textbox')).toBe(true);
       expect(callsOnClick('div', 'menuitem')).toBe(true);
+      expect(callsOnClick('div', 'menuitemcheckbox')).toBe(true);
+      expect(callsOnClick('div', 'menuitemradio')).toBe(true);
       expect(callsOnClick('div', 'bogus')).toBe(true);
       expect(callsOnClick('a')).toBe(true);
       expect(callsOnClick('button')).toBe(true);
@@ -128,6 +138,8 @@ describe('modules/createDOMProps', () => {
       expect(callsOnClick('div', 'link', true)).toBe(false);
       expect(callsOnClick('div', 'button', true)).toBe(false);
       expect(callsOnClick('div', 'menuitem', true)).toBe(false);
+      expect(callsOnClick('div', 'menuitemcheckbox', true)).toBe(false);
+      expect(callsOnClick('div', 'menuitemradio', true)).toBe(false);
       expect(callsOnClick('a', undefined, true)).toBe(false);
       expect(callsOnClick('button', undefined, true)).toBe(false);
       expect(callsOnClick('input', undefined, true)).toBe(false);
@@ -165,6 +177,8 @@ describe('modules/createDOMProps', () => {
       expect(respondsToEnter('div', 'button', true)).toBe(false);
       expect(respondsToEnter('div', 'textbox', true)).toBe(false);
       expect(respondsToEnter('div', 'menuitem', true)).toBe(false);
+      expect(respondsToEnter('div', 'menuitemcheckbox', true)).toBe(false);
+      expect(respondsToEnter('div', 'menuitemradio', true)).toBe(false);
       expect(respondsToEnter('div', 'bogus', true)).toBe(false);
     });
 
@@ -189,6 +203,8 @@ describe('modules/createDOMProps', () => {
     test('emulates "onClick" for "Enter" for certain roles', () => {
       expect(respondsToEnter('div', 'button')).toBe(true);
       expect(respondsToEnter('div', 'menuitem')).toBe(true);
+      expect(respondsToEnter('div', 'menuitemcheckbox')).toBe(true);
+      expect(respondsToEnter('div', 'menuitemradio')).toBe(true);
       expect(respondsToEnter('div', 'textbox')).toBe(false);
       expect(respondsToEnter('div', 'bogus')).toBe(false);
     });

--- a/packages/react-native-web/src/modules/createDOMProps/index.js
+++ b/packages/react-native-web/src/modules/createDOMProps/index.js
@@ -355,6 +355,8 @@ const createDOMProps = (elementType, props) => {
     role === 'checkbox' ||
     role === 'link' ||
     role === 'menuitem' ||
+    role === 'menuitemcheckbox' ||
+    role === 'menuitemradio' ||
     role === 'radio' ||
     role === 'textbox' ||
     role === 'switch'
@@ -412,8 +414,7 @@ const createDOMProps = (elementType, props) => {
   // Button-like roles should not trigger 'onClick' if they are disabled.
   if (
     isNativeInteractiveElement ||
-    role === 'button' ||
-    role === 'menuitem' ||
+    AccessibilityUtil.isButtonLikeRole(role) ||
     (_focusable === true && !disabled)
   ) {
     const onClick = domProps.onClick;
@@ -430,7 +431,7 @@ const createDOMProps = (elementType, props) => {
         domProps.onKeyDown = function (e) {
           const { key, repeat } = e;
           const isSpacebarKey = key === ' ' || key === 'Spacebar';
-          const isButtonRole = role === 'button' || role === 'menuitem';
+          const isButtonRole = AccessibilityUtil.isButtonLikeRole(role);
           if (onKeyDown != null) {
             onKeyDown(e);
           }

--- a/packages/react-native-web/src/modules/usePressEvents/PressResponder.js
+++ b/packages/react-native-web/src/modules/usePressEvents/PressResponder.js
@@ -10,6 +10,8 @@
 
 'use strict';
 
+import AccessibilityUtil from '../AccessibilityUtil';
+
 type ClickEvent = any;
 type KeyboardEvent = any;
 type ResponderEvent = any;
@@ -135,7 +137,7 @@ const isValidKeyPress = (event) => {
   const role = target.getAttribute('role');
   const isSpacebar = key === ' ' || key === 'Spacebar';
   return (
-    !event.repeat && (key === 'Enter' || (isSpacebar && (role === 'button' || role === 'menuitem')))
+    !event.repeat && (key === 'Enter' || (isSpacebar && AccessibilityUtil.isButtonLikeRole(role)))
   );
 };
 


### PR DESCRIPTION
### Issue

I noticed `accessibilityRole="menuitem"` provides _button_ like behavior — e.g. becomes focusable, is clicked when focused and <kbd>space</kbd> is pressed, ignores click events when disabled — but the same treatment isn't applied when the role is set to `menuitemcheckbox` or `menuitemradio`. Given the example in a [W3C wiki for ARIA menus](https://www.w3.org/WAI/GL/wiki/Using_ARIA_menus), the `menuitemcheckbox` and `menuitemradio` roles behave similarly to `menuitem`; i.e. as a _button_.

### Solution

Anywhere `menuitem` is given special treatment, do the same for `menuitemcheckbox` and `menuitemradio`.