### PR TITLE
Add support for onKeyDown to Pressable.

### DIFF
--- a/packages/react-native-web/src/exports/Pressable/index.js
+++ b/packages/react-native-web/src/exports/Pressable/index.js
@@ -86,6 +86,7 @@ function Pressable(props: Props, forwardedRef): React.Node {
     onPressMove,
     onPressIn,
     onPressOut,
+    onKeyDown,
     style,
     testOnly_hovered,
     testOnly_pressed,
@@ -110,7 +111,8 @@ function Pressable(props: Props, forwardedRef): React.Node {
       onPressChange: setPressed,
       onPressStart: onPressIn,
       onPressMove,
-      onPressEnd: onPressOut
+      onPressEnd: onPressOut,
+      onKeyDown
     }),
     [
       delayLongPress,
@@ -122,6 +124,7 @@ function Pressable(props: Props, forwardedRef): React.Node {
       onPressIn,
       onPressMove,
       onPressOut,
+      onKeyDown,
       setPressed
     ]
   );

--- a/packages/react-native-web/src/modules/usePressEvents/PressResponder.js
+++ b/packages/react-native-web/src/modules/usePressEvents/PressResponder.js
@@ -38,7 +38,9 @@ export type PressResponderConfig = $ReadOnly<{|
   // Called when the press location moves. (This should rarely be used.)
   onPressMove?: ?(event: ResponderEvent) => void,
   // Called when the press is deactivated to undo visual feedback.
-  onPressEnd?: ?(event: ResponderEvent) => void
+  onPressEnd?: ?(event: ResponderEvent) => void,
+  // Called when a key is pressed.
+  onKeyDown?: ?(event: KeyboardEvent) => void
 |}>;
 
 export type EventHandlers = $ReadOnly<{|
@@ -321,6 +323,9 @@ export default class PressResponder {
       },
 
       onKeyDown: (event) => {
+        if (this._config.onKeyDown != null) {
+          this._config.onKeyDown(event);
+        }
         if (isValidKeyPress(event)) {
           if (this._touchState === NOT_RESPONDER) {
             start(event, false);


### PR DESCRIPTION
This will always call the Pressable's onKeyDown when onKeyDown fires.

Fixes #1950.