### PR TITLE
Flow (1/N): Update flow to 0.142

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,7 @@
     "react": {
       "pragma": "React",
       "version": "16.6",
-      "flowVersion": "0.109.0" // Flow version
+      "flowVersion": "0.142.0" // Flow version
     }
   },
   // babel parser to support ES6/7 features

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,5 @@
 [version]
-^0.109.0
+^0.142.0
 
 [ignore]
 <PROJECT_ROOT>/.*/__tests__/.*
@@ -15,7 +15,9 @@
 <PROJECT_ROOT>/types
 
 [options]
-
+munge_underscores=true
+types_first=false
+well_formed_exports=false
 suppress_type=$FlowIssue
 suppress_type=$FlowFixMe
 suppress_type=$FlowFixMeProps

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-react": "^7.22.0",
     "eslint-plugin-react-hooks": "^4.2.0",
-    "flow-bin": "^0.109.0",
+    "flow-bin": "^0.142.0",
     "glob": "^7.1.6",
     "husky": "^4.3.8",
     "inline-style-prefixer": "^6.0.0",

--- a/packages/react-native-web/src/exports/Picker/index.js
+++ b/packages/react-native-web/src/exports/Picker/index.js
@@ -14,18 +14,18 @@ import createElement from '../createElement';
 import useMergeRefs from '../../modules/useMergeRefs';
 import usePlatformMethods from '../../modules/usePlatformMethods';
 import PickerItem from './PickerItem';
-import StyleSheet, { type StyleObj } from '../StyleSheet';
+import StyleSheet from '../StyleSheet';
 import { forwardRef, useRef } from 'react';
 
 type PickerProps = {
   ...ViewProps,
-  children?: PickerItem | Array<typeof PickerItem>,
+  children?: typeof PickerItem | Array<typeof PickerItem>,
   enabled?: boolean,
   onValueChange?: (number | string, number) => void,
   selectedValue?: number | string,
-  style?: StyleObj,
+  style?: any,
   /* compat */
-  itemStyle?: StyleObj,
+  itemStyle?: any,
   mode?: string,
   prompt?: string
 };
@@ -55,6 +55,7 @@ const Picker = forwardRef<PickerProps, *>((props, forwardedRef) => {
     }
   }
 
+  // $FlowFixMe ViewProps should be exact in the future
   const supportedProps: any = {
     children,
     disabled: enabled === false ? true : undefined,

--- a/packages/react-native-web/src/exports/StyleSheet/compile.js
+++ b/packages/react-native-web/src/exports/StyleSheet/compile.js
@@ -99,7 +99,7 @@ export function classic(style: Style, name: string): CompilerOutput {
  * Compile simple style object to inline DOM styles.
  * No support for 'animationKeyframes', 'placeholderTextColor', 'scrollbarWidth', or 'pointerEvents'.
  */
-export function inline(style: Style) {
+export function inline(style: Style): any {
   return prefixInlineStyles(createReactDOMStyle(style));
 }
 
@@ -107,7 +107,7 @@ export function inline(style: Style) {
  * Create a value string that normalizes different input values with a common
  * output.
  */
-export function stringifyValueWithProperty(value: Value, property: ?string) {
+export function stringifyValueWithProperty(value: Value, property: ?string): string {
   // e.g., 0 => '0px', 'black' => 'rgba(0,0,0,1)'
   const normalizedValue = normalizeValueWithProperty(value, property);
   return typeof normalizedValue !== 'string'
@@ -152,17 +152,17 @@ function createAtomicRules(identifier: string, property, value): Rules {
       if (value === 'auto' || value === 'box-only') {
         finalValue = 'auto!important';
         if (value === 'box-only') {
-          const block = createDeclarationBlock({ [property]: 'none' });
+          const block = createDeclarationBlock({ pointerEvents: 'none' });
           rules.push(`${selector}>*${block}`);
         }
       } else if (value === 'none' || value === 'box-none') {
         finalValue = 'none!important';
         if (value === 'box-none') {
-          const block = createDeclarationBlock({ [property]: 'auto' });
+          const block = createDeclarationBlock({ pointerEvents: 'auto' });
           rules.push(`${selector}>*${block}`);
         }
       }
-      const block = createDeclarationBlock({ [property]: finalValue });
+      const block = createDeclarationBlock({ pointerEvents: finalValue });
       rules.push(`${selector}${block}`);
       break;
     }
@@ -173,7 +173,7 @@ function createAtomicRules(identifier: string, property, value): Rules {
       if (value === 'none') {
         rules.push(`${selector}::-webkit-scrollbar{display:none}`);
       }
-      const block = createDeclarationBlock({ [property]: value });
+      const block = createDeclarationBlock({ scrollbarWidth: value });
       rules.push(`${selector}${block}`);
       break;
     }
@@ -218,7 +218,7 @@ function createDeclarationBlock(style: Style) {
 /**
  * An identifier is associated with a unique set of styles.
  */
-function createIdentifier(prefix, name, value) {
+function createIdentifier(prefix: string, name: string, value): string {
   const hashedString = hash(name + stringifyValueWithProperty(value, name));
   return process.env.NODE_ENV !== 'production'
     ? `${prefix}-${name}-${hashedString}`

--- a/packages/react-native-web/src/exports/StyleSheet/createOrderedCSSStyleSheet.js
+++ b/packages/react-native-web/src/exports/StyleSheet/createOrderedCSSStyleSheet.js
@@ -72,7 +72,7 @@ export default function createOrderedCSSStyleSheet(sheet: ?CSSStyleSheet) {
       // Increment the starting index of all subsequent groups
       for (let i = nextGroupIndex; i < orderedGroups.length; i += 1) {
         const groupNumber = orderedGroups[i];
-        const previousStart = groups[groupNumber].start;
+        const previousStart = groups[groupNumber].start || 0;
         groups[groupNumber].start = previousStart + 1;
       }
     }

--- a/packages/react-native-web/src/modules/useStable/index.js
+++ b/packages/react-native-web/src/modules/useStable/index.js
@@ -9,9 +9,7 @@
 
 import * as React from 'react';
 
-opaque type UninitializedMarker = Symbol | {||};
-
-const UNINITIALIZED: UninitializedMarker =
+const UNINITIALIZED =
   typeof Symbol === 'function' && typeof Symbol() === 'symbol' ? Symbol() : Object.freeze({});
 
 export default function useStable<T>(getInitialValue: () => T): T {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5321,10 +5321,10 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.1.tgz#c4b489e80096d9df1dfc97c79871aea7c617c469"
   integrity sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==
 
-flow-bin@^0.109.0:
-  version "0.109.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.109.0.tgz"
-  integrity sha512-tpcMTpAGIRivYhFV3KJq+zHI2HzcXo8MoGe9pXS4G/UZuey2Faq/e8/gdph2WF0erRlML5hmwfwiq7v9c25c7w==
+flow-bin@^0.142.0:
+  version "0.142.0"
+  resolved "https://registry.npmjs.org/flow-bin/-/flow-bin-0.142.0.tgz#b46b69de1123cf7c5a50917402968e07291df054"
+  integrity sha512-YgiapK/wrJjcgSgOWfoncbZ4vZrZWdHs+p7V9duI9zo4ehW2nM/VRrpSaWoZ+CWu3t+duGyAvupJvC6MM2l07w==
 
 follow-redirects@^1.0.0, follow-redirects@^1.10.0:
   version "1.13.1"


### PR DESCRIPTION
Goal is to update flow and implements types first, fixing issues as I go. This is an attempt at rewriting #1940 via stacked reviews.

In this review, I update to the maximum flow version which still allows disabling of various checks. This also fixes a few issues found in the intervening versions. Some previously missed nulls or missing types.

IMPORTANT: This branch itself is not shippable since it reveals a bunch of issues in vendored items. Please see part 2 for the first shippable unit. This is broken out to make it easier to connect logical work increments to code.
