### PR TITLE
Fix incorrect Pressable link in docs

### DIFF
--- a/packages/docs/src/pages/docs/components/touchables.md
+++ b/packages/docs/src/pages/docs/components/touchables.md
@@ -21,5 +21,5 @@ Please refer to the React Native documentation below:
 * [TouchableWithoutFeedback](https://reactnative.dev/docs/touchablewithoutfeedback)
 
 :::callout
-**Did you know?** The [Pressable]({{ '/docs/pressable' }}) component is a more accessible, flexible, and future-proof way to handle tap and click interactions with React Native.
+**Did you know?** The [Pressable]({{ '/docs/pressable' | url }}) component is a more accessible, flexible, and future-proof way to handle tap and click interactions with React Native.
 :::


### PR DESCRIPTION
**Touchables** "Did you know" section has incorrect link. It redirects to 404 page instead of **Pressable** docs.

Current: "/docs/pressable"
Fix: "/react-native-web/docs/pressable"