### PR TITLE
fix: View HrefAttrs.target handling should match Text

### DIFF
--- a/packages/react-native-web/src/exports/View/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/View/__tests__/index-test.js
@@ -118,7 +118,7 @@ describe('components/View', () => {
 
     test('target variant is set', () => {
       const hrefAttrs = {
-        target: 'blank'
+        target: '_blank'
       };
       const { container } = render(<View href="https://example.com" hrefAttrs={hrefAttrs} />);
       expect(container.firstChild).toMatchSnapshot();

--- a/packages/react-native-web/src/exports/View/index.js
+++ b/packages/react-native-web/src/exports/View/index.js
@@ -107,8 +107,8 @@ const View = forwardRef<ViewProps, *>((props, forwardedRef) => {
     if (rel != null) {
       supportedProps.rel = rel;
     }
-    if (typeof target === 'string' && target.charAt(0) !== '_') {
-      supportedProps.target = '_' + target;
+    if (typeof target === 'string') {
+      supportedProps.target = target.charAt(0) !== '_' ? '_' + target : target;
     }
   }
 


### PR DESCRIPTION
**Problem**
In the fix for #1937, (https://github.com/necolas/react-native-web/commit/71f1e9bf3a82194a5db4a5ff90f8aaaa085a1fea#) the PR fixed Text to allow for `_blank` to be passed in addition to `blank`. But this change and test update didn't get correctly updated in `View`

**Solution**
Copy-pasta to `View`