### PR TITLE
Flow 0.142 (4/N): Update View ref type; Fix forwardRefs in other components

### DIFF
--- a/packages/react-native-web/src/exports/ActivityIndicator/index.js
+++ b/packages/react-native-web/src/exports/ActivityIndicator/index.js
@@ -8,6 +8,7 @@
  * @flow
  */
 
+import type { ElementRef, AbstractComponent } from 'react';
 import type { ViewProps } from '../View';
 
 import StyleSheet from '../StyleSheet';
@@ -28,7 +29,10 @@ type ActivityIndicatorProps = {
   size?: 'small' | 'large' | number
 };
 
-const ActivityIndicator = forwardRef<ActivityIndicatorProps, *>((props, forwardedRef) => {
+const ActivityIndicator: AbstractComponent<
+  ActivityIndicatorProps,
+  ElementRef<typeof View>
+> = forwardRef((props, forwardedRef) => {
   const {
     animating = true,
     color = '#1976D2',

--- a/packages/react-native-web/src/exports/Button/index.js
+++ b/packages/react-native-web/src/exports/Button/index.js
@@ -22,7 +22,10 @@ type ButtonProps = {|
   title: string
 |};
 
-const Button = React.forwardRef<ButtonProps, *>((props, forwardedRef) => {
+const Button: React.AbstractComponent<
+  ButtonProps,
+  React.ElementRef<typeof TouchableOpacity>
+> = React.forwardRef((props, forwardedRef) => {
   const { accessibilityLabel, color, disabled, onPress, testID, title } = props;
 
   return (

--- a/packages/react-native-web/src/exports/CheckBox/index.js
+++ b/packages/react-native-web/src/exports/CheckBox/index.js
@@ -12,7 +12,6 @@ import type { ColorValue } from '../../types';
 import type { ViewProps } from '../View';
 
 import * as React from 'react';
-import { forwardRef } from 'react';
 import createElement from '../createElement';
 import StyleSheet from '../StyleSheet';
 import View from '../View';
@@ -26,7 +25,10 @@ type CheckBoxProps = {
   value?: boolean
 };
 
-const CheckBox = forwardRef<CheckBoxProps, *>((props, forwardedRef) => {
+const CheckBox: React.AbstractComponent<
+  CheckBoxProps,
+  React.ElementRef<typeof View>
+> = React.forwardRef((props, forwardedRef) => {
   const { color, disabled, onChange, onValueChange, style, value, ...other } = props;
 
   function handleChange(event: Object) {

--- a/packages/react-native-web/src/exports/Image/index.js
+++ b/packages/react-native-web/src/exports/Image/index.js
@@ -8,6 +8,7 @@
  * @flow
  */
 
+import type { AbstractComponent, ElementRef } from 'react';
 import type { ImageProps } from './types';
 
 import createElement from '../createElement';
@@ -132,7 +133,7 @@ function resolveAssetUri(source): ?string {
   return uri;
 }
 
-const Image = forwardRef<ImageProps, *>((props, ref) => {
+const Image: AbstractComponent<ImageProps, ElementRef<typeof View>> = forwardRef((props, ref) => {
   const {
     accessibilityLabel,
     blurRadius,

--- a/packages/react-native-web/src/exports/ImageBackground/index.js
+++ b/packages/react-native-web/src/exports/ImageBackground/index.js
@@ -28,7 +28,10 @@ const emptyObject = {};
 /**
  * Very simple drop-in replacement for <Image> which supports nesting views.
  */
-const ImageBackground = forwardRef<ImageBackgroundProps, *>((props, forwardedRef) => {
+const ImageBackground: React.AbstractComponent<
+  ImageBackgroundProps,
+  React.ElementRef<typeof View>
+> = forwardRef((props, forwardedRef) => {
   const { children, style = emptyObject, imageStyle, imageRef, ...rest } = props;
   const { height, width } = StyleSheet.flatten(style);
 

--- a/packages/react-native-web/src/exports/Modal/ModalContent.js
+++ b/packages/react-native-web/src/exports/Modal/ModalContent.js
@@ -7,6 +7,7 @@
  *
  * @flow
  */
+import type { AbstractComponent, ElementRef } from 'react';
 
 import React, { forwardRef, useMemo, useEffect } from 'react';
 import { canUseDOM } from 'fbjs/lib/ExecutionEnvironment';
@@ -20,34 +21,41 @@ export type ModalContentProps = {|
   transparent?: ?boolean
 |};
 
-const ModalContent = forwardRef<ModalContentProps, *>((props, forwardedRef) => {
-  const { active, children, onRequestClose, transparent } = props;
+const ModalContent: AbstractComponent<ModalContentProps, ElementRef<typeof View>> = forwardRef(
+  (props, forwardedRef) => {
+    const { active, children, onRequestClose, transparent } = props;
 
-  useEffect(() => {
-    if (canUseDOM) {
-      const closeOnEscape = (e: KeyboardEvent) => {
-        if (active && e.key === 'Escape') {
-          e.stopPropagation();
-          if (onRequestClose) {
-            onRequestClose();
+    useEffect(() => {
+      if (canUseDOM) {
+        const closeOnEscape = (e: KeyboardEvent) => {
+          if (active && e.key === 'Escape') {
+            e.stopPropagation();
+            if (onRequestClose) {
+              onRequestClose();
+            }
           }
-        }
-      };
-      document.addEventListener('keyup', closeOnEscape, false);
-      return () => document.removeEventListener('keyup', closeOnEscape, false);
-    }
-  }, [active, onRequestClose]);
+        };
+        document.addEventListener('keyup', closeOnEscape, false);
+        return () => document.removeEventListener('keyup', closeOnEscape, false);
+      }
+    }, [active, onRequestClose]);
 
-  const style = useMemo(() => {
-    return [styles.modal, transparent ? styles.modalTransparent : styles.modalOpaque];
-  }, [transparent]);
+    const style = useMemo(() => {
+      return [styles.modal, transparent ? styles.modalTransparent : styles.modalOpaque];
+    }, [transparent]);
 
-  return (
-    <View accessibilityRole={active ? 'dialog' : null} aria-modal ref={forwardedRef} style={style}>
-      <View style={styles.container}>{children}</View>
-    </View>
-  );
-});
+    return (
+      <View
+        accessibilityRole={active ? 'dialog' : null}
+        aria-modal
+        ref={forwardedRef}
+        style={style}
+      >
+        <View style={styles.container}>{children}</View>
+      </View>
+    );
+  }
+);
 
 const styles = StyleSheet.create({
   modal: {

--- a/packages/react-native-web/src/exports/Modal/index.js
+++ b/packages/react-native-web/src/exports/Modal/index.js
@@ -7,6 +7,7 @@
  *
  * @flow
  */
+import type { AbstractComponent, ElementRef } from 'react';
 
 import React, { forwardRef, useCallback, useMemo, useEffect, useState } from 'react';
 import ModalPortal from './ModalPortal';
@@ -69,62 +70,64 @@ function addActiveModal(modalId, listener) {
   notifyActiveModalListeners();
 }
 
-const Modal = forwardRef<ModalProps, *>((props, forwardedRef) => {
-  const {
-    animationType,
-    children,
-    onDismiss,
-    onRequestClose,
-    onShow,
-    transparent,
-    visible = true
-  } = props;
+const Modal: AbstractComponent<ModalProps, ElementRef<typeof ModalContent>> = forwardRef(
+  (props, forwardedRef) => {
+    const {
+      animationType,
+      children,
+      onDismiss,
+      onRequestClose,
+      onShow,
+      transparent,
+      visible = true
+    } = props;
 
-  // Set a unique model identifier so we can correctly route
-  // dismissals and check the layering of modals.
-  const modalId = useMemo(() => uniqueModalIdentifier++, []);
+    // Set a unique model identifier so we can correctly route
+    // dismissals and check the layering of modals.
+    const modalId = useMemo(() => uniqueModalIdentifier++, []);
 
-  const [isActive, setIsActive] = useState(false);
+    const [isActive, setIsActive] = useState(false);
 
-  const onDismissCallback = useCallback(() => {
-    removeActiveModal(modalId);
-    if (onDismiss) {
-      onDismiss();
-    }
-  }, [modalId, onDismiss]);
+    const onDismissCallback = useCallback(() => {
+      removeActiveModal(modalId);
+      if (onDismiss) {
+        onDismiss();
+      }
+    }, [modalId, onDismiss]);
 
-  const onShowCallback = useCallback(() => {
-    addActiveModal(modalId, setIsActive);
-    if (onShow) {
-      onShow();
-    }
-  }, [modalId, onShow]);
+    const onShowCallback = useCallback(() => {
+      addActiveModal(modalId, setIsActive);
+      if (onShow) {
+        onShow();
+      }
+    }, [modalId, onShow]);
 
-  useEffect(() => {
-    return () => removeActiveModal(modalId);
-  }, [modalId]);
+    useEffect(() => {
+      return () => removeActiveModal(modalId);
+    }, [modalId]);
 
-  return (
-    <ModalPortal>
-      <ModalAnimation
-        animationType={animationType}
-        onDismiss={onDismissCallback}
-        onShow={onShowCallback}
-        visible={visible}
-      >
-        <ModalFocusTrap active={isActive}>
-          <ModalContent
-            active={isActive}
-            onRequestClose={onRequestClose}
-            ref={forwardedRef}
-            transparent={transparent}
-          >
-            {children}
-          </ModalContent>
-        </ModalFocusTrap>
-      </ModalAnimation>
-    </ModalPortal>
-  );
-});
+    return (
+      <ModalPortal>
+        <ModalAnimation
+          animationType={animationType}
+          onDismiss={onDismissCallback}
+          onShow={onShowCallback}
+          visible={visible}
+        >
+          <ModalFocusTrap active={isActive}>
+            <ModalContent
+              active={isActive}
+              onRequestClose={onRequestClose}
+              ref={forwardedRef}
+              transparent={transparent}
+            >
+              {children}
+            </ModalContent>
+          </ModalFocusTrap>
+        </ModalAnimation>
+      </ModalPortal>
+    );
+  }
+);
 
 export default Modal;

--- a/packages/react-native-web/src/exports/Picker/index.js
+++ b/packages/react-native-web/src/exports/Picker/index.js
@@ -8,6 +8,8 @@
  * @flow
  */
 
+import type { AbstractComponent } from 'react';
+import type { NativeMethodsMixin } from '../../types';
 import type { ViewProps } from '../View';
 
 import createElement from '../createElement';
@@ -30,50 +32,52 @@ type PickerProps = {
   prompt?: string
 };
 
-const Picker = forwardRef<PickerProps, *>((props, forwardedRef) => {
-  const {
-    children,
-    enabled,
-    onValueChange,
-    selectedValue,
-    style,
-    testID,
-    /* eslint-disable */
-    itemStyle,
-    mode,
-    prompt,
-    /* eslint-enable */
-    ...other
-  } = props;
+const Picker: AbstractComponent<PickerProps, HTMLElement & NativeMethodsMixin> = forwardRef(
+  (props, forwardedRef) => {
+    const {
+      children,
+      enabled,
+      onValueChange,
+      selectedValue,
+      style,
+      testID,
+      /* eslint-disable */
+      itemStyle,
+      mode,
+      prompt,
+      /* eslint-enable */
+      ...other
+    } = props;
 
-  const hostRef = useRef(null);
+    const hostRef = useRef(null);
 
-  function handleChange(e: Object) {
-    const { selectedIndex, value } = e.target;
-    if (onValueChange) {
-      onValueChange(value, selectedIndex);
+    function handleChange(e: Object) {
+      const { selectedIndex, value } = e.target;
+      if (onValueChange) {
+        onValueChange(value, selectedIndex);
+      }
     }
+
+    // $FlowFixMe
+    const supportedProps: any = {
+      children,
+      disabled: enabled === false ? true : undefined,
+      onChange: handleChange,
+      style: [styles.initial, style],
+      testID,
+      value: selectedValue,
+      ...other
+    };
+
+    const platformMethodsRef = usePlatformMethods(supportedProps);
+
+    const setRef = useMergeRefs(hostRef, platformMethodsRef, forwardedRef);
+
+    supportedProps.ref = setRef;
+
+    return createElement('select', supportedProps);
   }
-
-  // $FlowFixMe
-  const supportedProps: any = {
-    children,
-    disabled: enabled === false ? true : undefined,
-    onChange: handleChange,
-    style: [styles.initial, style],
-    testID,
-    value: selectedValue,
-    ...other
-  };
-
-  const platformMethodsRef = usePlatformMethods(supportedProps);
-
-  const setRef = useMergeRefs(hostRef, platformMethodsRef, forwardedRef);
-
-  supportedProps.ref = setRef;
-
-  return createElement('select', supportedProps);
-});
+);
 
 // $FlowFixMe
 Picker.Item = PickerItem;

--- a/packages/react-native-web/src/exports/ProgressBar/index.js
+++ b/packages/react-native-web/src/exports/ProgressBar/index.js
@@ -9,6 +9,7 @@
 
 import type { ColorValue } from '../../types';
 import type { ViewProps } from '../View';
+import type { AbstractComponent, ElementRef } from 'react';
 
 import StyleSheet from '../StyleSheet';
 import View from '../View';
@@ -22,47 +23,49 @@ type ProgressBarProps = {
   trackColor?: ColorValue
 };
 
-const ProgressBar = forwardRef<ProgressBarProps, *>((props, ref) => {
-  const {
-    color = '#1976D2',
-    indeterminate = false,
-    progress = 0,
-    trackColor = 'transparent',
-    style,
-    ...other
-  } = props;
+const ProgressBar: AbstractComponent<ProgressBarProps, ElementRef<typeof View>> = forwardRef(
+  (props, ref) => {
+    const {
+      color = '#1976D2',
+      indeterminate = false,
+      progress = 0,
+      trackColor = 'transparent',
+      style,
+      ...other
+    } = props;
 
-  const percentageProgress = progress * 100;
+    const percentageProgress = progress * 100;
 
-  const progressRef = useRef(null);
-  useEffect(() => {
-    const width = indeterminate ? '25%' : `${percentageProgress}%`;
-    if (progressRef.current != null) {
-      progressRef.current.setNativeProps({
-        style: { width }
-      });
-    }
-  }, [indeterminate, percentageProgress, progressRef]);
+    const progressRef = useRef(null);
+    useEffect(() => {
+      const width = indeterminate ? '25%' : `${percentageProgress}%`;
+      if (progressRef.current != null) {
+        progressRef.current.setNativeProps({
+          style: { width }
+        });
+      }
+    }, [indeterminate, percentageProgress, progressRef]);
 
-  return (
-    <View
-      {...other}
-      accessibilityRole="progressbar"
-      accessibilityValue={{
-        max: 100,
-        min: 0,
-        now: indeterminate ? null : percentageProgress
-      }}
-      ref={ref}
-      style={[styles.track, style, { backgroundColor: trackColor }]}
-    >
+    return (
       <View
-        ref={progressRef}
-        style={[styles.progress, indeterminate && styles.animation, { backgroundColor: color }]}
-      />
-    </View>
-  );
-});
+        {...other}
+        accessibilityRole="progressbar"
+        accessibilityValue={{
+          max: 100,
+          min: 0,
+          now: indeterminate ? null : percentageProgress
+        }}
+        ref={ref}
+        style={[styles.track, style, { backgroundColor: trackColor }]}
+      >
+        <View
+          ref={progressRef}
+          style={[styles.progress, indeterminate && styles.animation, { backgroundColor: color }]}
+        />
+      </View>
+    );
+  }
+);
 
 ProgressBar.displayName = 'ProgressBar';
 

--- a/packages/react-native-web/src/exports/SafeAreaView/index.js
+++ b/packages/react-native-web/src/exports/SafeAreaView/index.js
@@ -9,7 +9,7 @@
  */
 
 import type { ViewProps } from '../View';
-import type { Node } from 'react';
+import type { AbstractComponent, ElementRef } from 'react';
 
 import { canUseDOM } from 'fbjs/lib/ExecutionEnvironment';
 import StyleSheet from '../StyleSheet';
@@ -28,11 +28,13 @@ const cssFunction: 'constant' | 'env' = (function () {
   return 'env';
 })();
 
-const SafeAreaView = forwardRef<ViewProps, Node>((props, ref) => {
-  const { style, ...rest } = props;
+const SafeAreaView: AbstractComponent<ViewProps, ElementRef<typeof View>> = forwardRef(
+  (props, ref) => {
+    const { style, ...rest } = props;
 
-  return <View {...rest} ref={ref} style={StyleSheet.compose(styles.root, style)} />;
-});
+    return <View {...rest} ref={ref} style={StyleSheet.compose(styles.root, style)} />;
+  }
+);
 
 SafeAreaView.displayName = 'SafeAreaView';
 

--- a/packages/react-native-web/src/exports/ScrollView/index.js
+++ b/packages/react-native-web/src/exports/ScrollView/index.js
@@ -334,7 +334,10 @@ const styles = StyleSheet.create({
   }
 });
 
-const ForwardedScrollView = React.forwardRef((props, forwardedRef) => {
+const ForwardedScrollView: React.AbstractComponent<
+  React.ElementConfig<typeof ScrollView>,
+  React.ElementRef<typeof ScrollView>
+> = React.forwardRef((props, forwardedRef) => {
   return <ScrollView {...props} forwardedRef={forwardedRef} />;
 });
 

--- a/packages/react-native-web/src/exports/Switch/index.js
+++ b/packages/react-native-web/src/exports/Switch/index.js
@@ -32,102 +32,104 @@ const emptyObject = {};
 const thumbDefaultBoxShadow = '0px 1px 3px rgba(0,0,0,0.5)';
 const thumbFocusedBoxShadow = `${thumbDefaultBoxShadow}, 0 0 0 10px rgba(0,0,0,0.1)`;
 
-const Switch = forwardRef<SwitchProps, *>((props, forwardedRef) => {
-  const {
-    accessibilityLabel,
-    activeThumbColor = '#009688',
-    activeTrackColor = '#A3D3CF',
-    disabled = false,
-    onValueChange,
-    style = emptyObject,
-    thumbColor = '#FAFAFA',
-    trackColor = '#939393',
-    value = false,
-    ...other
-  } = props;
+const Switch: React.AbstractComponent<SwitchProps, React.ElementRef<typeof View>> = forwardRef(
+  (props, forwardedRef) => {
+    const {
+      accessibilityLabel,
+      activeThumbColor = '#009688',
+      activeTrackColor = '#A3D3CF',
+      disabled = false,
+      onValueChange,
+      style = emptyObject,
+      thumbColor = '#FAFAFA',
+      trackColor = '#939393',
+      value = false,
+      ...other
+    } = props;
 
-  const thumbRef = useRef(null);
+    const thumbRef = useRef(null);
 
-  function handleChange(event: Object) {
-    if (onValueChange != null) {
-      onValueChange(event.nativeEvent.target.checked);
-    }
-  }
-
-  function handleFocusState(event: Object) {
-    const isFocused = event.nativeEvent.type === 'focus';
-    const boxShadow = isFocused ? thumbFocusedBoxShadow : thumbDefaultBoxShadow;
-    if (thumbRef.current != null) {
-      thumbRef.current.style.boxShadow = boxShadow;
-    }
-  }
-
-  const { height: styleHeight, width: styleWidth } = StyleSheet.flatten(style);
-  const height = styleHeight || '20px';
-  const minWidth = multiplyStyleLengthValue(height, 2);
-  const width = styleWidth > minWidth ? styleWidth : minWidth;
-  const trackBorderRadius = multiplyStyleLengthValue(height, 0.5);
-  const trackCurrentColor = (function () {
-    if (value === true) {
-      if (trackColor != null && typeof trackColor === 'object') {
-        return trackColor.true;
-      } else {
-        return activeTrackColor;
-      }
-    } else {
-      if (trackColor != null && typeof trackColor === 'object') {
-        return trackColor.false;
-      } else {
-        return trackColor;
+    function handleChange(event: Object) {
+      if (onValueChange != null) {
+        onValueChange(event.nativeEvent.target.checked);
       }
     }
-  })();
-  const thumbCurrentColor = value ? activeThumbColor : thumbColor;
-  const thumbHeight = height;
-  const thumbWidth = thumbHeight;
 
-  const rootStyle = [styles.root, style, disabled && styles.cursorDefault, { height, width }];
-
-  const trackStyle = [
-    styles.track,
-    {
-      backgroundColor: disabled ? '#D5D5D5' : trackCurrentColor,
-      borderRadius: trackBorderRadius
+    function handleFocusState(event: Object) {
+      const isFocused = event.nativeEvent.type === 'focus';
+      const boxShadow = isFocused ? thumbFocusedBoxShadow : thumbDefaultBoxShadow;
+      if (thumbRef.current != null) {
+        thumbRef.current.style.boxShadow = boxShadow;
+      }
     }
-  ];
 
-  const thumbStyle = [
-    styles.thumb,
-    value && styles.thumbActive,
-    {
-      backgroundColor: disabled ? '#BDBDBD' : thumbCurrentColor,
-      height: thumbHeight,
-      marginStart: value ? multiplyStyleLengthValue(thumbWidth, -1) : 0,
-      width: thumbWidth
-    }
-  ];
+    const { height: styleHeight, width: styleWidth } = StyleSheet.flatten(style);
+    const height = styleHeight || '20px';
+    const minWidth = multiplyStyleLengthValue(height, 2);
+    const width = styleWidth > minWidth ? styleWidth : minWidth;
+    const trackBorderRadius = multiplyStyleLengthValue(height, 0.5);
+    const trackCurrentColor = (function () {
+      if (value === true) {
+        if (trackColor != null && typeof trackColor === 'object') {
+          return trackColor.true;
+        } else {
+          return activeTrackColor;
+        }
+      } else {
+        if (trackColor != null && typeof trackColor === 'object') {
+          return trackColor.false;
+        } else {
+          return trackColor;
+        }
+      }
+    })();
+    const thumbCurrentColor = value ? activeThumbColor : thumbColor;
+    const thumbHeight = height;
+    const thumbWidth = thumbHeight;
 
-  const nativeControl = createElement('input', {
-    accessibilityLabel,
-    checked: value,
-    disabled: disabled,
-    onBlur: handleFocusState,
-    onChange: handleChange,
-    onFocus: handleFocusState,
-    ref: forwardedRef,
-    style: [styles.nativeControl, styles.cursorInherit],
-    type: 'checkbox',
-    role: 'switch'
-  });
+    const rootStyle = [styles.root, style, disabled && styles.cursorDefault, { height, width }];
 
-  return (
-    <View {...other} style={rootStyle}>
-      <View style={trackStyle} />
-      <View ref={thumbRef} style={thumbStyle} />
-      {nativeControl}
-    </View>
-  );
-});
+    const trackStyle = [
+      styles.track,
+      {
+        backgroundColor: disabled ? '#D5D5D5' : trackCurrentColor,
+        borderRadius: trackBorderRadius
+      }
+    ];
+
+    const thumbStyle = [
+      styles.thumb,
+      value && styles.thumbActive,
+      {
+        backgroundColor: disabled ? '#BDBDBD' : thumbCurrentColor,
+        height: thumbHeight,
+        marginStart: value ? multiplyStyleLengthValue(thumbWidth, -1) : 0,
+        width: thumbWidth
+      }
+    ];
+
+    const nativeControl = createElement('input', {
+      accessibilityLabel,
+      checked: value,
+      disabled: disabled,
+      onBlur: handleFocusState,
+      onChange: handleChange,
+      onFocus: handleFocusState,
+      ref: forwardedRef,
+      style: [styles.nativeControl, styles.cursorInherit],
+      type: 'checkbox',
+      role: 'switch'
+    });
+
+    return (
+      <View {...other} style={rootStyle}>
+        <View style={trackStyle} />
+        <View ref={thumbRef} style={thumbStyle} />
+        {nativeControl}
+      </View>
+    );
+  }
+);
 
 Switch.displayName = 'Switch';
 

--- a/packages/react-native-web/src/exports/Text/index.js
+++ b/packages/react-native-web/src/exports/Text/index.js
@@ -8,6 +8,7 @@
  * @flow
  */
 
+import type { NativeMethodsMixin } from '../../types';
 import type { TextProps } from './types';
 
 import * as React from 'react';
@@ -39,116 +40,118 @@ const forwardPropsList = {
 
 const pickProps = (props) => pick(props, forwardPropsList);
 
-const Text = forwardRef<TextProps, *>((props, forwardedRef) => {
-  const {
-    dir,
-    hrefAttrs,
-    numberOfLines,
-    onClick,
-    onLayout,
-    onPress,
-    onMoveShouldSetResponder,
-    onMoveShouldSetResponderCapture,
-    onResponderEnd,
-    onResponderGrant,
-    onResponderMove,
-    onResponderReject,
-    onResponderRelease,
-    onResponderStart,
-    onResponderTerminate,
-    onResponderTerminationRequest,
-    onScrollShouldSetResponder,
-    onScrollShouldSetResponderCapture,
-    onSelectionChangeShouldSetResponder,
-    onSelectionChangeShouldSetResponderCapture,
-    onStartShouldSetResponder,
-    onStartShouldSetResponderCapture,
-    selectable
-  } = props;
+const Text: React$AbstractComponent<TextProps, HTMLElement & NativeMethodsMixin> = forwardRef(
+  (props, forwardedRef) => {
+    const {
+      dir,
+      hrefAttrs,
+      numberOfLines,
+      onClick,
+      onLayout,
+      onPress,
+      onMoveShouldSetResponder,
+      onMoveShouldSetResponderCapture,
+      onResponderEnd,
+      onResponderGrant,
+      onResponderMove,
+      onResponderReject,
+      onResponderRelease,
+      onResponderStart,
+      onResponderTerminate,
+      onResponderTerminationRequest,
+      onScrollShouldSetResponder,
+      onScrollShouldSetResponderCapture,
+      onSelectionChangeShouldSetResponder,
+      onSelectionChangeShouldSetResponderCapture,
+      onStartShouldSetResponder,
+      onStartShouldSetResponderCapture,
+      selectable
+    } = props;
 
-  const hasTextAncestor = useContext(TextAncestorContext);
-  const hostRef = useRef(null);
+    const hasTextAncestor = useContext(TextAncestorContext);
+    const hostRef = useRef(null);
 
-  const classList = [
-    classes.text,
-    hasTextAncestor === true && classes.textHasAncestor,
-    numberOfLines === 1 && classes.textOneLine,
-    numberOfLines != null && numberOfLines > 1 && classes.textMultiLine
-  ];
-  const style = [
-    props.style,
-    numberOfLines != null && numberOfLines > 1 && { WebkitLineClamp: numberOfLines },
-    selectable === true && styles.selectable,
-    selectable === false && styles.notSelectable,
-    onPress && styles.pressable
-  ];
+    const classList = [
+      classes.text,
+      hasTextAncestor === true && classes.textHasAncestor,
+      numberOfLines === 1 && classes.textOneLine,
+      numberOfLines != null && numberOfLines > 1 && classes.textMultiLine
+    ];
+    const style = [
+      props.style,
+      numberOfLines != null && numberOfLines > 1 && { WebkitLineClamp: numberOfLines },
+      selectable === true && styles.selectable,
+      selectable === false && styles.notSelectable,
+      onPress && styles.pressable
+    ];
 
-  useElementLayout(hostRef, onLayout);
-  useResponderEvents(hostRef, {
-    onMoveShouldSetResponder,
-    onMoveShouldSetResponderCapture,
-    onResponderEnd,
-    onResponderGrant,
-    onResponderMove,
-    onResponderReject,
-    onResponderRelease,
-    onResponderStart,
-    onResponderTerminate,
-    onResponderTerminationRequest,
-    onScrollShouldSetResponder,
-    onScrollShouldSetResponderCapture,
-    onSelectionChangeShouldSetResponder,
-    onSelectionChangeShouldSetResponderCapture,
-    onStartShouldSetResponder,
-    onStartShouldSetResponderCapture
-  });
+    useElementLayout(hostRef, onLayout);
+    useResponderEvents(hostRef, {
+      onMoveShouldSetResponder,
+      onMoveShouldSetResponderCapture,
+      onResponderEnd,
+      onResponderGrant,
+      onResponderMove,
+      onResponderReject,
+      onResponderRelease,
+      onResponderStart,
+      onResponderTerminate,
+      onResponderTerminationRequest,
+      onScrollShouldSetResponder,
+      onScrollShouldSetResponderCapture,
+      onSelectionChangeShouldSetResponder,
+      onSelectionChangeShouldSetResponderCapture,
+      onStartShouldSetResponder,
+      onStartShouldSetResponderCapture
+    });
 
-  function handleClick(e) {
-    if (onClick != null) {
-      onClick(e);
+    function handleClick(e) {
+      if (onClick != null) {
+        onClick(e);
+      }
+      if (onClick == null && onPress != null) {
+        e.stopPropagation();
+        onPress(e);
+      }
     }
-    if (onClick == null && onPress != null) {
-      e.stopPropagation();
-      onPress(e);
+
+    const component = hasTextAncestor ? 'span' : 'div';
+    const supportedProps = pickProps(props);
+    supportedProps.classList = classList;
+    supportedProps.dir = dir;
+    // 'auto' by default allows browsers to infer writing direction (root elements only)
+    if (!hasTextAncestor) {
+      supportedProps.dir = dir != null ? dir : 'auto';
     }
+    supportedProps.onClick = handleClick;
+    supportedProps.style = style;
+    if (props.href != null && hrefAttrs != null) {
+      const { download, rel, target } = hrefAttrs;
+      if (download != null) {
+        supportedProps.download = download;
+      }
+      if (rel != null) {
+        supportedProps.rel = rel;
+      }
+      if (typeof target === 'string') {
+        supportedProps.target = target.charAt(0) !== '_' ? '_' + target : target;
+      }
+    }
+
+    const platformMethodsRef = usePlatformMethods(supportedProps);
+    const setRef = useMergeRefs(hostRef, platformMethodsRef, forwardedRef);
+
+    supportedProps.ref = setRef;
+
+    const element = createElement(component, supportedProps);
+
+    return hasTextAncestor ? (
+      element
+    ) : (
+      <TextAncestorContext.Provider value={true}>{element}</TextAncestorContext.Provider>
+    );
   }
-
-  const component = hasTextAncestor ? 'span' : 'div';
-  const supportedProps = pickProps(props);
-  supportedProps.classList = classList;
-  supportedProps.dir = dir;
-  // 'auto' by default allows browsers to infer writing direction (root elements only)
-  if (!hasTextAncestor) {
-    supportedProps.dir = dir != null ? dir : 'auto';
-  }
-  supportedProps.onClick = handleClick;
-  supportedProps.style = style;
-  if (props.href != null && hrefAttrs != null) {
-    const { download, rel, target } = hrefAttrs;
-    if (download != null) {
-      supportedProps.download = download;
-    }
-    if (rel != null) {
-      supportedProps.rel = rel;
-    }
-    if (typeof target === 'string') {
-      supportedProps.target = target.charAt(0) !== '_' ? '_' + target : target;
-    }
-  }
-
-  const platformMethodsRef = usePlatformMethods(supportedProps);
-  const setRef = useMergeRefs(hostRef, platformMethodsRef, forwardedRef);
-
-  supportedProps.ref = setRef;
-
-  const element = createElement(component, supportedProps);
-
-  return hasTextAncestor ? (
-    element
-  ) : (
-    <TextAncestorContext.Provider value={true}>{element}</TextAncestorContext.Provider>
-  );
-});
+);
 
 Text.displayName = 'Text';
 

--- a/packages/react-native-web/src/exports/TextInput/index.js
+++ b/packages/react-native-web/src/exports/TextInput/index.js
@@ -8,6 +8,7 @@
  * @flow
  */
 
+import type { NativeMethodsMixin } from '../../types';
 import type { TextInputProps } from './types';
 
 import { forwardRef, useCallback, useMemo, useRef } from 'react';
@@ -82,7 +83,10 @@ function isEventComposing(nativeEvent) {
   return nativeEvent.isComposing || nativeEvent.keyCode === 229;
 }
 
-const TextInput = forwardRef<TextInputProps, *>((props, forwardedRef) => {
+const TextInput: React$AbstractComponent<
+  TextInputProps,
+  HTMLElement & NativeMethodsMixin
+> = forwardRef((props, forwardedRef) => {
   const {
     autoCapitalize = 'sentences',
     autoComplete,

--- a/packages/react-native-web/src/exports/View/index.js
+++ b/packages/react-native-web/src/exports/View/index.js
@@ -8,6 +8,7 @@
  * @flow
  */
 
+import type { NativeMethodsMixin } from '../../types';
 import type { ViewProps } from './types';
 
 import * as React from 'react';
@@ -41,84 +42,88 @@ const forwardPropsList = {
 
 const pickProps = (props) => pick(props, forwardPropsList);
 
-const View = forwardRef<ViewProps, *>((props, forwardedRef) => {
-  const {
-    hrefAttrs,
-    onLayout,
-    onMoveShouldSetResponder,
-    onMoveShouldSetResponderCapture,
-    onResponderEnd,
-    onResponderGrant,
-    onResponderMove,
-    onResponderReject,
-    onResponderRelease,
-    onResponderStart,
-    onResponderTerminate,
-    onResponderTerminationRequest,
-    onScrollShouldSetResponder,
-    onScrollShouldSetResponderCapture,
-    onSelectionChangeShouldSetResponder,
-    onSelectionChangeShouldSetResponderCapture,
-    onStartShouldSetResponder,
-    onStartShouldSetResponderCapture
-  } = props;
+const View: React$AbstractComponent<ViewProps, HTMLElement & NativeMethodsMixin> = forwardRef(
+  (props, forwardedRef) => {
+    const {
+      hrefAttrs,
+      onLayout,
+      onMoveShouldSetResponder,
+      onMoveShouldSetResponderCapture,
+      onResponderEnd,
+      onResponderGrant,
+      onResponderMove,
+      onResponderReject,
+      onResponderRelease,
+      onResponderStart,
+      onResponderTerminate,
+      onResponderTerminationRequest,
+      onScrollShouldSetResponder,
+      onScrollShouldSetResponderCapture,
+      onSelectionChangeShouldSetResponder,
+      onSelectionChangeShouldSetResponderCapture,
+      onStartShouldSetResponder,
+      onStartShouldSetResponderCapture
+    } = props;
 
-  if (process.env.NODE_ENV !== 'production') {
-    React.Children.toArray(props.children).forEach((item) => {
-      if (typeof item === 'string') {
-        console.error(`Unexpected text node: ${item}. A text node cannot be a child of a <View>.`);
-      }
+    if (process.env.NODE_ENV !== 'production') {
+      React.Children.toArray(props.children).forEach((item) => {
+        if (typeof item === 'string') {
+          console.error(
+            `Unexpected text node: ${item}. A text node cannot be a child of a <View>.`
+          );
+        }
+      });
+    }
+
+    const hasTextAncestor = useContext(TextAncestorContext);
+    const hostRef = useRef(null);
+
+    useElementLayout(hostRef, onLayout);
+    useResponderEvents(hostRef, {
+      onMoveShouldSetResponder,
+      onMoveShouldSetResponderCapture,
+      onResponderEnd,
+      onResponderGrant,
+      onResponderMove,
+      onResponderReject,
+      onResponderRelease,
+      onResponderStart,
+      onResponderTerminate,
+      onResponderTerminationRequest,
+      onScrollShouldSetResponder,
+      onScrollShouldSetResponderCapture,
+      onSelectionChangeShouldSetResponder,
+      onSelectionChangeShouldSetResponderCapture,
+      onStartShouldSetResponder,
+      onStartShouldSetResponderCapture
     });
+
+    const style = StyleSheet.compose(hasTextAncestor && styles.inline, props.style);
+
+    const supportedProps = pickProps(props);
+    supportedProps.classList = classList;
+    supportedProps.style = style;
+    if (props.href != null && hrefAttrs != null) {
+      const { download, rel, target } = hrefAttrs;
+      if (download != null) {
+        supportedProps.download = download;
+      }
+      if (rel != null) {
+        supportedProps.rel = rel;
+      }
+      if (typeof target === 'string') {
+        supportedProps.target = target.charAt(0) !== '_' ? '_' + target : target;
+      }
+    }
+
+    const platformMethodsRef = usePlatformMethods(supportedProps);
+    const setRef = useMergeRefs(hostRef, platformMethodsRef, forwardedRef);
+
+    supportedProps.ref = setRef;
+
+    return createElement('div', supportedProps);
   }
-
-  const hasTextAncestor = useContext(TextAncestorContext);
-  const hostRef = useRef(null);
-
-  useElementLayout(hostRef, onLayout);
-  useResponderEvents(hostRef, {
-    onMoveShouldSetResponder,
-    onMoveShouldSetResponderCapture,
-    onResponderEnd,
-    onResponderGrant,
-    onResponderMove,
-    onResponderReject,
-    onResponderRelease,
-    onResponderStart,
-    onResponderTerminate,
-    onResponderTerminationRequest,
-    onScrollShouldSetResponder,
-    onScrollShouldSetResponderCapture,
-    onSelectionChangeShouldSetResponder,
-    onSelectionChangeShouldSetResponderCapture,
-    onStartShouldSetResponder,
-    onStartShouldSetResponderCapture
-  });
-
-  const style = StyleSheet.compose(hasTextAncestor && styles.inline, props.style);
-
-  const supportedProps = pickProps(props);
-  supportedProps.classList = classList;
-  supportedProps.style = style;
-  if (props.href != null && hrefAttrs != null) {
-    const { download, rel, target } = hrefAttrs;
-    if (download != null) {
-      supportedProps.download = download;
-    }
-    if (rel != null) {
-      supportedProps.rel = rel;
-    }
-    if (typeof target === 'string') {
-      supportedProps.target = target.charAt(0) !== '_' ? '_' + target : target;
-    }
-  }
-
-  const platformMethodsRef = usePlatformMethods(supportedProps);
-  const setRef = useMergeRefs(hostRef, platformMethodsRef, forwardedRef);
-
-  supportedProps.ref = setRef;
-
-  return createElement('div', supportedProps);
-});
+);
 
 View.displayName = 'View';
 

--- a/packages/react-native-web/src/types/index.js
+++ b/packages/react-native-web/src/types/index.js
@@ -45,3 +45,21 @@ export type PointValue = {|
   x: number,
   y: number
 |};
+
+type LayoutCallback = ({
+  ...LayoutValue,
+  left: number,
+  top: number
+}) => void;
+
+type MeasureInWindowCallback = (EdgeInsetsValue) => void;
+
+// Mixin to HTMLElement that represents additions from the `usePlatformMethods` hook
+export class NativeMethodsMixin {
+  blur: () => void;
+  focus: () => void;
+  measure: (callback: LayoutCallback) => void;
+  measureInWindow: (callback: MeasureInWindowCallback) => void;
+  measureLayout: (relativeToNativeNode: {}, onSuccess: LayoutCallback, onFail: () => void) => void;
+  setNativeProps: (nativeProps: {}) => void;
+}

--- a/packages/react-native-web/src/types/index.js
+++ b/packages/react-native-web/src/types/index.js
@@ -55,7 +55,7 @@ type LayoutCallback = ({
 type MeasureInWindowCallback = (EdgeInsetsValue) => void;
 
 // Mixin to HTMLElement that represents additions from the `usePlatformMethods` hook
-export class NativeMethodsMixin {
+declare class NativeMethodsMixin {
   blur: () => void;
   focus: () => void;
   measure: (callback: LayoutCallback) => void;

--- a/packages/react-native-web/src/types/index.js
+++ b/packages/react-native-web/src/types/index.js
@@ -55,7 +55,7 @@ type LayoutCallback = ({
 type MeasureInWindowCallback = (EdgeInsetsValue) => void;
 
 // Mixin to HTMLElement that represents additions from the `usePlatformMethods` hook
-declare class NativeMethodsMixin {
+export interface NativeMethodsMixin {
   blur: () => void;
   focus: () => void;
   measure: (callback: LayoutCallback) => void;


### PR DESCRIPTION
- Defines a `NativeMethodsMixin` type that reflects what the useNativeMethods mixin adds.
- Sets a instance type for View (and a few other foundational components that use the mixin)
- Updates all forwardRef usages to refer to and have instance types set, and to be well-formed exports

In general, that means converting:
```
const component = forwardRef<Props, *>(...
```
to
```
const component: AbstractComponent<Props, ElementRef<View>> = forwardRef(...
```
Basically moving the signature to the export and letting the generic on forwardRef get inferred that way.

NOTE: The changes can look larger than they are because prettier wanted to tab some things