### PR TITLE
Flow 0.142 (5/N): Codemod export-types on src folder

### DIFF
--- a/packages/react-native-web/src/exports/Animated/index.js
+++ b/packages/react-native-web/src/exports/Animated/index.js
@@ -17,18 +17,18 @@ import View from '../View';
 
 const Animated = {
   ...AnimatedImplementation,
-  FlatList: AnimatedImplementation.createAnimatedComponent(FlatList, {
+  FlatList: (AnimatedImplementation.createAnimatedComponent(FlatList, {
     scrollEventThrottle: 0.0001
-  }),
-  Image: AnimatedImplementation.createAnimatedComponent(Image),
-  ScrollView: AnimatedImplementation.createAnimatedComponent(ScrollView, {
+  }): any),
+  Image: (AnimatedImplementation.createAnimatedComponent(Image): any),
+  ScrollView: (AnimatedImplementation.createAnimatedComponent(ScrollView, {
     scrollEventThrottle: 0.0001
-  }),
-  SectionList: AnimatedImplementation.createAnimatedComponent(SectionList, {
+  }): any),
+  SectionList: (AnimatedImplementation.createAnimatedComponent(SectionList, {
     scrollEventThrottle: 0.0001
-  }),
-  View: AnimatedImplementation.createAnimatedComponent(View),
-  Text: AnimatedImplementation.createAnimatedComponent(Text)
+  }): any),
+  View: (AnimatedImplementation.createAnimatedComponent(View): any),
+  Text: (AnimatedImplementation.createAnimatedComponent(Text): any)
 };
 
 export default Animated;

--- a/packages/react-native-web/src/exports/Animated/index.js
+++ b/packages/react-native-web/src/exports/Animated/index.js
@@ -17,18 +17,18 @@ import View from '../View';
 
 const Animated = {
   ...AnimatedImplementation,
-  FlatList: (AnimatedImplementation.createAnimatedComponent(FlatList, {
+  FlatList: AnimatedImplementation.createAnimatedComponent(FlatList, {
     scrollEventThrottle: 0.0001
-  }): any),
-  Image: (AnimatedImplementation.createAnimatedComponent(Image): any),
-  ScrollView: (AnimatedImplementation.createAnimatedComponent(ScrollView, {
+  }),
+  Image: AnimatedImplementation.createAnimatedComponent(Image),
+  ScrollView: AnimatedImplementation.createAnimatedComponent(ScrollView, {
     scrollEventThrottle: 0.0001
-  }): any),
-  SectionList: (AnimatedImplementation.createAnimatedComponent(SectionList, {
+  }),
+  SectionList: AnimatedImplementation.createAnimatedComponent(SectionList, {
     scrollEventThrottle: 0.0001
-  }): any),
-  View: (AnimatedImplementation.createAnimatedComponent(View): any),
-  Text: (AnimatedImplementation.createAnimatedComponent(Text): any)
+  }),
+  View: AnimatedImplementation.createAnimatedComponent(View),
+  Text: AnimatedImplementation.createAnimatedComponent(Text)
 };
 
 export default Animated;

--- a/packages/react-native-web/src/exports/AppRegistry/AppContainer.js
+++ b/packages/react-native-web/src/exports/AppRegistry/AppContainer.js
@@ -9,6 +9,7 @@
  */
 
 import type { ComponentType, Context } from 'react';
+import type { Node } from 'React';
 
 import StyleSheet from '../StyleSheet';
 import View from '../View';
@@ -23,7 +24,7 @@ type Props = {
 
 const RootTagContext: Context<any> = createContext(null);
 
-export default function AppContainer(props: Props) {
+export default function AppContainer(props: Props): Node {
   const { children, WrapperComponent } = props;
 
   let innerView = (

--- a/packages/react-native-web/src/exports/BackHandler/index.js
+++ b/packages/react-native-web/src/exports/BackHandler/index.js
@@ -12,7 +12,7 @@ function emptyFunction() {}
 
 const BackHandler = {
   exitApp: emptyFunction,
-  addEventListener() {
+  addEventListener(): {| remove: () => void |} {
     return {
       remove: emptyFunction
     };

--- a/packages/react-native-web/src/exports/Clipboard/index.js
+++ b/packages/react-native-web/src/exports/Clipboard/index.js
@@ -11,7 +11,7 @@
 let clipboardAvailable;
 
 export default class Clipboard {
-  static isAvailable() {
+  static isAvailable(): boolean {
     if (clipboardAvailable === undefined) {
       clipboardAvailable =
         typeof document.queryCommandSupported === 'function' &&
@@ -24,7 +24,7 @@ export default class Clipboard {
     return Promise.resolve('');
   }
 
-  static setString(text: string) {
+  static setString(text: string): boolean {
     let success = false;
     const body = document.body;
 

--- a/packages/react-native-web/src/exports/DeviceInfo/index.js
+++ b/packages/react-native-web/src/exports/DeviceInfo/index.js
@@ -34,22 +34,23 @@ const DeviceInfo = {
     }
   },
 
-  get locale() {
+  get locale(): string | void {
     if (canUseDOM) {
-      if (window.navigator.languages) {
-        return window.navigator.languages[0];
+      if (navigator.languages) {
+        return navigator.languages[0];
       } else {
-        return window.navigator.language;
+        return navigator.language;
       }
     }
   },
 
-  get totalMemory() {
-    return canUseDOM ? window.navigator.deviceMemory : undefined;
+  get totalMemory(): number | void {
+    // $FlowIssue deviceMemory not defined in navigator
+    return canUseDOM ? navigator.deviceMemory : undefined;
   },
 
-  get userAgent() {
-    return canUseDOM ? window.navigator.userAgent : '';
+  get userAgent(): string {
+    return canUseDOM ? navigator.userAgent : '';
   }
 };
 

--- a/packages/react-native-web/src/exports/InteractionManager/index.js
+++ b/packages/react-native-web/src/exports/InteractionManager/index.js
@@ -44,7 +44,7 @@ const InteractionManager = {
   /**
    * Notify manager that an interaction has started.
    */
-  createInteractionHandle() {
+  createInteractionHandle(): number {
     return 1;
   },
 

--- a/packages/react-native-web/src/exports/Keyboard/index.js
+++ b/packages/react-native-web/src/exports/Keyboard/index.js
@@ -11,7 +11,7 @@
 import dismissKeyboard from '../../modules/dismissKeyboard';
 
 const Keyboard = {
-  addListener() {
+  addListener(): {| remove: () => void |} {
     return { remove: () => {} };
   },
   dismiss() {

--- a/packages/react-native-web/src/exports/KeyboardAvoidingView/index.js
+++ b/packages/react-native-web/src/exports/KeyboardAvoidingView/index.js
@@ -10,6 +10,7 @@
 
 import type { LayoutEvent, LayoutValue } from '../../types';
 import type { ViewProps } from '../View';
+import type { Node } from 'React';
 
 import View from '../View';
 import React from 'react';
@@ -35,11 +36,11 @@ class KeyboardAvoidingView extends React.Component<KeyboardAvoidingViewProps> {
 
   onKeyboardChange(event: Object) {}
 
-  onLayout = (event: LayoutEvent) => {
+  onLayout: (event: LayoutEvent) => void = (event: LayoutEvent) => {
     this.frame = event.nativeEvent.layout;
   };
 
-  render() {
+  render(): Node {
     const {
       /* eslint-disable */
       behavior,

--- a/packages/react-native-web/src/exports/Modal/ModalAnimation.js
+++ b/packages/react-native-web/src/exports/Modal/ModalAnimation.js
@@ -7,6 +7,7 @@
  *
  * @flow
  */
+import type { Node } from 'react';
 
 import { useEffect, useCallback, useState, useRef } from 'react';
 import StyleSheet from '../StyleSheet';
@@ -32,7 +33,7 @@ export type ModalAnimationProps = {|
   visible?: ?boolean
 |};
 
-function ModalAnimation(props: ModalAnimationProps) {
+function ModalAnimation(props: ModalAnimationProps): Node {
   const { animationType, children, onDismiss, onShow, visible } = props;
 
   const [isRendering, setIsRendering] = useState(false);

--- a/packages/react-native-web/src/exports/Modal/ModalFocusTrap.js
+++ b/packages/react-native-web/src/exports/Modal/ModalFocusTrap.js
@@ -8,6 +8,7 @@
  * @flow
  */
 
+import type { Node as ReactNode } from 'React';
 import React, { useRef, useEffect } from 'react';
 import { canUseDOM } from 'fbjs/lib/ExecutionEnvironment';
 import View from '../View';
@@ -70,7 +71,7 @@ export type ModalFocusTrapProps = {|
   children?: any
 |};
 
-const ModalFocusTrap = ({ active, children }: ModalFocusTrapProps) => {
+const ModalFocusTrap = ({ active, children }: ModalFocusTrapProps): ReactNode => {
   const trapElementRef = useRef<?HTMLElement>();
   const focusRef = useRef<{ trapFocusInProgress: boolean, lastFocusedElement: ?HTMLElement }>({
     trapFocusInProgress: false,

--- a/packages/react-native-web/src/exports/Modal/ModalPortal.js
+++ b/packages/react-native-web/src/exports/Modal/ModalPortal.js
@@ -7,6 +7,7 @@
  *
  * @flow
  */
+import type { Node } from 'react';
 
 import { useEffect, useRef } from 'react';
 import { canUseDOM } from 'fbjs/lib/ExecutionEnvironment';
@@ -16,7 +17,7 @@ export type ModalPortalProps = {|
   children: any
 |};
 
-function ModalPortal(props: ModalPortalProps) {
+function ModalPortal(props: ModalPortalProps): Node {
   const { children } = props;
   const elementRef = useRef(null);
 

--- a/packages/react-native-web/src/exports/PanResponder/Alternative.js
+++ b/packages/react-native-web/src/exports/PanResponder/Alternative.js
@@ -201,7 +201,25 @@ const PanResponder = {
    * gestureState once in the capture phase and can use it in the bubble phase
    * as well.
    */
-  create(config: PanResponderConfig) {
+  create(
+    config: PanResponderConfig
+  ): {|
+    getInteractionHandle: () => ?number,
+    panHandlers: {|
+      onMoveShouldSetResponder: (event: PressEvent) => boolean,
+      onMoveShouldSetResponderCapture: (event: PressEvent) => boolean,
+      onResponderEnd: (event: PressEvent) => void,
+      onResponderGrant: (event: PressEvent) => void,
+      onResponderMove: (event: PressEvent) => void,
+      onResponderReject: (event: PressEvent) => void,
+      onResponderRelease: (event: PressEvent) => void,
+      onResponderStart: (event: PressEvent) => void,
+      onResponderTerminate: (event: PressEvent) => void,
+      onResponderTerminationRequest: (event: PressEvent) => boolean,
+      onStartShouldSetResponder: (event: PressEvent) => boolean,
+      onStartShouldSetResponderCapture: (event: PressEvent) => boolean
+    |}
+  |} {
     const interactionState = {
       handle: (null: ?number)
     };

--- a/packages/react-native-web/src/exports/Platform/index.js
+++ b/packages/react-native-web/src/exports/Platform/index.js
@@ -10,7 +10,7 @@
 
 const Platform = {
   OS: 'web',
-  select: (obj: Object) => ('web' in obj ? obj.web : obj.default),
+  select: (obj: Object): any => ('web' in obj ? obj.web : obj.default),
   get isTesting(): boolean {
     if (process.env.NODE_DEV === 'test') {
       return true;

--- a/packages/react-native-web/src/exports/RefreshControl/index.js
+++ b/packages/react-native-web/src/exports/RefreshControl/index.js
@@ -10,6 +10,7 @@
 
 import type { ColorValue } from '../../types';
 import type { ViewProps } from '../View';
+import type { Node } from 'React';
 
 import View from '../View';
 import React from 'react';
@@ -28,7 +29,7 @@ type RefreshControlProps = {
   titleColor?: ColorValue
 };
 
-function RefreshControl(props: RefreshControlProps) {
+function RefreshControl(props: RefreshControlProps): Node {
   const {
     /* eslint-disable */
     colors,

--- a/packages/react-native-web/src/exports/StatusBar/index.js
+++ b/packages/react-native-web/src/exports/StatusBar/index.js
@@ -9,7 +9,7 @@
 
 const emptyFunction = () => {};
 
-function StatusBar() {
+function StatusBar(): null {
   return null;
 }
 

--- a/packages/react-native-web/src/exports/StyleSheet/StyleSheet.js
+++ b/packages/react-native-web/src/exports/StyleSheet/StyleSheet.js
@@ -18,12 +18,12 @@ const absoluteFillObject = {
   top: 0,
   bottom: 0
 };
-const absoluteFill = ReactNativePropRegistry.register(absoluteFillObject);
+const absoluteFill: number = ReactNativePropRegistry.register(absoluteFillObject);
 
 const StyleSheet = {
   absoluteFill,
   absoluteFillObject,
-  compose(style1: any, style2: any) {
+  compose(style1: any, style2: any): any {
     if (process.env.NODE_ENV !== 'production') {
       /* eslint-disable prefer-rest-params */
       const len = arguments.length;
@@ -44,7 +44,7 @@ const StyleSheet = {
       return style1 || style2;
     }
   },
-  create(styles: Object) {
+  create(styles: Object): {| [key: string]: number |} {
     const result = {};
     Object.keys(styles).forEach((key) => {
       if (process.env.NODE_ENV !== 'production') {

--- a/packages/react-native-web/src/exports/StyleSheet/createCompileableStyle.js
+++ b/packages/react-native-web/src/exports/StyleSheet/createCompileableStyle.js
@@ -40,7 +40,7 @@ function textShadowReducer(resolvedStyle, style) {
   }
 }
 
-const createCompileableStyle = (styles: Object) => {
+const createCompileableStyle = (styles: Object): Object => {
   const {
     shadowColor,
     shadowOffset,

--- a/packages/react-native-web/src/exports/StyleSheet/createOrderedCSSStyleSheet.js
+++ b/packages/react-native-web/src/exports/StyleSheet/createOrderedCSSStyleSheet.js
@@ -27,7 +27,12 @@ const slice = Array.prototype.slice;
  * https://developer.mozilla.org/en-US/docs/Web/API/CSSMediaRule
  * https://gist.github.com/necolas/aa0c37846ad6bd3b05b727b959e82674
  */
-export default function createOrderedCSSStyleSheet(sheet: ?CSSStyleSheet) {
+export default function createOrderedCSSStyleSheet(
+  sheet: ?CSSStyleSheet
+): {|
+  getTextContent: () => string,
+  insert: (cssText: string, groupValue: number) => void
+|} {
   const groups: Groups = {};
   const selectors: Selectors = {};
 

--- a/packages/react-native-web/src/exports/StyleSheet/i18nStyle.js
+++ b/packages/react-native-web/src/exports/StyleSheet/i18nStyle.js
@@ -76,9 +76,9 @@ const PROPERTIES_VALUE = {
 };
 
 // Invert the sign of a numeric-like value
-const additiveInverse = (value: String | Number) => multiplyStyleLengthValue(value, -1);
+const additiveInverse = (value: string | number) => multiplyStyleLengthValue(value, -1);
 
-const i18nStyle = (originalStyle: Object) => {
+const i18nStyle = <T: {| [key: string]: any |}>(originalStyle: T): T => {
   const { doLeftAndRightSwapInRTL, isRTL } = I18nManager.getConstants();
   const style = originalStyle || emptyObject;
   const frozenProps = {};
@@ -145,6 +145,7 @@ const i18nStyle = (originalStyle: Object) => {
     }
   }
 
+  // $FlowIgnore: Lots of conditionals happening above that means we can't promise the new value will have the same keys as the old, but it will
   return nextStyle;
 };
 

--- a/packages/react-native-web/src/exports/StyleSheet/initialRules.js
+++ b/packages/react-native-web/src/exports/StyleSheet/initialRules.js
@@ -13,9 +13,9 @@ const resets = [
   'body{margin:0;}',
   // minimal form pseudo-element reset
   'button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0;}',
-  'input::-webkit-inner-spin-button,input::-webkit-outer-spin-button,' +
+  ('input::-webkit-inner-spin-button,input::-webkit-outer-spin-button,' +
     'input::-webkit-search-cancel-button,input::-webkit-search-decoration,' +
-    'input::-webkit-search-results-button,input::-webkit-search-results-decoration{display:none;}'
+    'input::-webkit-search-results-button,input::-webkit-search-results-decoration{display:none;}': string)
 ];
 
 export default resets;

--- a/packages/react-native-web/src/exports/StyleSheet/normalizeValueWithProperty.js
+++ b/packages/react-native-web/src/exports/StyleSheet/normalizeValueWithProperty.js
@@ -23,7 +23,7 @@ const colorProps = {
   textShadowColor: true
 };
 
-export default function normalizeValueWithProperty(value: any, property?: ?string) {
+export default function normalizeValueWithProperty(value: any, property?: ?string): any {
   let returnValue = value;
   if ((property == null || !unitlessNumbers[property]) && typeof value === 'number') {
     returnValue = `${value}px`;

--- a/packages/react-native-web/src/exports/StyleSheet/resolveShadowValue.js
+++ b/packages/react-native-web/src/exports/StyleSheet/resolveShadowValue.js
@@ -12,7 +12,7 @@ import normalizeValueWithProperty from './normalizeValueWithProperty';
 
 const defaultOffset = { height: 0, width: 0 };
 
-const resolveShadowValue = (style: Object) => {
+const resolveShadowValue = (style: Object): void | string => {
   const { shadowColor, shadowOffset, shadowOpacity, shadowRadius } = style;
   const { height, width } = shadowOffset || defaultOffset;
   const offsetX = normalizeValueWithProperty(width);

--- a/packages/react-native-web/src/exports/StyleSheet/styleResolver.js
+++ b/packages/react-native-web/src/exports/StyleSheet/styleResolver.js
@@ -8,5 +8,5 @@
  */
 
 import createStyleResolver from './createStyleResolver';
-const styleResolver = createStyleResolver();
+const styleResolver: any = createStyleResolver();
 export default styleResolver;

--- a/packages/react-native-web/src/exports/Touchable/BoundingDimensions.js
+++ b/packages/react-native-web/src/exports/Touchable/BoundingDimensions.js
@@ -25,7 +25,7 @@ BoundingDimensions.prototype.destructor = function () {
   this.height = null;
 };
 
-BoundingDimensions.getPooledFromElement = function (element) {
+BoundingDimensions.getPooledFromElement = function (element): any {
   return BoundingDimensions.getPooled(element.offsetWidth, element.offsetHeight);
 };
 

--- a/packages/react-native-web/src/exports/Touchable/index.js
+++ b/packages/react-native-web/src/exports/Touchable/index.js
@@ -9,6 +9,7 @@
  */
 
 'use strict';
+import type { Node } from 'React';
 
 import AccessibilityUtil from '../../modules/AccessibilityUtil';
 import BoundingDimensions from './BoundingDimensions';
@@ -401,7 +402,9 @@ const TouchableMixin = {
    * @return {object} State object to be placed inside of
    * `this.state.touchable`.
    */
-  touchableGetInitialState: function () {
+  touchableGetInitialState: function (): {|
+    touchable: {| responderID: null, touchState: void |}
+  |} {
     return {
       touchable: { touchState: undefined, responderID: null }
     };
@@ -411,21 +414,21 @@ const TouchableMixin = {
   /**
    * Must return true if embedded in a native platform scroll view.
    */
-  touchableHandleResponderTerminationRequest: function () {
+  touchableHandleResponderTerminationRequest: function (): any {
     return !this.props.rejectResponderTermination;
   },
 
   /**
    * Must return true to start the process of `Touchable`.
    */
-  touchableHandleStartShouldSetResponder: function () {
+  touchableHandleStartShouldSetResponder: function (): any {
     return !this.props.disabled;
   },
 
   /**
    * Return true to cancel press on long press.
    */
-  touchableLongPressCancelsPress: function () {
+  touchableLongPressCancelsPress: function (): boolean {
     return true;
   },
 
@@ -761,7 +764,7 @@ const TouchableMixin = {
     this.longPressDelayTimeout = null;
   },
 
-  _isHighlight: function (state: State) {
+  _isHighlight: function (state: State): boolean {
     return (
       state === States.RESPONDER_ACTIVE_PRESS_IN || state === States.RESPONDER_ACTIVE_LONG_PRESS_IN
     );
@@ -776,7 +779,7 @@ const TouchableMixin = {
     this.pressInLocation = { pageX, pageY, locationX, locationY };
   },
 
-  _getDistanceBetweenPoints: function (aX: number, aY: number, bX: number, bY: number) {
+  _getDistanceBetweenPoints: function (aX: number, aY: number, bX: number, bY: number): number {
     const deltaX = aX - bX;
     const deltaY = aY - bY;
     return Math.sqrt(deltaX * deltaX + deltaY * deltaY);
@@ -904,7 +907,7 @@ const TouchableMixin = {
     }
   },
 
-  withoutDefaultFocusAndBlur: {}
+  withoutDefaultFocusAndBlur: ({}: { ... })
 };
 
 /**
@@ -928,7 +931,13 @@ const Touchable = {
   /**
    * Renders a debugging overlay to visualize touch target with hitSlop (might not work on Android).
    */
-  renderDebugView: ({ color, hitSlop }: { color: string | number, hitSlop: EdgeInsetsProp }) => {
+  renderDebugView: ({
+    color,
+    hitSlop
+  }: {
+    color: string | number,
+    hitSlop: EdgeInsetsProp
+  }): Node => {
     if (!Touchable.TOUCH_TARGET_DEBUG) {
       return null;
     }

--- a/packages/react-native-web/src/exports/YellowBox/index.js
+++ b/packages/react-native-web/src/exports/YellowBox/index.js
@@ -8,10 +8,11 @@
  * @flow
  */
 
+import type { Node } from 'React';
 import React from 'react';
 import UnimplementedView from '../../modules/UnimplementedView';
 
-function YellowBox(props: Object) {
+function YellowBox(props: Object): Node {
   return <UnimplementedView {...props} />;
 }
 

--- a/packages/react-native-web/src/modules/AccessibilityUtil/isDisabled.js
+++ b/packages/react-native-web/src/modules/AccessibilityUtil/isDisabled.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-const isDisabled = (props: Object) =>
+const isDisabled = (props: Object): boolean =>
   props.disabled ||
   (Array.isArray(props.accessibilityStates) && props.accessibilityStates.indexOf('disabled') > -1);
 

--- a/packages/react-native-web/src/modules/AccessibilityUtil/propsToAccessibilityComponent.js
+++ b/packages/react-native-web/src/modules/AccessibilityUtil/propsToAccessibilityComponent.js
@@ -32,7 +32,7 @@ const roleComponents = {
 
 const emptyObject = {};
 
-const propsToAccessibilityComponent = (props: Object = emptyObject) => {
+const propsToAccessibilityComponent = (props: Object = emptyObject): void | string => {
   // special-case for "label" role which doesn't map to an ARIA role
   if (props.accessibilityRole === 'label') {
     return 'label';

--- a/packages/react-native-web/src/modules/AccessibilityUtil/propsToAriaRole.js
+++ b/packages/react-native-web/src/modules/AccessibilityUtil/propsToAriaRole.js
@@ -22,7 +22,7 @@ const accessibilityRoleToWebRole = {
   text: null
 };
 
-const propsToAriaRole = ({ accessibilityRole }: Object) => {
+const propsToAriaRole = ({ accessibilityRole }: { accessibilityRole?: string }): string | void => {
   if (accessibilityRole) {
     const inferredRole = accessibilityRoleToWebRole[accessibilityRole];
     if (inferredRole !== null) {

--- a/packages/react-native-web/src/modules/ImageLoader/index.js
+++ b/packages/react-native-web/src/modules/ImageLoader/index.js
@@ -13,7 +13,7 @@ export class ImageUriCache {
   static _maximumEntries: number = 256;
   static _entries = {};
 
-  static has(uri: string) {
+  static has(uri: string): boolean {
     const entries = ImageUriCache._entries;
     const isDataUri = dataUriPattern.test(uri);
     return isDataUri || Boolean(entries[uri]);
@@ -110,7 +110,7 @@ const ImageLoader = {
       clearInterval(interval);
     }
   },
-  has(uri: string) {
+  has(uri: string): boolean {
     return ImageUriCache.has(uri);
   },
   load(uri: string, onLoad: Function, onError: Function): number {

--- a/packages/react-native-web/src/modules/UnimplementedView/index.js
+++ b/packages/react-native-web/src/modules/UnimplementedView/index.js
@@ -7,6 +7,7 @@
  * @flow
  */
 
+import type { Node } from 'React';
 import View from '../../exports/View';
 import React from 'react';
 
@@ -18,7 +19,7 @@ class UnimplementedView extends React.Component<*, *> {
     // Do nothing.
   }
 
-  render() {
+  render(): Node {
     return <View style={[unimplementedViewStyles, this.props.style]}>{this.props.children}</View>;
   }
 }

--- a/packages/react-native-web/src/modules/flattenArray/index.js
+++ b/packages/react-native-web/src/modules/flattenArray/index.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-function flattenArray(array: Array<any>) {
+function flattenArray(array: Array<any>): Array<any> {
   function flattenDown(array, result) {
     for (let i = 0; i < array.length; i++) {
       const value = array[i];

--- a/packages/react-native-web/src/modules/getBoundingClientRect/index.js
+++ b/packages/react-native-web/src/modules/getBoundingClientRect/index.js
@@ -7,7 +7,7 @@
  * @flow strict
  */
 
-const getBoundingClientRect = (node: ?HTMLElement) => {
+const getBoundingClientRect = (node: ?HTMLElement): void | ClientRect => {
   if (node != null) {
     const isElement = node.nodeType === 1; /* Node.ELEMENT_NODE */
     if (isElement && typeof node.getBoundingClientRect === 'function') {

--- a/packages/react-native-web/src/modules/isSelectionValid/index.js
+++ b/packages/react-native-web/src/modules/isSelectionValid/index.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-export default function isSelectionValid() {
+export default function isSelectionValid(): boolean {
   const selection = window.getSelection();
   const string = selection.toString();
   const anchorNode = selection.anchorNode;

--- a/packages/react-native-web/src/modules/mergeRefs/index.js
+++ b/packages/react-native-web/src/modules/mergeRefs/index.js
@@ -9,7 +9,9 @@
 
 import * as React from 'react';
 
-export default function mergeRefs(...args: $ReadOnlyArray<React.ElementRef<any>>) {
+export default function mergeRefs(
+  ...args: $ReadOnlyArray<React.ElementRef<any>>
+): (node: HTMLElement | null) => void {
   return function forwardRef(node: HTMLElement | null) {
     args.forEach((ref: React.ElementRef<any>) => {
       if (ref == null) {

--- a/packages/react-native-web/src/modules/modality/index.js
+++ b/packages/react-native-web/src/modules/modality/index.js
@@ -212,7 +212,7 @@ export function getModality(): Modality {
 
 export function addModalityListener(
   listener: ({ activeModality: Modality, modality: Modality }) => void
-) {
+): () => void {
   listeners.add(listener);
   return () => {
     listeners.delete(listener);

--- a/packages/react-native-web/src/modules/normalizeColor/index.js
+++ b/packages/react-native-web/src/modules/normalizeColor/index.js
@@ -10,7 +10,7 @@
 import isWebColor from '../isWebColor';
 import processColor from '../../exports/processColor';
 
-const normalizeColor = (color?: number | string, opacity?: number = 1) => {
+const normalizeColor = (color?: number | string, opacity?: number = 1): void | string => {
   if (color == null) return;
 
   if (typeof color === 'string' && isWebColor(color)) {

--- a/packages/react-native-web/src/modules/prefixStyles/index.js
+++ b/packages/react-native-web/src/modules/prefixStyles/index.js
@@ -10,11 +10,11 @@
 import createPrefixer from 'inline-style-prefixer/lib/createPrefixer';
 import staticData from './static';
 
-const prefixAll = createPrefixer(staticData);
+const prefixAll: any = createPrefixer(staticData);
 
 export default prefixAll;
 
-export const prefixInlineStyles = (style: Object) => {
+export const prefixInlineStyles = (style: Object): any => {
   const prefixedStyles = prefixAll(style);
 
   // React@15 removed undocumented support for fallback values in

--- a/packages/react-native-web/src/modules/requestIdleCallback/index.js
+++ b/packages/react-native-web/src/modules/requestIdleCallback/index.js
@@ -21,15 +21,18 @@ const _requestIdleCallback = function (cb: Function, options?: Object) {
   }, 1);
 };
 
-// $FlowFixMe (TimeoutID type is not recognized by eslint)
 const _cancelIdleCallback = function (id) {
   clearTimeout(id);
 };
 
 const isSupported = canUseDOM && typeof window.requestIdleCallback !== 'undefined';
 
-const requestIdleCallback = isSupported ? window.requestIdleCallback : _requestIdleCallback;
-const cancelIdleCallback = isSupported ? window.cancelIdleCallback : _cancelIdleCallback;
+const requestIdleCallback: (cb: any, options?: any) => TimeoutID = isSupported
+  ? window.requestIdleCallback
+  : _requestIdleCallback;
+const cancelIdleCallback: (TimeoutID) => void = isSupported
+  ? window.cancelIdleCallback
+  : _cancelIdleCallback;
 
 export default requestIdleCallback;
 export { cancelIdleCallback };

--- a/packages/react-native-web/src/modules/useMergeRefs/index.js
+++ b/packages/react-native-web/src/modules/useMergeRefs/index.js
@@ -10,7 +10,9 @@
 import * as React from 'react';
 import mergeRefs from '../mergeRefs';
 
-export default function useMergeRefs(...args: $ReadOnlyArray<React.ElementRef<any>>) {
+export default function useMergeRefs(
+  ...args: $ReadOnlyArray<React.ElementRef<any>>
+): (node: HTMLElement | null) => void {
   return React.useMemo(
     () => mergeRefs(...args),
     // eslint-disable-next-line

--- a/packages/react-native-web/src/modules/usePlatformMethods/index.js
+++ b/packages/react-native-web/src/modules/usePlatformMethods/index.js
@@ -58,7 +58,7 @@ export default function usePlatformMethods({
   classList?: Array<string | boolean>,
   style?: GenericStyleProp<*>,
   pointerEvents?: $PropertyType<ViewProps, 'pointerEvents'>
-}) {
+}): (hostNode: any) => void {
   const previousStyleRef = useRef(null);
   const setNativePropsArgsRef = useRef(null);
   setNativePropsArgsRef.current = { classList, pointerEvents, style };

--- a/packages/react-native-web/src/modules/useResponderEvents/utils.js
+++ b/packages/react-native-web/src/modules/useResponderEvents/utils.js
@@ -78,7 +78,7 @@ export function getResponderPaths(
 /**
  * Walk the paths and find the first common ancestor
  */
-export function getLowestCommonAncestor(pathA: Array<any>, pathB: Array<any>) {
+export function getLowestCommonAncestor(pathA: Array<any>, pathB: Array<any>): any {
   let pathALength = pathA.length;
   let pathBLength = pathB.length;
   if (
@@ -146,7 +146,7 @@ export function hasTargetTouches(target: any, touches: any): boolean {
  * Ignore 'selectionchange' events that don't correspond with a person's intent to
  * select text.
  */
-export function hasValidSelection(domEvent: any) {
+export function hasValidSelection(domEvent: any): boolean {
   if (domEvent.type === 'selectionchange') {
     return isSelectionValid();
   }


### PR DESCRIPTION
Run `flow codemod annotate-exports` on the src folder of RNW and manually audit all these types to make sure they are reasonable.

Many places still have any-types, so let those as is. In a few places, I was able to make flow happy by using `navigator` directly instead of `window.navigator`. I'm not sure why this is a thing, but I believe they are interchangeable and flow has navigator typed but not as window.navigator. So that helped a bit.

Other than the above note, no functional changes...just a wee bit messier at times