### PR TITLE
Flow 0.142 (6/7): Enable types-first by default; fix remaining issues

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,7 @@
     "react": {
       "pragma": "React",
       "version": "16.6",
-      "flowVersion": "0.142.0" // Flow version
+      "flowVersion": "0.148.0" // Flow version
     }
   },
   // babel parser to support ES6/7 features

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,5 @@
 [version]
-^0.142.0
+^0.148.0
 
 [ignore]
 <PROJECT_ROOT>/.*/__tests__/.*
@@ -15,10 +15,3 @@
 
 [options]
 munge_underscores=true
-types_first=false
-well_formed_exports=false
-esproposal.optional_chaining=enable
-suppress_type=$FlowIssue
-suppress_type=$FlowFixMe
-suppress_type=$FlowFixMeProps
-suppress_type=$FlowFixMeState

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "eslint-plugin-promise": "^4.2.1",
     "eslint-plugin-react": "^7.22.0",
     "eslint-plugin-react-hooks": "^4.2.0",
-    "flow-bin": "^0.142.0",
+    "flow-bin": "^0.148.0",
     "glob": "^7.1.6",
     "husky": "^4.3.8",
     "inline-style-prefixer": "^6.0.0",

--- a/packages/benchmarks/src/app/Benchmark/index.js
+++ b/packages/benchmarks/src/app/Benchmark/index.js
@@ -7,6 +7,8 @@
 
 /* global $Values */
 
+import type { Node } from 'react';
+
 import * as Timing from './timing';
 import React, { Component } from 'react';
 import { getMean, getMedian, getStdDev } from './math';
@@ -94,15 +96,19 @@ export default class Benchmark extends Component<BenchmarkPropsType, BenchmarkSt
   _startTime: number;
   _samples: Array<SampleTimingType>;
 
-  static displayName = 'Benchmark';
+  static displayName: ?string = 'Benchmark';
 
-  static defaultProps = {
+  static defaultProps: {|
+    sampleCount: number,
+    timeout: number,
+    type: $PropertyType<BenchmarkPropsType, 'type'>
+  |} = {
     sampleCount: 50,
     timeout: 10000, // 10 seconds
     type: BenchmarkType.MOUNT
   };
 
-  static Type = BenchmarkType;
+  static Type: typeof BenchmarkType = BenchmarkType;
 
   constructor(props: BenchmarkPropsType, context?: {}) {
     super(props, context);
@@ -162,7 +168,7 @@ export default class Benchmark extends Component<BenchmarkPropsType, BenchmarkSt
     }
   }
 
-  render() {
+  render(): Node {
     const { component: Component, type } = this.props;
     const { componentProps, cycle, running } = this.state;
     if (running && shouldRecord(cycle, type)) {

--- a/packages/react-native-web/src/exports/Touchable/BoundingDimensions.js
+++ b/packages/react-native-web/src/exports/Touchable/BoundingDimensions.js
@@ -25,7 +25,7 @@ BoundingDimensions.prototype.destructor = function () {
   this.height = null;
 };
 
-BoundingDimensions.getPooledFromElement = function (element): any {
+BoundingDimensions.getPooledFromElement = function (element: HTMLElement): any {
   return BoundingDimensions.getPooled(element.offsetWidth, element.offsetHeight);
 };
 

--- a/packages/react-native-web/src/exports/useWindowDimensions/index.js
+++ b/packages/react-native-web/src/exports/useWindowDimensions/index.js
@@ -19,8 +19,7 @@ export default function useWindowDimensions(): DisplayMetrics {
   const [dims, setDims] = useState(() => Dimensions.get('window'));
   useEffect(() => {
     function handleChange({ window }) {
-      // $FlowFixMe
-      setDims(window);
+      window && setDims(window);
     }
     Dimensions.addEventListener('change', handleChange);
     // We might have missed an update between calling `get` in render and

--- a/packages/react-native-web/src/modules/useEvent/index.js
+++ b/packages/react-native-web/src/modules/useEvent/index.js
@@ -60,5 +60,6 @@ export default function useEvent(
     };
   }, [addListener]);
 
+  // $FlowFixMe: this hook has some funk where addListener can be nulled via cleanup, but flow and eslint don't like that
   return addListener;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5321,10 +5321,10 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.1.tgz#c4b489e80096d9df1dfc97c79871aea7c617c469"
   integrity sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==
 
-flow-bin@^0.142.0:
-  version "0.142.0"
-  resolved "https://registry.npmjs.org/flow-bin/-/flow-bin-0.142.0.tgz#b46b69de1123cf7c5a50917402968e07291df054"
-  integrity sha512-YgiapK/wrJjcgSgOWfoncbZ4vZrZWdHs+p7V9duI9zo4ehW2nM/VRrpSaWoZ+CWu3t+duGyAvupJvC6MM2l07w==
+flow-bin@^0.148.0:
+  version "0.148.0"
+  resolved "https://registry.npmjs.org/flow-bin/-/flow-bin-0.148.0.tgz#1d264606dbb4d6e6070cc98a775e21dcd64e6890"
+  integrity sha512-7Cx6BUm8UAlbqtYJNYXdMrh900MQhNV+SjtBxZuWN7UmlVG4tIRNzNLEOjNnj2DN2vcL1wfI5IlSUXnws/QCEw==
 
 follow-redirects@^1.0.0, follow-redirects@^1.10.0:
   version "1.13.1"


### PR DESCRIPTION
Get to our goal of enabling the new Flow architecture, types-first. The newer versions of flow remove the option at all, so instead of setting to true, I just updated flow again and cleaned up the config.

Fixed a few lingering issues missed by code-mods or raised by the new system (it catches a bit more).

NOTE: If you can take a look at useEffect that would be great. I didn't want to touch functionality and I'm not very good with hooks, but both flow and ESLint seem upset about how it's working, so maybe a quick tweak there would make it happier.