### PR TITLE
Update linking example: use hrefAttrs instead of target

### DIFF
--- a/packages/examples/pages/linking/index.js
+++ b/packages/examples/pages/linking/index.js
@@ -21,7 +21,7 @@ export default class LinkingPage extends PureComponent {
           accessibilityRole="link"
           href="https://mathiasbynens.github.io/rel-noopener/malicious.html"
           hrefAttrs={{
-              target: '_blank'
+            target: '_blank'
           }}
           style={styles.text}
         >

--- a/packages/examples/pages/linking/index.js
+++ b/packages/examples/pages/linking/index.js
@@ -20,8 +20,10 @@ export default class LinkingPage extends PureComponent {
         <Text
           accessibilityRole="link"
           href="https://mathiasbynens.github.io/rel-noopener/malicious.html"
+          hrefAttrs={{
+              target: '_blank'
+          }}
           style={styles.text}
-          target="_blank"
         >
           target="_blank"
         </Text>


### PR DESCRIPTION
The `target` prop no longer works. The correct way to set `target="_blank"` is to set `hrefAttrs={{target: '_blank'}}`.