### PR TITLE
Fix misspellings of NODE_ENV

### DIFF
--- a/packages/dom-event-testing-library/src/domEnvironment.js
+++ b/packages/dom-event-testing-library/src/domEnvironment.js
@@ -22,7 +22,7 @@ export function hasPointerEvent() {
 export function setPointerEvent(bool) {
   const pointerCaptureFn = (name) => (id) => {
     if (typeof id !== 'number') {
-      if (process.env.NODE_DEV !== 'production') {
+      if (process.env.NODE_ENV !== 'production') {
         console.error('A pointerId must be passed to "%s"', name);
       }
     }

--- a/packages/react-native-web/src/exports/Platform/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/Platform/__tests__/index-test.js
@@ -14,4 +14,21 @@ describe('apis/Platform', () => {
       ).toEqual('web');
     });
   });
+  describe('isTesting', () => {
+    const NODE_ENV_BACKUP = process.env.NODE_ENV;
+
+    afterEach(() => {
+      process.env.NODE_ENV = NODE_ENV_BACKUP;
+    });
+
+    test('true when NODE_ENV is "test"', () => {
+      process.env.NODE_ENV = 'test';
+      expect(Platform.isTesting).toEqual(true);
+    });
+
+    test('false when NODE_ENV is not "test"', () => {
+      process.env.NODE_ENV = 'development';
+      expect(Platform.isTesting).toEqual(false);
+    });
+  });
 });

--- a/packages/react-native-web/src/exports/Platform/index.js
+++ b/packages/react-native-web/src/exports/Platform/index.js
@@ -12,7 +12,7 @@ const Platform = {
   OS: 'web',
   select: (obj: Object): any => ('web' in obj ? obj.web : obj.default),
   get isTesting(): boolean {
-    if (process.env.NODE_DEV === 'test') {
+    if (process.env.NODE_ENV === 'test') {
       return true;
     }
     return false;


### PR DESCRIPTION
I spent a good 2 hours trying to figure out why my webpack.DefinePlugin was refusing to
replace process.env.NODE_ENV in react-native-web before I realized that it had been misspelled
as NODE_DEV in a couple places 😅. This change fixes that and adds a test for the Platform module.

This is technically a breaking change for the Platform module, although it's likely that anyone who
figured this issue out just set NODE_DEV=$NODE_ENV and will have NODE_ENV set correctly. The other
fix only controls a debug statement and is not breaking.