### PR TITLE
Add failing test for resolving behaviour of long form properties that have been de-duped into classnames

### DIFF
--- a/packages/react-native-web/src/exports/StyleSheet/__tests__/__snapshots__/createStyleResolver-test.js.snap
+++ b/packages/react-native-web/src/exports/StyleSheet/__tests__/__snapshots__/createStyleResolver-test.js.snap
@@ -1,5 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`StyleSheet/createStyleResolver resolve long form style properties take precedence over shorthand properties 1`] = `
+Object {
+  "classList": Array [
+    "r-paddingHorizontal-5wp0in",
+  ],
+  "className": "r-paddingHorizontal-5wp0in",
+  "style": Object {
+    "paddingBottom": "8px",
+    "paddingLeft": "40px",
+    "paddingRight": "40px",
+    "paddingTop": "8px",
+  },
+}
+`;
+
+exports[`StyleSheet/createStyleResolver resolve long form style properties take precedence over shorthand properties 2`] = `
+Object {
+  "classList": Array [
+    "r-marginVertical-1unineu",
+  ],
+  "className": "r-marginVertical-1unineu",
+  "style": Object {
+    "marginBottom": "40px",
+    "marginLeft": "8px",
+    "marginRight": "8px",
+    "marginTop": "40px",
+  },
+}
+`;
+
 exports[`StyleSheet/createStyleResolver resolve resolves inline-style pointerEvents to classname 1`] = `
 Object {
   "classList": Array [

--- a/packages/react-native-web/src/exports/StyleSheet/__tests__/createStyleResolver-test.js
+++ b/packages/react-native-web/src/exports/StyleSheet/__tests__/createStyleResolver-test.js
@@ -77,6 +77,16 @@ describe('StyleSheet/createStyleResolver', () => {
       expect(styleResolver.resolve({ pointerEvents: 'box-none' })).toMatchSnapshot();
     });
 
+    test('long form style properties take precedence over shorthand properties', () => {
+      const registeredStyle1 = ReactNativePropRegistry.register({ paddingHorizontal: '40px' });
+      const inlineStyle1 = { padding: '8px', paddingHorizontal: '40px' };
+      expect(styleResolver.resolve([registeredStyle1, inlineStyle1])).toMatchSnapshot();
+
+      const registeredStyle2 = ReactNativePropRegistry.register({ marginVertical: '40px' });
+      const inlineStyle2 = { margin: '8px', marginVertical: '40px' };
+      expect(styleResolver.resolve([registeredStyle2, inlineStyle2])).toMatchSnapshot();
+    });
+
     describe('sheet', () => {
       beforeEach(() => {
         ExecutionEnvironment.canUseDOM = false;


### PR DESCRIPTION
@necolas here's the failing test for https://github.com/necolas/react-native-web/issues/2007