### PR TITLE
[fix] Convert aspectRatio value to string

### DIFF
--- a/packages/react-native-web/src/exports/StyleSheet/__tests__/createReactDOMStyle-test.js
+++ b/packages/react-native-web/src/exports/StyleSheet/__tests__/createReactDOMStyle-test.js
@@ -39,6 +39,12 @@ describe('StyleSheet/createReactDOMStyle', () => {
     expect(createReactDOMStyle(style)).toMatchSnapshot();
   });
 
+  test('aspectRatio', () => {
+    expect(createReactDOMStyle({ aspectRatio: 9 / 16 })).toEqual({
+      aspectRatio: '0.5625'
+    });
+  });
+
   describe('flexbox styles', () => {
     test('flex: -1', () => {
       expect(createReactDOMStyle({ flex: -1 })).toEqual({

--- a/packages/react-native-web/src/exports/StyleSheet/createReactDOMStyle.js
+++ b/packages/react-native-web/src/exports/StyleSheet/createReactDOMStyle.js
@@ -87,6 +87,11 @@ const createReactDOMStyle = (style) => {
           break;
         }
 
+        case 'aspectRatio': {
+          resolvedStyle[prop] = value.toString();
+          break;
+        }
+
         // TODO: remove once this issue is fixed
         // https://github.com/rofrischmann/inline-style-prefixer/issues/159
         case 'backgroundClip': {

--- a/packages/react-native-web/src/modules/unitlessNumbers/index.js
+++ b/packages/react-native-web/src/modules/unitlessNumbers/index.js
@@ -10,6 +10,7 @@
 
 const unitlessNumbers = {
   animationIterationCount: true,
+  aspectRatio: true,
   borderImageOutset: true,
   borderImageSlice: true,
   borderImageWidth: true,


### PR DESCRIPTION
Turns out React expects the aspectRatio value to be a [string](https://github.com/frenic/csstype/blob/master/index.d.ts#L259), otherwise it ignores it.

This should make #427 finally work.