### PR TITLE
Specify esModule: false for url-loader config

### DIFF
--- a/packages/docs/src/pages/docs/getting-started/multi-platform.md
+++ b/packages/docs/src/pages/docs/getting-started/multi-platform.md
@@ -107,7 +107,8 @@ const imageLoaderConfiguration = {
   use: {
     loader: 'url-loader',
     options: {
-      name: '[name].[ext]'
+      name: '[name].[ext]',
+      esModule: false,
     }
   }
 };


### PR DESCRIPTION
Latest versions of `url-loader` default `esModule: true` which outputs a module object with `default` property for asset imports. This behaviour is different from metro which doesn't do that.

This breaks compatibility with a lot of React Native libraries since it's common to do an inline `require` for assets., so it'd work for Metro, but break with url-loader.