### PR TITLE
[fix] Ignore transition after component unmount

### DIFF
--- a/packages/react-native-web/src/exports/TouchableOpacity/index.js
+++ b/packages/react-native-web/src/exports/TouchableOpacity/index.js
@@ -15,6 +15,7 @@ import type { ViewProps } from '../View';
 
 import * as React from 'react';
 import { useCallback, useMemo, useState, useRef } from 'react';
+import useIsMounted from '../../modules/useIsMounted';
 import useMergeRefs from '../../modules/useMergeRefs';
 import usePressEvents from '../../modules/usePressEvents';
 import StyleSheet from '../StyleSheet';
@@ -51,16 +52,21 @@ function TouchableOpacity(props: Props, forwardedRef): React.Node {
 
   const hostRef = useRef(null);
   const setRef = useMergeRefs(forwardedRef, hostRef);
+  const isMounted = useIsMounted();
 
   const [duration, setDuration] = useState('0s');
   const [opacityOverride, setOpacityOverride] = useState(null);
 
   const setOpacityTo = useCallback(
     (value: ?number, duration: number) => {
+      if (!isMounted()) {
+        return;
+      }
+
       setOpacityOverride(value);
       setDuration(duration ? `${duration / 1000}s` : '0s');
     },
-    [setOpacityOverride, setDuration]
+    [setOpacityOverride, setDuration, isMounted]
   );
 
   const setOpacityActive = useCallback(

--- a/packages/react-native-web/src/modules/useIsMounted/index.js
+++ b/packages/react-native-web/src/modules/useIsMounted/index.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ */
+
+import * as React from 'react';
+
+export default function useIsMounted(): () => boolean {
+  const ref = React.useRef(false);
+
+  React.useEffect(() => {
+    ref.current = true;
+
+    return () => {
+      ref.current = false;
+    };
+  }, []);
+
+  return React.useCallback(() => ref.current, [ref]);
+}


### PR DESCRIPTION
fix https://github.com/necolas/react-native-web/issues/2051

Prevent `setOpacityTo` to run if the component unmount. When using the press event, and `onPress` result in the component unmounting, onPressEnd will still run after it, resulting in react warning about a memory leak.