### PR TITLE
fix: Set white-space to pre for single-line Text

### DIFF
--- a/packages/examples/pages/text/index.js
+++ b/packages/examples/pages/text/index.js
@@ -375,6 +375,19 @@ export default function TextPage() {
             {"'"}
             ll just truncate after one line.
           </Text>
+          <View style={{ border: '1px solid #cecece' }}>
+            <Text style={{ fontWeight: 700 }}>The next two lines should look identical:</Text>
+            <View style={{ display: 'flex', flexDirection: 'row' }}>
+              <Text numberOfLines={1}>Spaces </Text>
+              <Text numberOfLines={1}>between</Text>
+              <Text numberOfLines={1}> words</Text>
+            </View>
+            <View style={{ display: 'flex', flexDirection: 'row' }}>
+              <Text>Spaces </Text>
+              <Text>between</Text>
+              <Text> words</Text>
+            </View>
+          </View>
           <Text numberOfLines={2} style={{ marginTop: 20 }}>
             Maximum of two lines, no matter how much I write here. If I keep writing, it
             {"'"}

--- a/packages/react-native-web/src/exports/Text/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/react-native-web/src/exports/Text/__tests__/__snapshots__/index-test.js.snap
@@ -157,6 +157,13 @@ exports[`components/Text prop "numberOfLines" value is set 1`] = `
 />
 `;
 
+exports[`components/Text prop "numberOfLines" value is set to one 1`] = `
+<div
+  class="css-text-901oao css-textOneLine-vcwn7f"
+  dir="auto"
+/>
+`;
+
 exports[`components/Text prop "selectable" value of false 1`] = `
 <div
   class="css-text-901oao r-userSelect-lrvibr"

--- a/packages/react-native-web/src/exports/Text/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/Text/__tests__/index-test.js
@@ -129,7 +129,11 @@ describe('components/Text', () => {
 
   describe('prop "numberOfLines"', () => {
     test('value is set', () => {
-      const { container } = render(<Text numberOfLines="3" />);
+      const { container } = render(<Text numberOfLines={3} />);
+      expect(container.firstChild).toMatchSnapshot();
+    });
+    test('value is set to one', () => {
+      const { container } = render(<Text numberOfLines={1} />);
       expect(container.firstChild).toMatchSnapshot();
     });
   });

--- a/packages/react-native-web/src/exports/Text/index.js
+++ b/packages/react-native-web/src/exports/Text/index.js
@@ -175,7 +175,7 @@ const classes = css.create({
     maxWidth: '100%',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap'
+    whiteSpace: 'pre'
   },
   // See #13
   textMultiLine: {


### PR DESCRIPTION
By default, the Text component is rendered with `white-space: pre-wrap`
in order to keep meaningful whitespace behavior. When a Text component
had `numberOfLines={1}` set, word-wrapping was disabled by changing it
to specify `white-space: nowrap`.

However, `nowrap` removes the meaningful whitespace behavior. Instead,
use the `pre` value to maintain the leading and trailing whitespaces of
strings.

| Before | After |
|:---:|:---:|
| ![image](https://user-images.githubusercontent.com/418560/122192206-bc52f600-ce93-11eb-984c-0550534e9753.png) | ![image](https://user-images.githubusercontent.com/418560/122192240-c4129a80-ce93-11eb-8778-12a0502dbcde.png) |

References: [MDN's white-space page][white-space docs]

[white-space docs]: https://developer.mozilla.org/en-US/docs/Web/CSS/white-space