### PR TITLE
Removing persistent `clickHandler` in favour of checking for usefulness

### DIFF
--- a/packages/react-native-web/src/exports/Text/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/Text/__tests__/index-test.js
@@ -155,6 +155,22 @@ describe('components/Text', () => {
     });
   });
 
+  describe('prop "onClick"', () => {
+    test('is called', () => {
+      const onClick = jest.fn();
+      const ref = React.createRef();
+      act(() => {
+        render(<Text onClick={onClick} ref={ref} />);
+      });
+      const target = createEventTarget(ref.current);
+      act(() => {
+        target.pointerdown({ button: 0 });
+        target.pointerup({ button: 0 });
+      });
+      expect(onClick).toBeCalled();
+    });
+  });
+
   describe('prop "onFocus"', () => {
     test('is called', () => {
       const onFocus = jest.fn();

--- a/packages/react-native-web/src/exports/Text/index.js
+++ b/packages/react-native-web/src/exports/Text/index.js
@@ -104,22 +104,18 @@ const Text: React.AbstractComponent<TextProps, HTMLElement & PlatformMethods> = 
       onStartShouldSetResponderCapture
     });
 
-    const handleClick = React.useMemo(() => {
-      if (onClick) {
-        return (e) => {
-          // This is redundant, but Flow doesn't like it otherwise
-          onClick && onClick(e);
-        };
-      } else if (onPress) {
-        return (e) => {
+    const handleClick = React.useCallback(
+      function (e) {
+        if (onClick != null) {
+          onClick(e);
+        }
+        if (onClick == null && onPress != null) {
           e.stopPropagation();
-          // This is redundant, but Flow doesn't like it otherwise
-          onPress && onPress(e);
-        };
-      } else {
-        return undefined;
-      }
-    }, [onClick, onPress]);
+          onPress(e);
+        }
+      },
+      [onClick, onPress]
+    );
 
     let component = hasTextAncestor ? 'span' : 'div';
     const supportedProps = pickProps(props);
@@ -129,7 +125,11 @@ const Text: React.AbstractComponent<TextProps, HTMLElement & PlatformMethods> = 
     if (!hasTextAncestor) {
       supportedProps.dir = dir != null ? dir : 'auto';
     }
-    supportedProps.onClick = handleClick;
+
+    if (onClick || onPress) {
+      supportedProps.onClick = handleClick;
+    }
+
     supportedProps.style = style;
     if (props.href != null) {
       component = 'a';

--- a/packages/react-native-web/src/exports/Text/index.js
+++ b/packages/react-native-web/src/exports/Text/index.js
@@ -104,15 +104,22 @@ const Text: React.AbstractComponent<TextProps, HTMLElement & PlatformMethods> = 
       onStartShouldSetResponderCapture
     });
 
-    function handleClick(e) {
-      if (onClick != null) {
-        onClick(e);
+    const handleClick = React.useMemo(() => {
+      if (onClick) {
+        return (e) => {
+          // This is redundant, but Flow doesn't like it otherwise
+          onClick && onClick(e);
+        };
+      } else if (onPress) {
+        return (e) => {
+          e.stopPropagation();
+          // This is redundant, but Flow doesn't like it otherwise
+          onPress && onPress(e);
+        };
+      } else {
+        return undefined;
       }
-      if (onClick == null && onPress != null) {
-        e.stopPropagation();
-        onPress(e);
-      }
-    }
+    }, [onClick, onPress]);
 
     let component = hasTextAncestor ? 'span' : 'div';
     const supportedProps = pickProps(props);


### PR DESCRIPTION
I noticed that `Text` always has an `onClick` handler, whether it's needed or not. This can be confusing for some screen reader users, because their screen reader will announce an element as "clickable" if it has a click event handler attached. To reduce that confusion, this patch suggests using `React.useMemo` to only generate a click handler as needed.

Make of it what you will - just a thought.