### PR TITLE
Fix keyboard number type

### DIFF
--- a/packages/react-native-web/src/exports/TextInput/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/TextInput/__tests__/index-test.js
@@ -171,18 +171,21 @@ describe('components/TextInput', () => {
       const { container } = render(<TextInput keyboardType="decimal-pad" />);
       const input = findInput(container);
       expect(input.inputMode).toEqual('decimal');
+      expect(input.type).toEqual('number');
     });
 
     test('value "number-pad"', () => {
       const { container } = render(<TextInput keyboardType="number-pad" />);
       const input = findInput(container);
       expect(input.inputMode).toEqual('numeric');
+      expect(input.type).toEqual('number');
     });
 
     test('value "numeric"', () => {
       const { container } = render(<TextInput keyboardType="numeric" />);
       const input = findInput(container);
       expect(input.inputMode).toEqual('numeric');
+      expect(input.type).toEqual('number');
     });
 
     test('value "phone-pad"', () => {

--- a/packages/react-native-web/src/exports/TextInput/index.js
+++ b/packages/react-native-web/src/exports/TextInput/index.js
@@ -142,9 +142,11 @@ const TextInput: React.AbstractComponent<
     case 'number-pad':
     case 'numeric':
       inputMode = 'numeric';
+      type = 'number';
       break;
     case 'decimal-pad':
       inputMode = 'decimal';
+      type = 'number';
       break;
     case 'phone-pad':
       type = 'tel';


### PR DESCRIPTION
Numeric/decimal keyboardType should also set type=number to allow only numeric keys on desktop and mobile.