### PR TITLE
Update pan-responder docs

### DIFF
--- a/packages/docs/src/pages/docs/apis/pan-responder.md
+++ b/packages/docs/src/pages/docs/apis/pan-responder.md
@@ -13,6 +13,10 @@ eleventyNavigation:
 PanResponder reconciles several pointers into a single gesture. It makes single-pointer gestures resilient to extra touches, and can be used to recognize basic multi-touch gestures.
 :::
 
+:::callout
+**Note:** Using PanResponder on components that contain text will interrupt dragging the component to begin selecting the text instead. You can avoid this by applying the following CSS to the text elements: `userSelect: 'none'`.
+:::
+
 Please refer to the React Native documentation below:
 
 * [PanResponder](https://reactnative.dev/docs/panresponder)


### PR DESCRIPTION
Update pan-responder docs to include a note about an issue in web projects where dragging components with text will stop dragging and being selecting text, including a way to avoid the issue.