### PR TITLE
Linking.openURL(tel link) call in current tab.

### DIFF
--- a/packages/react-native-web/src/exports/Linking/index.js
+++ b/packages/react-native-web/src/exports/Linking/index.js
@@ -88,7 +88,11 @@ class Linking {
 const open = (url) => {
   if (canUseDOM) {
     const urlToOpen = new URL(url, window.location).toString();
-    window.open(urlToOpen, '_blank', 'noopener');
+    if (urlToOpen.startsWith('tel:')) {
+      window.location = urlToOpen;
+    } else {
+      window.open(urlToOpen, '_blank', 'noopener');
+    }
   }
 };
 


### PR DESCRIPTION
If url is tel link, i changed it to [the previous way](https://github.com/necolas/react-native-web/commit/b7b383098aac42609166da38808a65497b5469a5#diff-c499d85ecabac736ba8c25cf587b40613f85e13411a048868dabac27b34df970).

Detailed description in issue: #2124 

Fixes: #2124 