### PR TITLE
Adjust AppState to match 0.65 API

### DIFF
--- a/packages/docs/src/pages/docs/apis/app-state.md
+++ b/packages/docs/src/pages/docs/apis/app-state.md
@@ -36,7 +36,7 @@ Returns the current state of the app.
 
 ### Static methods
 
-{% call macro.prop('addEventListener', '(type: ?string, listener: (boolean) => void) => void') %}
+{% call macro.prop('addEventListener', '(type: ?string, listener: (boolean) => void) => ?EmitterSubscription') %}
 Add a listener to `AppState` changes. Listen to the `"change"` event type. The handler is called with the app state value.
 {% endcall %}
 

--- a/packages/examples/pages/app-state/index.js
+++ b/packages/examples/pages/app-state/index.js
@@ -18,9 +18,9 @@ export default function AppStatePage() {
       }));
     };
 
-    AppState.addEventListener('change', handleChange);
+    const subscription = AppState.addEventListener('change', handleChange);
     return () => {
-      AppState.removeEventListener('change', handleChange);
+      subscription.remove();
     };
   }, []);
 

--- a/packages/react-native-web/src/exports/AppState/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/AppState/__tests__/index-test.js
@@ -5,22 +5,22 @@ import AppState from '..';
 describe('apis/AppState', () => {
   const handler = () => {};
 
-  afterEach(() => {
-    try {
-      AppState.removeEventListener('change', handler);
-    } catch (e) {}
-  });
-
   describe('addEventListener', () => {
     test('throws if the provided "eventType" is not supported', () => {
       expect(() => AppState.addEventListener('foo', handler)).toThrow();
-      expect(() => AppState.addEventListener('change', handler)).not.toThrow();
+      expect(() => AppState.addEventListener('change', handler).remove()).not.toThrow();
     });
   });
 
   describe('removeEventListener', () => {
-    test('throws if the handler is not registered', () => {
-      expect(() => AppState.removeEventListener('change', handler)).toThrow();
+    beforeEach(() => {
+      // removeEventListener logs a deprecation warning, ignore
+      jest.spyOn(console, 'error');
+      console.error.mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      console.error.mockRestore();
     });
 
     test('throws if the provided "eventType" is not supported', () => {

--- a/packages/react-native-web/src/exports/AppState/index.js
+++ b/packages/react-native-web/src/exports/AppState/index.js
@@ -9,8 +9,8 @@
  */
 
 import { canUseDOM } from 'fbjs/lib/ExecutionEnvironment';
-import findIndex from 'array-find-index';
 import invariant from 'fbjs/lib/invariant';
+import EventEmitter from '../../vendor/react-native/emitter/_EventEmitter';
 
 // Android 4.4 browser
 const isPrefixed =
@@ -25,7 +25,12 @@ const AppStates = {
   ACTIVE: 'active'
 };
 
-const listeners = [];
+const changeEmitter = new EventEmitter();
+document.addEventListener(
+  VISIBILITY_CHANGE_EVENT,
+  () => changeEmitter.emit('change', AppState.currentState),
+  false
+);
 
 export default class AppState {
   static isAvailable = canUseDOM && document[VISIBILITY_STATE_PROPERTY];
@@ -53,9 +58,7 @@ export default class AppState {
         type
       );
       if (type === 'change') {
-        const callback = () => handler(AppState.currentState);
-        listeners.push([handler, callback]);
-        document.addEventListener(VISIBILITY_CHANGE_EVENT, callback, false);
+        return changeEmitter.addListener(type, handler);
       }
     }
   }
@@ -68,14 +71,7 @@ export default class AppState {
         type
       );
       if (type === 'change') {
-        const listenerIndex = findIndex(listeners, (pair) => pair[0] === handler);
-        invariant(
-          listenerIndex !== -1,
-          'Trying to remove AppState listener for unregistered handler'
-        );
-        const callback = listeners[listenerIndex][1];
-        document.removeEventListener(VISIBILITY_CHANGE_EVENT, callback, false);
-        listeners.splice(listenerIndex, 1);
+        return changeEmitter.removeListener(handler);
       }
     }
   }

--- a/packages/react-native-web/src/exports/AppState/index.js
+++ b/packages/react-native-web/src/exports/AppState/index.js
@@ -25,12 +25,7 @@ const AppStates = {
   ACTIVE: 'active'
 };
 
-const changeEmitter = new EventEmitter();
-document.addEventListener(
-  VISIBILITY_CHANGE_EVENT,
-  () => changeEmitter.emit('change', AppState.currentState),
-  false
-);
+let changeEmitter = null;
 
 export default class AppState {
   static isAvailable = canUseDOM && document[VISIBILITY_STATE_PROPERTY];
@@ -58,6 +53,18 @@ export default class AppState {
         type
       );
       if (type === 'change') {
+        if (!changeEmitter) {
+          changeEmitter = new EventEmitter();
+          document.addEventListener(
+            VISIBILITY_CHANGE_EVENT,
+            () => {
+              if (changeEmitter) {
+                changeEmitter.emit('change', AppState.currentState);
+              }
+            },
+            false
+          );
+        }
         return changeEmitter.addListener(type, handler);
       }
     }
@@ -70,7 +77,7 @@ export default class AppState {
         'Trying to remove listener for unknown event: "%s"',
         type
       );
-      if (type === 'change') {
+      if (type === 'change' && changeEmitter) {
         return changeEmitter.removeListener(handler);
       }
     }

--- a/packages/react-native-web/src/exports/AppState/index.js
+++ b/packages/react-native-web/src/exports/AppState/index.js
@@ -78,7 +78,7 @@ export default class AppState {
         type
       );
       if (type === 'change' && changeEmitter) {
-        return changeEmitter.removeListener(handler);
+        changeEmitter.removeListener(handler);
       }
     }
   }


### PR DESCRIPTION
In 0.65, `AppState` has been changed to emit an `EmitterSubscription` when calling `.add`; this is in line w/ the expectation that you should no longer call `removeEventListener` on `AppState`, but instead call `.remove` on the returned subscription. This PR changes `AppState` such that it uses the internal `_EventEmitter` object to mirror how 0.65+ `AppState` should behave, and allow callers to unsubscribe from the emitter using the `.remove` method.

In doing so, this changes the implementation such that `document` should only ever have one and only one event listener to app viability changes; that event listener does the work of dispatching to the internal `EventEmitter` object, which dispatches to any N application level event listeners that are waiting for `AppState` changes.  

Thanks for any review / criticism, not sure if that implementation change is the right one or captured what changed correctly. Also feel slightly sketchy with regards to what I did in the tests, so happy for any opinion there.