### PR TITLE
Return subscription object for addEventListener method

### DIFF
--- a/packages/react-native-web/src/exports/Dimensions/index.js
+++ b/packages/react-native-web/src/exports/Dimensions/index.js
@@ -8,6 +8,7 @@
  * @flow
  */
 
+import type { EventSubscription } from '../../vendor/react-native/emitter/EventEmitter';
 import { canUseDOM } from 'fbjs/lib/ExecutionEnvironment';
 import invariant from 'fbjs/lib/invariant';
 
@@ -94,9 +95,15 @@ export default class Dimensions {
   static addEventListener(
     type: DimensionEventListenerType,
     handler: (DimensionsValue) => void
-  ): void {
+  ): EventSubscription {
     listeners[type] = listeners[type] || [];
     listeners[type].push(handler);
+
+    return {
+      remove: () => {
+        this.removeEventListener(type, handler);
+      }
+    };
   }
 
   static removeEventListener(


### PR DESCRIPTION

Fixes #2130, detailed explain on the issue.

This PR introduce additional way to stop listen from `Dimensions.addEventListener`, beside `Dimensions.removeEventListener`.

```js
React.useEffect(() => {
  const subscription = Dimensions.addEventListener(...);

  return () => {
    subscription.remove();
  }
});
```
This PR wont change the behavior of `Dimensions.removeEventListener`, it still work as it is.
