### PR TITLE
fix: Patch class names in documentation

### DIFF
--- a/packages/docs/src/pages/docs/concepts/styling.md
+++ b/packages/docs/src/pages/docs/concepts/styling.md
@@ -340,10 +340,10 @@ Output:
 
 ```html
 <style>
-  .rn-1mnahxq { margin-top: 0px; }
-  .rn-61z16t { margin-right: 0px; }
-  .rn-p1pxzi { margin-bottom: 0px; }
-  .rn-11wrixw { margin-left: 0px; }
+  .r-156q2ks { margin-top: 0px; }
+  .r-61z16t { margin-right: 0px; }
+  .r-p1pxzi { margin-bottom: 0px; }
+  .r-11wrixw { margin-left: 0px; }
 </style>
 
 <div class="r-156q2ks r-61z16t r-p1pxzi r-11wrixw"></div>


### PR DESCRIPTION
## What
Fixed two typos in the documentation.
- Change `rn-` to `r-`.
- Correct class name for `margin-top`.

## Ref
- https://github.com/necolas/react-native-web/pull/2121