### PR TITLE
feat: shadow root support

### DIFF
--- a/packages/react-native-web/src/exports/AppRegistry/renderApplication.js
+++ b/packages/react-native-web/src/exports/AppRegistry/renderApplication.js
@@ -31,6 +31,10 @@ export default function renderApplication<Props: Object>(
 
   invariant(rootTag, 'Expect to have a valid rootTag, instead got ', rootTag);
 
+  if (rootTag.getRootNode() instanceof ShadowRoot) {
+    styleResolver.addShadowSheet(rootTag);
+  }
+
   renderFn(
     <AppContainer WrapperComponent={WrapperComponent} rootTag={rootTag}>
       <RootComponent {...initialProps} />

--- a/packages/react-native-web/src/exports/StyleSheet/__tests__/createStyleResolver-test.js
+++ b/packages/react-native-web/src/exports/StyleSheet/__tests__/createStyleResolver-test.js
@@ -4,6 +4,7 @@ import ExecutionEnvironment from 'fbjs/lib/ExecutionEnvironment';
 import I18nManager from '../../I18nManager';
 import ReactNativePropRegistry from '../ReactNativePropRegistry';
 import createStyleResolver from '../createStyleResolver';
+import { STYLE_ELEMENT_ID } from '../constants';
 
 const canUseDOM = ExecutionEnvironment.canUseDOM;
 let styleResolver;
@@ -93,6 +94,28 @@ describe('StyleSheet/createStyleResolver', () => {
         styleResolver.getStyleSheet();
 
         expect(styleResolver.sheet).not.toBe(sheet);
+      });
+    });
+
+    describe('addShadowSheet', () => {
+      test('creates a new sheet', () => {
+        const divElement = document.createElement('div');
+        const shadowRoot = divElement.attachShadow({ mode: 'open'});
+        const rootTag = document.createElement('div');
+        shadowRoot.appendChild(rootTag);
+        styleResolver.addShadowSheet(rootTag);
+
+        expect(styleResolver.sheets.length).toBe(2);
+      });
+
+      test('creates a new sheet within Shadow DOM root', () => {
+        const divElement = document.createElement('div');
+        const shadowRoot = divElement.attachShadow({ mode: 'open'});
+        const rootTag = document.createElement('div');
+        shadowRoot.appendChild(rootTag);
+        styleResolver.addShadowSheet(rootTag);
+
+        expect(shadowRoot.getElementById(STYLE_ELEMENT_ID)).not.toBe(null);
       });
     });
   });

--- a/packages/react-native-web/src/exports/StyleSheet/createCSSStyleSheet.js
+++ b/packages/react-native-web/src/exports/StyleSheet/createCSSStyleSheet.js
@@ -10,18 +10,27 @@
 import { canUseDOM } from 'fbjs/lib/ExecutionEnvironment';
 
 // $FlowFixMe: HTMLStyleElement is incorrectly typed - https://github.com/facebook/flow/issues/2696
-export default function createCSSStyleSheet(id: string): ?CSSStyleSheet {
+export default function createCSSStyleSheet(id: string, rootTag?: HTMLElement): ?CSSStyleSheet {
   if (canUseDOM) {
-    const element = document.getElementById(id);
+    let root = document;
+    if (rootTag && rootTag.getRootNode() instanceof ShadowRoot) {
+      root = rootTag.getRootNode().host.shadowRoot;
+    }
+    const element = root.getElementById(id);
     if (element != null) {
       // $FlowFixMe: HTMLElement is incorrectly typed
       return element.sheet;
     } else {
       const element = document.createElement('style');
       element.setAttribute('id', id);
-      const head = document.head;
-      if (head) {
-        head.insertBefore(element, head.firstChild);
+
+      if (root instanceof ShadowRoot) {
+        root.insertBefore(element, root.firstChild);
+      } else {
+        const head = document.head;
+        if (head) {
+          head.insertBefore(element, head.firstChild);
+        }
       }
       return element.sheet;
     }

--- a/packages/react-native-web/src/exports/StyleSheet/createCSSStyleSheet.js
+++ b/packages/react-native-web/src/exports/StyleSheet/createCSSStyleSheet.js
@@ -14,8 +14,9 @@ export default function createCSSStyleSheet(id: string, rootTag?: HTMLElement): 
   if (canUseDOM) {
     let root = document;
     if (rootTag && rootTag.getRootNode() instanceof ShadowRoot) {
-      root = rootTag.getRootNode().host.shadowRoot;
+      root = rootTag.getRootNode();
     }
+    // $FlowFixMe: both document and ShadowRoot have getElementById
     const element = root.getElementById(id);
     if (element != null) {
       // $FlowFixMe: HTMLElement is incorrectly typed

--- a/packages/react-native-web/src/exports/StyleSheet/createStyleResolver.js
+++ b/packages/react-native-web/src/exports/StyleSheet/createStyleResolver.js
@@ -252,6 +252,9 @@ export default function createStyleResolver() {
     get sheet() {
       return sheets.length ? sheets[0] : undefined;
     },
+    get sheets() {
+      return sheets;
+    },
     addShadowSheet(rootTag) {
       init(rootTag);
     }

--- a/packages/react-native-web/src/exports/StyleSheet/createStyleResolver.js
+++ b/packages/react-native-web/src/exports/StyleSheet/createStyleResolver.js
@@ -27,7 +27,7 @@ import { STYLE_ELEMENT_ID, STYLE_GROUPS } from './constants';
 
 export default function createStyleResolver() {
   let inserted, cache;
-  const sheets = [];
+  let sheets = [];
   const resolved = { css: {}, ltr: {}, rtl: {}, rtlNoSwap: {} };
 
   const init = (rootTag) => {
@@ -38,7 +38,11 @@ export default function createStyleResolver() {
     initialRules.forEach((rule) => {
       sheet.insert(rule, STYLE_GROUPS.reset);
     });
-    sheets.push(sheet);
+    if (rootTag) {
+      sheets.push(sheet);
+    } else {
+      sheets = [sheet];
+    }
   };
 
   init();


### PR DESCRIPTION
### Background
Importing `react-native-web` kicks off `StyleSheet` resolution on a single `style` element which gets added to the `head` of the HTML document. However, when rendering an application within a Shadow DOM root (e.g. when encapsulating within an HTML custom element), any stylesheets from the main `document` are ignored. 

### Issue Link
https://github.com/necolas/react-native-web/issues/1517

### In This Update
- Updated `renderApplication` to check if the `rootTag`'s `RootNode` is of `ShadowRoot` type. If so, an additional `style` tag is added to the shadow root
- Modified `createStyleResolver` to insert any new rules into both the document-level stylesheet as well as any additional shadow root stylesheets

This is my first PR for RNW so let me know if there's anything else I should consider!
