### PR TITLE
[Draft] Fix reverted virtualized list

### DIFF
--- a/packages/react-native-web/src/vendor/react-native/VirtualizedList/index.js
+++ b/packages/react-native-web/src/vendor/react-native/VirtualizedList/index.js
@@ -1355,7 +1355,7 @@ class VirtualizedList extends React.PureComponent<Props, State> {
   };
 
   _onScroll = (e: Object) => {
-    var contentOffset = (_this.props.inverted) ? {
+    var contentOffset = (this.props.inverted) ? {
       x: - e.nativeEvent.contentOffset.x,
       y: - e.nativeEvent.contentOffset.y,
     } : e.nativeEvent.contentOffset


### PR DESCRIPTION
## Expected Result:
- When copying text in `<FlatList inverted={true} />` that when you highlight lines of text, including across multiple messages, that the text is highlighted in order from top to bottom or bottom to top.
- When pasting text that has been copied from `Flatlist`, that it shows up in the correct order.

## Actual Result:
- Copying is sporadic and 'jumps around' when you highlight text over multiple messages.
- Pasting - When pasting copied text from multiple e.cash messages, it's out of order

Highlighting glitch             |  Copy order 
:-------------------------:|:-------------------------:
<img src="https://user-images.githubusercontent.com/4882133/139319391-19719d4d-29c1-470c-8100-e5c8cd2ef31c.png" width="250" /> | <img src="https://user-images.githubusercontent.com/4882133/139319431-2a9123bd-7c5a-4334-94d3-5e4e56aad283.png" width="250" />

This has been reviewed and tested by multiple developers. Some references are:
- https://github.com/Expensify/App/issue/3381
- https://github.com/Expensify/App/pull/5561
- https://github.com/necolas/react-native-web/issues/1807
- https://github.com/facebook/react-native/issues/30383

## Implementation
I have removed flatlist inversion (by inverted=true prop) which used [transform: translate] css hack and instead adding flatlist array items in reverse order [unshift instead of push]; It also reverses ScrollView event response received from browser [e.nativeEvent.configOffset *= -1];

## Sidenote
I was not able to fix this issue by applying this code directly in React Native repo. The reason is that RN column-reverse won't anchor scroll position to the bottom on Mobile device as it does on Web
https://github.com/facebook/yoga/issues/866#issuecomment-797548962

