### PR TITLE
[fix] Focus jumps between TextInputs

### DIFF
--- a/packages/react-native-web/src/exports/TextInput/index.js
+++ b/packages/react-native-web/src/exports/TextInput/index.js
@@ -243,7 +243,8 @@ const TextInput: React.AbstractComponent<
       }
       if (selectTextOnFocus) {
         // Safari requires selection to occur in a setTimeout
-        setTimeout(() => {
+        clearTimeout(TextInput.focusTimeout);
+        TextInput.focusTimeout = setTimeout(() => {
           hostNode.select();
         }, 0);
       }
@@ -380,5 +381,7 @@ const classes = css.create({
     resize: 'none'
   }
 });
+
+TextInput.focusTimeout = 0;
 
 export default TextInput;


### PR DESCRIPTION
Adding the property selectTextOnFocus to multiple TextInputs can cause the focus to jump between them indefinitely. This PR fixes the corresponding issue #2162.