### PR TITLE
Fix ellipsis issues for Text `numberOfLines={1}`

### DIFF
--- a/packages/react-native-web/src/exports/Text/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/react-native-web/src/exports/Text/__tests__/__snapshots__/index-test.js.snap
@@ -159,7 +159,7 @@ exports[`components/Text prop "numberOfLines" value is set 1`] = `
 
 exports[`components/Text prop "numberOfLines" value is set to one 1`] = `
 <div
-  class="css-text-901oao css-textMultiLine-cens5h"
+  class="css-text-901oao css-textOneLine-vcwn7f"
   dir="auto"
 />
 `;

--- a/packages/react-native-web/src/exports/Text/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/react-native-web/src/exports/Text/__tests__/__snapshots__/index-test.js.snap
@@ -159,7 +159,7 @@ exports[`components/Text prop "numberOfLines" value is set 1`] = `
 
 exports[`components/Text prop "numberOfLines" value is set to one 1`] = `
 <div
-  class="css-text-901oao css-textOneLine-vcwn7f"
+  class="css-text-901oao css-textOneLine-nfaoni"
   dir="auto"
 />
 `;

--- a/packages/react-native-web/src/exports/Text/index.js
+++ b/packages/react-native-web/src/exports/Text/index.js
@@ -184,7 +184,8 @@ const classes = css.create({
     maxWidth: '100%',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
-    whiteSpace: 'pre'
+    whiteSpace: 'pre',
+    wordWrap: 'normal'
   },
   // See #13
   textMultiLine: {

--- a/packages/react-native-web/src/exports/Text/index.js
+++ b/packages/react-native-web/src/exports/Text/index.js
@@ -73,11 +73,12 @@ const Text: React.AbstractComponent<TextProps, HTMLElement & PlatformMethods> = 
     const classList = [
       classes.text,
       hasTextAncestor === true && classes.textHasAncestor,
-      numberOfLines != null && classes.textMultiLine
+      numberOfLines === 1 && classes.textOneLine,
+      numberOfLines != null && numberOfLines > 1 && classes.textMultiLine
     ];
     const style = [
       props.style,
-      numberOfLines != null && { WebkitLineClamp: numberOfLines },
+      numberOfLines != null && numberOfLines > 1 && { WebkitLineClamp: numberOfLines },
       selectable === true && styles.selectable,
       selectable === false && styles.notSelectable,
       onPress && styles.pressable
@@ -178,6 +179,12 @@ const classes = css.create({
     color: 'inherit',
     font: 'inherit',
     whiteSpace: 'inherit'
+  },
+  textOneLine: {
+    maxWidth: '100%',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'pre'
   },
   // See #13
   textMultiLine: {


### PR DESCRIPTION
1. Revert commit https://github.com/necolas/react-native-web/commit/562db69a0f3305b07f252ad26b4661bb92bcb72c to fix ellipsis for `<Text numberOfLines={1} />`.
2. Fix ellipsis for Safari via adding `word-wrap: normal` to text-oneline styles. Based on https://stackoverflow.com/a/56961220/7462668

Fixes https://github.com/necolas/react-native-web/issues/2186
Fixes https://github.com/necolas/react-native-web/issues/2111


