### PR TITLE
fix(Text): Support ellipsizeMode="clip"

### DIFF
--- a/packages/examples/pages/text/index.js
+++ b/packages/examples/pages/text/index.js
@@ -383,21 +383,37 @@ export default function TextPage() {
               <Text> words</Text>
             </View>
           </View>
-          <Text numberOfLines={1} style={{ marginBottom: 20 }}>
-            Maximum of one line, no matter how much I write here. If I keep writing, it
-            {"'"}
-            ll just truncate after one line.
-          </Text>
+          <View style={{ marginBottom: 20 }}>
+            <Text numberOfLines={1}>
+              Maximum of one line, no matter how much I write here. If I keep writing, it
+              {"'"}
+              ll just truncate after one line.
+            </Text>
+            <Text ellipsizeMode="clip" numberOfLines={1}>
+              Maximum of one line, no matter how much I write here. If I keep writing, it
+              {"'"}
+              ll just truncate after one line.
+            </Text>
+          </View>
+
           <Text numberOfLines={2} style={{ marginBottom: 20 }}>
             Maximum of two lines, no matter how much I write here. If I keep writing, it
             {"'"}
             ll just truncate after two lines.
           </Text>
-          <Text style={{ marginBottom: 20 }}>
-            No maximum lines specified, no matter how much I write here. If I keep writing, it
-            {"'"}
-            ll just keep going and going.
-          </Text>
+
+          <View style={{ marginBottom: 20 }}>
+            <Text>
+              No maximum lines specified, no matter how much I write here. If I keep writing, it
+              {"'"}
+              ll just keep going and going.
+            </Text>
+            <Text numberOfLines={0}>
+              No maximum lines specified, no matter how much I write here. If I keep writing, it
+              {"'"}
+              ll just keep going and going.
+            </Text>
+          </View>
         </View>
 
         <View>

--- a/packages/examples/pages/text/index.js
+++ b/packages/examples/pages/text/index.js
@@ -389,6 +389,11 @@ export default function TextPage() {
               {"'"}
               ll just truncate after one line.
             </Text>
+            <Text ellipsizeMode="tail" numberOfLines={1}>
+              Maximum of one line, no matter how much I write here. If I keep writing, it
+              {"'"}
+              ll just truncate after one line.
+            </Text>
             <Text ellipsizeMode="clip" numberOfLines={1}>
               Maximum of one line, no matter how much I write here. If I keep writing, it
               {"'"}

--- a/packages/react-native-web/src/exports/Text/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/react-native-web/src/exports/Text/__tests__/__snapshots__/index-test.js.snap
@@ -150,16 +150,51 @@ exports[`components/Text prop "nativeID" value is set 1`] = `
 />
 `;
 
+exports[`components/Text prop "numberOfLines" ellipsizeMode="clip" numberOfLines={1} 1`] = `
+<div
+  class="css-text-901oao css-textMultiLine-r38r4o css-textEllipsizeClip-5kzskm"
+  dir="auto"
+/>
+`;
+
+exports[`components/Text prop "numberOfLines" ellipsizeMode="clip" numberOfLines={2} 1`] = `
+<div
+  class="css-text-901oao css-textMultiLine-r38r4o"
+  dir="auto"
+/>
+`;
+
+exports[`components/Text prop "numberOfLines" ellipsizeMode="tail" numberOfLines={1} 1`] = `
+<div
+  class="css-text-901oao css-textMultiLine-r38r4o"
+  dir="auto"
+/>
+`;
+
+exports[`components/Text prop "numberOfLines" ellipsizeMode="tail" numberOfLines={2} 1`] = `
+<div
+  class="css-text-901oao css-textMultiLine-r38r4o"
+  dir="auto"
+/>
+`;
+
 exports[`components/Text prop "numberOfLines" value is set 1`] = `
 <div
-  class="css-text-901oao css-textMultiLine-cens5h"
+  class="css-text-901oao css-textMultiLine-r38r4o"
   dir="auto"
 />
 `;
 
 exports[`components/Text prop "numberOfLines" value is set to one 1`] = `
 <div
-  class="css-text-901oao css-textMultiLine-cens5h"
+  class="css-text-901oao css-textMultiLine-r38r4o"
+  dir="auto"
+/>
+`;
+
+exports[`components/Text prop "numberOfLines" value is set to zero 1`] = `
+<div
+  class="css-text-901oao"
   dir="auto"
 />
 `;

--- a/packages/react-native-web/src/exports/Text/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/Text/__tests__/index-test.js
@@ -132,8 +132,34 @@ describe('components/Text', () => {
       const { container } = render(<Text numberOfLines={3} />);
       expect(container.firstChild).toMatchSnapshot();
     });
+
     test('value is set to one', () => {
       const { container } = render(<Text numberOfLines={1} />);
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
+    test('value is set to zero', () => {
+      const { container } = render(<Text numberOfLines={0} />);
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
+    test('ellipsizeMode="clip" numberOfLines={1}', () => {
+      const { container } = render(<Text ellipsizeMode="clip" numberOfLines={1} />);
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
+    test('ellipsizeMode="tail" numberOfLines={1}', () => {
+      const { container } = render(<Text ellipsizeMode="tail" numberOfLines={1} />);
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
+    test('ellipsizeMode="clip" numberOfLines={2}', () => {
+      const { container } = render(<Text ellipsizeMode="clip" numberOfLines={2} />);
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
+    test('ellipsizeMode="tail" numberOfLines={2}', () => {
+      const { container } = render(<Text ellipsizeMode="tail" numberOfLines={2} />);
       expect(container.firstChild).toMatchSnapshot();
     });
   });

--- a/packages/react-native-web/src/exports/Text/index.js
+++ b/packages/react-native-web/src/exports/Text/index.js
@@ -43,6 +43,7 @@ const Text: React.AbstractComponent<TextProps, HTMLElement & PlatformMethods> = 
   (props, forwardedRef) => {
     const {
       dir,
+      ellipsizeMode,
       hrefAttrs,
       numberOfLines,
       onClick,
@@ -73,11 +74,19 @@ const Text: React.AbstractComponent<TextProps, HTMLElement & PlatformMethods> = 
     const classList = [
       classes.text,
       hasTextAncestor === true && classes.textHasAncestor,
-      numberOfLines != null && classes.textMultiLine
+      numberOfLines && classes.textMultiLine,
+      // The browser only supports the "clip" text-overflow property for single
+      // lines of text. This isn't perfect, but it's the best that we can do
+      // until the browsers catch up.
+      numberOfLines === 1 &&
+        // Browsers only support "clip" and "tail", so that's all that we can
+        // support at the moment.
+        ellipsizeMode === 'clip' &&
+        classes.textEllipsizeClip
     ];
     const style = [
       props.style,
-      numberOfLines != null && { WebkitLineClamp: numberOfLines },
+      numberOfLines && { WebkitLineClamp: numberOfLines },
       selectable === true && styles.selectable,
       selectable === false && styles.notSelectable,
       onPress && styles.pressable
@@ -184,8 +193,13 @@ const classes = css.create({
     display: '-webkit-box',
     maxWidth: '100%',
     overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    WebkitBoxOrient: 'vertical'
+    WebkitBoxOrient: 'vertical',
+    textOverflow: 'ellipsis'
+  },
+  textEllipsizeClip: {
+    // Note: this only works for one line (numberOfLines={1}), unfortunately.
+    whiteSpace: 'nowrap',
+    textOverflow: 'clip'
   }
 });
 

--- a/packages/react-native-web/src/exports/Text/types.js
+++ b/packages/react-native-web/src/exports/Text/types.js
@@ -86,6 +86,7 @@ export type TextProps = {
     selected?: ?boolean
   },
   dir?: 'auto' | 'ltr' | 'rtl',
+  ellipsizeMode?: 'head' | 'middle' | 'tail' | 'clip',
   numberOfLines?: ?number,
   onPress?: (e: any) => void,
   selectable?: boolean,


### PR DESCRIPTION
The `Text` component supports different options for `ellipsizeMode`,
rather than assuming a trailing-edge '...'.

This change adds support for `ellipsizeMode="clip"` -- but only in one
special case: `numberOfLines={1}`. This is because that's all that is
supported by the browser vendors at the moment, so it's the best that
can be done by pure CSS.

Additionally, ths expands the handling of `numerOfLines` to accommodate
the value `0`, as react-native specifies that a value of `0` is [the
same as not specifying anything][rn docs].

[rn docs]: https://reactnative.dev/docs/text#numberoflines