### PR TITLE
Allow className to be passed in

### DIFF
--- a/packages/react-native-web/src/modules/createDOMProps/index.js
+++ b/packages/react-native-web/src/modules/createDOMProps/index.js
@@ -393,6 +393,10 @@ const createDOMProps = (elementType, props) => {
   if (className != null && className !== '') {
     domProps.className = className;
   }
+  
+  if (props.className) {
+    domProps.className = className ? `${className} ${props.className}` : props.className
+  }
 
   if (style) {
     domProps.style = style;


### PR DESCRIPTION
Could be done any number of ways, whether through a more private API or not, or even just by giving a generic `domPropsExtension` hook. Happy to implement any.