### PR TITLE
Fix 'yarn lint' output on cleanly cloned repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .next
 build
 coverage

--- a/packages/react-native-web/src/modules/useEvent/index.js
+++ b/packages/react-native-web/src/modules/useEvent/index.js
@@ -55,7 +55,7 @@ export default function useEvent(
       });
       targetListeners.clear();
     };
-  }, []);
+  }, [targetListeners]);
 
   return addListener;
 }


### PR DESCRIPTION
This includes two small commits:

**First**
Git ignore local .idea folders created by IDEA-based IDEs like WebStorm opening the folder as a project.

**Second**
Fix 'yarn lint' issue on clean repo clone:
```
58:6  warning  React Hook useLayoutEffect has a missing dependency: 'targetListeners'.
   Either include it or remove the dependency array  react-hooks/exhaustive-deps.
```

Options considered would be to disable the linter on that line (as it should have no impact being a wrapped useRef) or to just add it to silence it.  Took the latter approach as that way is consistent with the precedent set by `useResponderEvents\index.js`.

Sorry I bucketed these two fixes together.  I will split the PRs if you like.