### PR TITLE
Git Ignore .idea Folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .next
 build
 coverage


### PR DESCRIPTION
Git ignore local `.idea` folders which are created by IDEA-based IDEs like WebStorm when opening the whole `react-native-web` folder as a project.

Recommend to merge this to avoid anyone accidentally trying to git add the `.idea` folder which is a user-specific area that should not be under source control.