### PR TITLE
Fix 'yarn lint' issue for targetListeners

### DIFF
--- a/packages/react-native-web/src/modules/useEvent/index.js
+++ b/packages/react-native-web/src/modules/useEvent/index.js
@@ -55,7 +55,7 @@ export default function useEvent(
       });
       targetListeners.clear();
     };
-  }, []);
+  }, [targetListeners]);
 
   return addListener;
 }


### PR DESCRIPTION
Cloning a fresh `react-native-web` repository produces the following warning output when running `yarn lint`:
```
58:6  warning  React Hook useLayoutEffect has a missing dependency: 'targetListeners'.
 Either include it or remove the dependency array  react-hooks/exhaustive-deps.
```
Options would be to disable the linter on that line (as it should have no impact being a wrapped useRef) or to just add it to silence it.  Took the latter approach as that way is consistent with the precedent set by `useResponderEvents\index.js`.