### PR TITLE
[change] Remove backgroundClip prefix workaround

### DIFF
--- a/packages/react-native-web/src/exports/StyleSheet/createReactDOMStyle.js
+++ b/packages/react-native-web/src/exports/StyleSheet/createReactDOMStyle.js
@@ -92,16 +92,6 @@ const createReactDOMStyle = (style) => {
           break;
         }
 
-        // TODO: remove once this issue is fixed
-        // https://github.com/rofrischmann/inline-style-prefixer/issues/159
-        case 'backgroundClip': {
-          if (value === 'text') {
-            resolvedStyle.backgroundClip = value;
-            resolvedStyle.WebkitBackgroundClip = value;
-          }
-          break;
-        }
-
         // The 'flex' property value in React Native must be a positive integer,
         // 0, or -1.
         case 'flex': {

--- a/packages/react-native-web/src/modules/prefixStyles/__tests__/index-test.js
+++ b/packages/react-native-web/src/modules/prefixStyles/__tests__/index-test.js
@@ -10,4 +10,15 @@ describe('modules/prefixStyles', () => {
 
     expect(prefixInlineStyles(style)).toEqual({ display: 'flex' });
   });
+
+  test('correctly prefix background-clip', () => {
+    const style = {
+      backgroundClip: 'text'
+    };
+
+    expect(prefixInlineStyles(style)).toEqual({
+      WebkitBackgroundClip: 'text',
+      backgroundClip: 'text'
+    });
+  });
 });

--- a/packages/react-native-web/src/modules/prefixStyles/static.js
+++ b/packages/react-native-web/src/modules/prefixStyles/static.js
@@ -1,4 +1,3 @@
-import backgroundClip from 'inline-style-prefixer/lib/plugins/backgroundClip';
 import crossFade from 'inline-style-prefixer/lib/plugins/crossFade';
 import cursor from 'inline-style-prefixer/lib/plugins/cursor';
 import filter from 'inline-style-prefixer/lib/plugins/filter';
@@ -21,7 +20,6 @@ const wmms = ['Webkit', 'Moz', 'ms'];
 
 export default {
   plugins: [
-    backgroundClip,
     crossFade,
     cursor,
     filter,
@@ -47,6 +45,7 @@ export default {
     animationPlayState: w,
     animationTimingFunction: w,
     appearance: wm,
+    backgroundClip: w,
     userSelect: wmms,
     textEmphasisPosition: w,
     textEmphasis: w,


### PR DESCRIPTION
The PR removes the workaround for `background-clip` when prefixing.

The fix has been submitted to `inline-style-prefixer` as well, see https://github.com/robinweser/inline-style-prefixer/pull/221