### PR TITLE
Allow explicit target for Linking.openURL(), default to "_blank"

### DIFF
--- a/packages/docs/src/pages/docs/apis/linking.md
+++ b/packages/docs/src/pages/docs/apis/linking.md
@@ -31,8 +31,8 @@ Returns a `Promise` that resolves to a boolean indicating whether the app can op
 Returns a `Promise` that resolves to the string of the URL that initially loaded the app.
 {% endcall %}
 
-{% call macro.prop('openURL', '(url) => Promise<>') %}
-Try to open the given url in a secure fashion. The method returns a Promise object. If the url opens, the promise is resolved. If not, the promise is rejected.
+{% call macro.prop('openURL', '(url, target) => Promise<>') %}
+Try to open the given url in a secure fashion. The provided target (including `undefined`) will be passed as the window target, or "_blank" if no target included. The method returns a Promise object. If the url opens, the promise is resolved. If not, the promise is rejected.
 {% endcall %}
 
 ---

--- a/packages/react-native-web/src/exports/Linking/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/Linking/__tests__/index-test.js
@@ -1,0 +1,37 @@
+/* eslint-env jasmine, jest */
+
+import Linking from '..';
+
+describe('apis/Linking', () => {
+  describe('openURL', () => {
+    test('calls open with a url and target', done => {
+      jest.spyOn(window, 'open').mockImplementationOnce((url, target, opener) => {
+        expect(url).toBe('http://foo.com/');
+        expect(target).toBe('target_name');
+        expect(opener).toBe('noopener');
+        done();
+      });
+      Linking.openURL('http://foo.com', 'target_name');
+    });
+
+    test('defaults target to _blank if not provided', done => {
+      jest.spyOn(window, 'open').mockImplementationOnce((url, target, opener) => {
+        expect(url).toBe('http://foo.com/');
+        expect(target).toBe('_blank');
+        expect(opener).toBe('noopener');
+        done();
+      });
+      Linking.openURL('http://foo.com');
+    });
+
+    test('accepts undefined as a target', done => {
+      jest.spyOn(window, 'open').mockImplementationOnce((url, target, opener) => {
+        expect(url).toBe('http://foo.com/');
+        expect(target).toBe(undefined);
+        expect(opener).toBe('noopener');
+        done();
+      });
+      Linking.openURL('http://foo.com', undefined);
+    });
+  });
+});

--- a/packages/react-native-web/src/exports/Linking/index.js
+++ b/packages/react-native-web/src/exports/Linking/index.js
@@ -66,12 +66,16 @@ class Linking {
 
   /**
    * Try to open the given url in a secure fashion. The method returns a Promise object.
+   * If a target is passed (including undefined) that target will be used, otherwise '_blank'.
    * If the url opens, the promise is resolved. If not, the promise is rejected.
-   * Dispatches the `onOpen` event if `url` is opened successfully
+   * Dispatches the `onOpen` event if `url` is opened successfully.
    */
-  openURL(url: string): Promise<Object | void> {
+  openURL(url: string, target?: string): Promise<Object | void> {
+    if (arguments.length == 1) {
+      target = '_blank';
+    }
     try {
-      open(url);
+      open(url, target);
       this._dispatchEvent('onOpen', url);
       return Promise.resolve();
     } catch (e) {
@@ -85,13 +89,13 @@ class Linking {
   }
 }
 
-const open = (url) => {
+const open = (url, string) => {
   if (canUseDOM) {
     const urlToOpen = new URL(url, window.location).toString();
     if (urlToOpen.indexOf('tel:') === 0) {
       window.location = urlToOpen;
     } else {
-      window.open(urlToOpen, '_blank', 'noopener');
+      window.open(urlToOpen, string, 'noopener');
     }
   }
 };


### PR DESCRIPTION
This PR extends on the work started by @Sharcoux in PR #1743 and relates to issues #162, #1544, and #1744.

The desire of those tickets was to open `Linking.openURL(url)` in a new tab, and the solution merged by @necolas [in this commit](https://github.com/necolas/react-native-web/commit/b7b383098aac42609166da38808a65497b5469a5) hard-codes the `"_blank"` target to force a new tab. This is great for people who want new tabs, but inconvenient for people who want to use the same tab.

This PR reworks the method to accept a second argument, `Linking.openURL(url, target)` for an explicit target. Any value passed will be used as the target, _including_ `undefined`. The ability to pass undefined allows users to maintain the same browser tab, while arbitrary values allow... well, anything.

For backwards compatibility, if `Linking.openURL(url)` is called **without** a `target`, the default value of `"_blank"` will be passed. Therefore this change should have zero impact on any code already written, only users henceforth who explicitly pass a `target` will get the new behavior.

Also, tests added! 