### PR TITLE
fix: use null prototypes to prevent prototype pollution

### DIFF
--- a/packages/react-native-web/src/exports/StyleSheet/compile.js
+++ b/packages/react-native-web/src/exports/StyleSheet/compile.js
@@ -29,7 +29,7 @@ const cache = {
   get(property, value) {
     if (
       cache[property] != null &&
-      cache[property].hasOwnProperty(value) &&
+      Object.hasOwnProperty.call(cache[property], value) &&
       cache[property][value] != null
     ) {
       return cache[property][value];
@@ -37,11 +37,12 @@ const cache = {
   },
   set(property, value, object) {
     if (cache[property] == null) {
-      cache[property] = {};
+      cache[property] = Object.create(null);
     }
     return (cache[property][value] = object);
   }
 };
+Object.setPrototypeOf(cache, null);
 
 /**
  * Compile style to atomic CSS rules.

--- a/packages/react-native-web/src/exports/StyleSheet/createStyleResolver.js
+++ b/packages/react-native-web/src/exports/StyleSheet/createStyleResolver.js
@@ -32,7 +32,7 @@ export default function createStyleResolver() {
   const init = () => {
     inserted = { css: {}, ltr: {}, rtl: {}, rtlNoSwap: {} };
     sheet = createOrderedCSSStyleSheet(createCSSStyleSheet(STYLE_ELEMENT_ID));
-    cache = {};
+    cache = Object.create(null);
     modality((rule) => sheet.insert(rule, STYLE_GROUPS.modality));
     initialRules.forEach((rule) => {
       sheet.insert(rule, STYLE_GROUPS.reset);
@@ -43,14 +43,14 @@ export default function createStyleResolver() {
 
   function addToCache(className, prop, value) {
     if (!cache[prop]) {
-      cache[prop] = {};
+      cache[prop] = Object.create(null);
     }
     cache[prop][value] = className;
   }
 
   function getClassName(prop, value) {
     const val = stringifyValueWithProperty(value, prop);
-    return cache[prop] && cache[prop].hasOwnProperty(val) && cache[prop][val];
+    return cache[prop] && Object.hasOwnProperty.call(cache[prop], val) && cache[prop][val];
   }
 
   function _injectRegisteredStyle(id) {


### PR DESCRIPTION
I found a potential [prototype pollution vulnerability](https://raw.githubusercontent.com/HoLyVieR/prototype-pollution-nsec18/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf) while reading the code of the package. I'm not sure if it has any security impact, but I think it's better to fix it anyway.

The issue could be triggered if some cache property is named `__proto__`. In that case `cache[property][value] = object` would be creating properties in the global Object prototype. This could cause lots of unexpected things in the application.