### PR TITLE
[fix] Encode URL in background-image CSS property

### DIFF
--- a/packages/react-native-web/src/exports/Image/index.js
+++ b/packages/react-native-web/src/exports/Image/index.js
@@ -194,7 +194,7 @@ const Image: React.AbstractComponent<ImageProps, React.ElementRef<typeof View>> 
     const selectedSource = shouldDisplaySource ? source : defaultSource;
     const displayImageUri = resolveAssetUri(selectedSource);
     const imageSizeStyle = resolveAssetDimensions(selectedSource);
-    const backgroundImage = displayImageUri ? `url("${displayImageUri}")` : null;
+    const backgroundImage = displayImageUri ? `url("${encodeURI(displayImageUri)}")` : null;
     const backgroundSize = getBackgroundSize();
 
     // Accessibility image allows users to trigger the browser's image context menu


### PR DESCRIPTION
URLs containing a double quote might be troublesome without properly encoding them. Based on https://stackoverflow.com/questions/25613552/how-should-i-escape-image-urls-for-css, using the builtin function `encodeURI()` is the best way to encode a URL inside the context of a CSS property.