### PR TITLE
fix: Fix Touchable with href is still clickable if disabled

### DIFF
--- a/packages/react-native-web/src/exports/Button/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/react-native-web/src/exports/Button/__tests__/__snapshots__/index-test.js.snap
@@ -32,7 +32,7 @@ exports[`components/Button prop "color" 1`] = `
 exports[`components/Button prop "disabled" 1`] = `
 <div
   aria-disabled="true"
-  class="css-view-1dbjc4n r-backgroundColor-11mpjr4 r-borderRadius-1jkafct r-transitionProperty-1i6wzkk r-userSelect-lrvibr"
+  class="css-view-1dbjc4n r-backgroundColor-11mpjr4 r-borderRadius-1jkafct r-pointerEvents-633pao r-transitionProperty-1i6wzkk r-userSelect-lrvibr"
   role="button"
   style="transition-duration: 0s;"
   tabindex="-1"

--- a/packages/react-native-web/src/exports/TouchableHighlight/index.js
+++ b/packages/react-native-web/src/exports/TouchableHighlight/index.js
@@ -167,6 +167,7 @@ function TouchableHighlight(props: Props, forwardedRef): React.Node {
       {...pressEventHandlers}
       accessibilityDisabled={disabled}
       focusable={!disabled && focusable !== false}
+      pointerEvents={disabled ? 'none' : undefined}
       ref={setRef}
       style={[
         styles.root,

--- a/packages/react-native-web/src/exports/TouchableOpacity/index.js
+++ b/packages/react-native-web/src/exports/TouchableOpacity/index.js
@@ -126,6 +126,7 @@ function TouchableOpacity(props: Props, forwardedRef): React.Node {
       {...pressEventHandlers}
       accessibilityDisabled={disabled}
       focusable={!disabled && focusable !== false}
+      pointerEvents={disabled ? 'none' : undefined}
       ref={setRef}
       style={[
         styles.root,


### PR DESCRIPTION
fix #2298

According to the implementation of `View`

https://github.com/necolas/react-native-web/blob/dc9ecfbc84c7e6cbf0c36c537ac1b0a86b7e43c1/packages/react-native-web/src/exports/View/index.js#L106-L107

`div` will be changed to `a` if `props.href` is provided, the `a` will be clickable no matter if `props.disabled` is true or not.

`TouchableHighlight` and `TouchableOpacity` are both using `View` as a base component

https://github.com/necolas/react-native-web/blob/dc9ecfbc84c7e6cbf0c36c537ac1b0a86b7e43c1/packages/react-native-web/src/exports/TouchableHighlight/index.js#L164-L165
https://github.com/necolas/react-native-web/blob/dc9ecfbc84c7e6cbf0c36c537ac1b0a86b7e43c1/packages/react-native-web/src/exports/TouchableOpacity/index.js#L123-L124

This PR will add `pointerEvents="none"` to the component if `props.disabled` is `true` in `TouchableHighlight` and `TouchableOpacity` to make them actually disabled.

Tested on the example app and also our app. 
