### PR TITLE
feat(examples): example page add ssr styles

### DIFF
--- a/packages/examples/pages/_document.js
+++ b/packages/examples/pages/_document.js
@@ -1,0 +1,25 @@
+import Document, { Html, Head, Main, NextScript } from 'next/document';
+import { AppRegistry } from 'react-native';
+
+export default class MyDocument extends Document {
+  static async getInitialProps(ctx) {
+    const { renderPage } = ctx;
+    AppRegistry.registerComponent('rn', () => Main);
+    const { getStyleElement } = AppRegistry.getApplication('rn');
+    const page = await renderPage();
+    const styles = getStyleElement();
+    return { ...page, styles };
+  }
+
+  render() {
+    return (
+      <Html>
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}


### PR DESCRIPTION
Example pages dont have styles in html after nextjs server-side rendering. 
Web pages have large layout shift and flashes during rendering.
We can use nextjs `next/document` and react-native-web`getStyleElement` to get styles we need.

fix: https://github.com/necolas/react-native-web/issues/2309
