### PR TITLE
feat: Online Example App Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The [documentation site](https://necolas.github.io/react-native-web/) covers ins
 
 ## Example
 
-And here is a simple example to get you started. The example app includes interactive examples and the [source code](https://github.com/necolas/react-native-web/blob/master/packages/examples) is also available.
+And here is a [simple example](https://necolas.github.io/react-native-web/examples/) to get you started. The example app includes [interactive examples](https://necolas.github.io/react-native-web/examples/) and the [source code](https://github.com/necolas/react-native-web/blob/master/packages/examples) is also available.
 
 ```js
 import React from 'react';

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "docs:release": "yarn docs:build && git checkout gh-pages && rm -rf ./docs && mv packages/docs/dist ./docs && git add ./docs && git commit -m \"Deploy documentation\" && git push origin gh-pages && git checkout -",
     "examples": "cd packages/examples && yarn dev",
     "examples:build": "cd packages/examples && yarn build",
+    "examples:release": "cd packages/examples && yarn export && cd ../../ && git checkout gh-pages && rm -rf ./docs/examples && mv packages/examples/dist ./docs/examples && git add -A && git commit -m \"Deploy examples\" && git push origin gh-pages && git checkout -",
     "flow": "flow",
     "fmt": "prettier --write \"**/*.js\"",
     "fmt:report": "prettier --check \"**/*.js\"",
@@ -26,7 +27,7 @@
     "lint:report": "eslint packages scripts",
     "prerelease": "yarn test && yarn compile",
     "release": "node ./scripts/release/publish.js",
-    "postrelease": "yarn docs:release && yarn benchmarks:release",
+    "postrelease": "yarn docs:release && yarn benchmarks:release && yarn examples:release",
     "test": "yarn flow && yarn lint:report && yarn jest --runInBand"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "docs:release": "yarn docs:build && git checkout gh-pages && rm -rf ./docs && mv packages/docs/dist ./docs && git add ./docs && git commit -m \"Deploy documentation\" && git push origin gh-pages && git checkout -",
     "examples": "cd packages/examples && yarn dev",
     "examples:build": "cd packages/examples && yarn build",
-    "examples:release": "cd packages/examples && yarn export && cd ../../ && git checkout gh-pages && rm -rf ./docs/examples && mv packages/examples/dist ./docs/examples && git add -A && git commit -m \"Deploy examples\" && git push origin gh-pages && git checkout -",
+    "examples:release": "cd packages/examples && yarn export && cd ../../ && git checkout gh-pages && rm -rf ./docs/examples && mv packages/examples/dist ./docs/examples && touch ./docs/.nojekyll && git add -A && git commit -m \"Deploy examples\" && git push origin gh-pages && git checkout -",
     "flow": "flow",
     "fmt": "prettier --write \"**/*.js\"",
     "fmt:report": "prettier --check \"**/*.js\"",

--- a/packages/examples/next.config.js
+++ b/packages/examples/next.config.js
@@ -8,5 +8,7 @@ const pages = fs
 
 module.exports = {
   outDir: 'dist',
-  env: { pages }
+  basePath: '/react-native-web/examples',
+  env: { pages },
+  trailingSlash: true
 };

--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -3,10 +3,11 @@
   "name": "examples",
   "version": "0.18.1",
   "scripts": {
-    "dev": "next",
+    "dev": "open http://localhost:3000/react-native-web/examples/ & next",
     "build": "next build",
-    "start": "next start"
-  },
+    "start": "next start",
+    "export": "next build && next export -o dist"
+  }, 
   "dependencies": {
     "next": "^12.1.0",
     "react": "^17.0.2",

--- a/packages/examples/pages/_document.js
+++ b/packages/examples/pages/_document.js
@@ -1,0 +1,25 @@
+import Document, { Html, Head, Main, NextScript } from 'next/document';
+import { AppRegistry } from 'react-native';
+
+export default class MyDocument extends Document {
+  static async getInitialProps(ctx) {
+    const { renderPage } = ctx;
+    AppRegistry.registerComponent('rn', () => Main);
+    const { getStyleElement } = AppRegistry.getApplication('rn');
+    const page = await renderPage();
+    const styles = getStyleElement();
+    return { ...page, styles };
+  }
+
+  render() {
+    return (
+      <Html>
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}

--- a/packages/examples/pages/index.js
+++ b/packages/examples/pages/index.js
@@ -37,7 +37,7 @@ export default function IndexPage() {
       <View accessibilityRole="list">
         {process.env.pages.map((name) => (
           <View accessibilityRole="listitem" key={name} style={styles.listitem}>
-            <Link href={'/' + name} style={styles.pageLink}>
+            <Link href={name} style={styles.pageLink}>
               {name}
             </Link>
           </View>

--- a/packages/examples/shared/example.js
+++ b/packages/examples/shared/example.js
@@ -4,7 +4,7 @@ export default function Example(props) {
   return (
     <View style={styles.root}>
       <View style={styles.header}>
-        <Text accessibilityLabel="Back" href="/" style={styles.back}>
+        <Text accessibilityLabel="Back" href="/react-native-web/examples/" style={styles.back}>
           <svg
             style={{ fill: '#555', height: '100%' }}
             viewBox="0 0 140 140"


### PR DESCRIPTION
If you want to try react-native-web example app, you have to pull git source and npm install and run it locally, which is very inconvenient.
We need a online exapmle app pages.

I use nextjs export static pages, and add scripts to auto deploy to github pages after release, so everyone can try the amazing react-native-web example app online with one click.

https://yuxizhe.github.io/react-native-web/examples (the url in my repo)

https://necolas.github.io/react-native-web/examples (after react native web release)

fix: https://github.com/necolas/react-native-web/issues/2310