### PR TITLE
[fix] Pressable suppression of contextmenu on windows 

### DIFF
--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -11,12 +11,13 @@
     "next": "^12.1.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-native-web": "0.18.2"
+    "react-native-web": "0.18.2",
+    "babel-plugin-react-native-web": "0.18.2"
   },
   "devDependencies": {
     "@babel/core": "^7.12.13",
-    "@babel/preset-flow": "^7.12.13",
-    "babel-plugin-react-native-web": "0.18.2"
+    "@babel/preset-flow": "^7.12.13"
+    
   },
   "license": "MIT"
 }

--- a/packages/react-native-web/src/modules/usePressEvents/PressResponder.js
+++ b/packages/react-native-web/src/modules/usePressEvents/PressResponder.js
@@ -475,7 +475,12 @@ export default class PressResponder {
     event: ResponderEvent
   ): void {
     if (isTerminalSignal(signal)) {
-      this._isPointerTouch = false;
+      // Pressable suppression of contextmenu on windows.
+      // On Windows, the contextmenu is displayed after pointerup.
+      // https://github.com/necolas/react-native-web/issues/2296
+      setTimeout(() => {
+        this._isPointerTouch = false;
+      }, 0);
       this._touchActivatePosition = null;
       this._cancelLongPressDelayTimeout();
     }


### PR DESCRIPTION
Fix https://github.com/necolas/react-native-web/issues/2296
Long-press with a touch on a Pressable does not suppress the contextmenu on Windows. On iOS and Android, the contextmenu is triggered while the pointer is down, after a certain length of time. However, on Windows, the contextmenu is displayed after pointerup (with the same timestamp as pointerup), whether triggered by a mouse right-click or a touch long-press.

before:
![Jun-28-2022 15-48-53](https://user-images.githubusercontent.com/14990734/176125066-78ae9e3d-3622-4443-a218-aa87af43f307.gif)

after:
![Jun-28-2022 15-50-21](https://user-images.githubusercontent.com/14990734/176125099-c0ed2790-8118-4f9b-b7d1-7644f39a7221.gif)

