### PR TITLE
Add Codesandbox CI integration for PRs.

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,0 +1,6 @@
+{
+  "packages": ["packages/react-native-web", "packages/babel-plugin-react-native-web"],
+  "buildCommand": "compile",
+  "sandboxes": ["/packages/examples/"],
+  "node": "16"
+}


### PR DESCRIPTION
https://github.com/necolas/react-native-web/issues/1484
Add Codesandbox CI integration for PRs.

It will build and private publish "packages/react-native-web", "packages/babel-plugin-react-native-web" in sandbox.
And use the private version to create the Examples App page.

<img width="500" alt="image" src="https://user-images.githubusercontent.com/14990734/176189294-43345d80-6b17-450b-805c-2eb70eebb338.png">
<img width="700" alt="image" src="https://user-images.githubusercontent.com/14990734/176218782-23c7b336-bea4-4f57-a20e-dfd6dcb4e5a4.png">

## Result:

private publish "packages/react-native-web", "packages/babel-plugin-react-native-web" in sandbox.
eg: https://ci.codesandbox.io/status/yuxizhe/react-native-web/pr/1/builds/265849
<img width="800" alt="image" src="https://user-images.githubusercontent.com/14990734/176189462-f096ebcc-3378-49fc-9c05-53e5c6262ce2.png">

sandbox auto ceate a examples page use the private version of RNW
eg: https://codesandbox.io/s/examples-m40glw
<img width="800" alt="image" src="https://user-images.githubusercontent.com/14990734/176189763-e2cd1b0e-fc79-43cf-9a49-91438979c7b1.png">

