### PR TITLE
Prevent style recalculation on pageload

### DIFF
--- a/packages/react-native-web/src/exports/Dimensions/index.js
+++ b/packages/react-native-web/src/exports/Dimensions/index.js
@@ -45,8 +45,14 @@ const dimensions = {
 };
 const listeners = {};
 
+let shouldInit = canUseDOM;
+
 export default class Dimensions {
   static get(dimension: DimensionKey): DisplayMetrics {
+    if (shouldInit) {
+      shouldInit = false;
+      this._update();
+    }
     invariant(dimensions[dimension], `No dimension set for key ${dimension}`);
     return dimensions[dimension];
   }
@@ -118,6 +124,5 @@ export default class Dimensions {
 }
 
 if (canUseDOM) {
-  Dimensions._update();
   window.addEventListener('resize', Dimensions._update, false);
 }

--- a/packages/react-native-web/src/exports/Dimensions/index.js
+++ b/packages/react-native-web/src/exports/Dimensions/index.js
@@ -51,7 +51,7 @@ export default class Dimensions {
   static get(dimension: DimensionKey): DisplayMetrics {
     if (shouldInit) {
       shouldInit = false;
-      this._update();
+      Dimensions._update();
     }
     invariant(dimensions[dimension], `No dimension set for key ${dimension}`);
     return dimensions[dimension];


### PR DESCRIPTION
This saves a style recalculation on page loads, for us is saves 32ms of page load time and improved our lighthouse score 4%.