### PR TITLE
Update `Appearance` API to match RN's current `Appearance` API

### DIFF
--- a/packages/react-native-web-docs/src/pages/docs/apis/appearance.md
+++ b/packages/react-native-web-docs/src/pages/docs/apis/appearance.md
@@ -26,3 +26,7 @@ import { Appearance } from 'react-native';
 {% call macro.prop('getColorScheme', '() => ("dark" | "light")') %}
 You can use the Appearance module to determine if the user prefers a dark color scheme. Although the color scheme is available immediately, this may change (e.g. scheduled color scheme change at sunrise or sunset). Any rendering logic or styles that depend on the user preferred color scheme should try to call this function on every render, rather than caching the value.
 {% endcall %}
+
+{% call macro.prop('addChangeListener', '(listener) => { remove: () => void }') %}
+Add an event handler that is fired when appearance preferences change. Returns a `remove` method used to remove the change listener.
+{% endcall %}

--- a/packages/react-native-web/src/exports/Appearance/index.js
+++ b/packages/react-native-web/src/exports/Appearance/index.js
@@ -37,7 +37,7 @@ const Appearance = {
     return query && query.matches ? 'dark' : 'light';
   },
 
-  addChangeListener(listener: AppearanceListener): void {
+  addChangeListener(listener: AppearanceListener): { remove: () => void } {
     let mappedListener = listenerMapping.get(listener);
     if (!mappedListener) {
       mappedListener = ({ matches }: MediaQueryListEvent) => {
@@ -48,16 +48,16 @@ const Appearance = {
     if (query) {
       query.addListener(mappedListener);
     }
-  },
 
-  removeChangeListener(listener: AppearanceListener): void {
-    const mappedListener = listenerMapping.get(listener);
-    if (mappedListener) {
-      if (query) {
+    function remove(): void {
+      const mappedListener = listenerMapping.get(listener);
+      if (query && mappedListener) {
         query.removeListener(mappedListener);
       }
       listenerMapping.delete(listener);
     }
+
+    return { remove };
   }
 };
 

--- a/packages/react-native-web/src/exports/useColorScheme/index.js
+++ b/packages/react-native-web/src/exports/useColorScheme/index.js
@@ -21,8 +21,8 @@ export default function useColorScheme(): ColorSchemeName {
     function listener(appearance) {
       setColorScheme(appearance.colorScheme);
     }
-    Appearance.addChangeListener(listener);
-    return () => Appearance.removeChangeListener(listener);
+    const { remove } = Appearance.addChangeListener(listener);
+    return remove;
   });
 
   return colorScheme;


### PR DESCRIPTION
React Native has updated it's `Appearance` API to remove the `Appearance.removeChangeListener` static method in favor of `Appearance.addChangeListener` returning a `remove` method. [See here](https://reactnative.dev/docs/appearance#removechangelistener)

Right now, RNW and RN's implementations of `Appearance` are different and therefore use of `Appearance` API in modern RN projects will work on mobile, but will break with RNW. This PR addresses that issue by brining RNW's `Appearance` API up to spec with RN's `Appearance` API.