### PR TITLE
React 18 concurrent render functions / removal of findDOMNode / test updates

### DIFF
--- a/configs/.eslintrc
+++ b/configs/.eslintrc
@@ -2,7 +2,7 @@
   "settings": {
     "react": {
       "pragma": "React",
-      "version": "17.0",
+      "version": "18.0",
       "flowVersion": "0.148.0" // Flow version
     }
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -14964,8 +14964,8 @@
         "styleq": "^0.1.2"
       },
       "peerDependencies": {
-        "react": "^17.0.2 || ^18.0.0-0",
-        "react-dom": "^17.0.2 || ^18.0.0-0"
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "packages/react-native-web-docs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@babel/preset-env": "^7.18.6",
         "@babel/preset-flow": "^7.18.6",
         "@babel/preset-react": "^7.18.6",
-        "@testing-library/react": "^12.1.5",
+        "@testing-library/react": "^13.3.0",
         "babel-eslint": "^10.1.0",
         "babel-jest": "^28.1.2",
         "babel-plugin-add-module-exports": "^1.0.4",
@@ -3103,21 +3103,21 @@
       }
     },
     "node_modules/@testing-library/react": {
-      "version": "12.1.5",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.5.tgz",
-      "integrity": "sha512-OfTXCJUFgjd/digLUuPxa0+/3ZxsQmE7ub9kcbW/wi96Bh3o/p5vrETcBGfP17NWPGqeYYl5LTRpwyGoMC4ysg==",
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-13.3.0.tgz",
+      "integrity": "sha512-DB79aA426+deFgGSjnf5grczDPiL4taK3hFaa+M5q7q20Kcve9eQottOG5kZ74KEr55v0tU2CQormSSDK87zYQ==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^8.0.0",
-        "@types/react-dom": "<18.0.0"
+        "@testing-library/dom": "^8.5.0",
+        "@types/react-dom": "^18.0.0"
       },
       "engines": {
         "node": ">=12"
       },
       "peerDependencies": {
-        "react": "<18.0.0",
-        "react-dom": "<18.0.0"
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -3366,9 +3366,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "17.0.47",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.47.tgz",
-      "integrity": "sha512-mk0BL8zBinf2ozNr3qPnlu1oyVTYq+4V7WA76RgxUAtf0Em/Wbid38KN6n4abEkvO4xMTBWmnP1FtQzgkEiJoA==",
+      "version": "18.0.15",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.15.tgz",
+      "integrity": "sha512-iz3BtLuIYH1uWdsv6wXYdhozhqj20oD4/Hk2DNXIn1kFsmp9x8d9QB6FnPhfkbhd2PgEONt9Q1x/ebkwjfFLow==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -3377,12 +3377,12 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "17.0.17",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.17.tgz",
-      "integrity": "sha512-VjnqEmqGnasQKV0CWLevqMTXBYG9GbwuE6x3VetERLh0cq2LTptFE73MrQi2S7GkKXCf2GgwItB/melLnxfnsg==",
+      "version": "18.0.6",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.6.tgz",
+      "integrity": "sha512-/5OFZgfIPSwy+YuIBP/FgJnQnsxhZhjjrnxudMddeblOouIodEQ75X14Rr4wGSG/bknL+Omy9iWlLo1u/9GzAA==",
       "dev": true,
       "dependencies": {
-        "@types/react": "^17"
+        "@types/react": "*"
       }
     },
     "node_modules/@types/scheduler": {
@@ -12232,30 +12232,26 @@
       "license": "ISC"
     },
     "node_modules/react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-      "license": "MIT",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
-      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-      "license": "MIT",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
+        "scheduler": "^0.23.0"
       },
       "peerDependencies": {
-        "react": "17.0.2"
+        "react": "^18.2.0"
       }
     },
     "node_modules/react-is": {
@@ -12899,13 +12895,11 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
-      "license": "MIT",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/schema-utils": {
@@ -14958,7 +14952,7 @@
       "license": "MIT"
     },
     "packages/react-native-web": {
-      "version": "0.18.9",
+      "version": "0.19.0",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.6",
@@ -14970,8 +14964,8 @@
         "styleq": "^0.1.2"
       },
       "peerDependencies": {
-        "react": "^17.0.2 || ^18.0.0",
-        "react-dom": "^17.0.2 || ^18.0.0"
+        "react": "^17.0.2 || ^18.0.0-0",
+        "react-dom": "^17.0.2 || ^18.0.0-0"
       }
     },
     "packages/react-native-web-docs": {
@@ -15044,13 +15038,28 @@
       "dependencies": {
         "babel-plugin-react-native-web": "0.18.9",
         "next": "^12.2.0",
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2",
+        "react": "^17.0.2 || ^18.0.0-0",
+        "react-dom": "^17.0.2 || ^18.0.0-0",
         "react-native-web": "0.18.9"
+      }
+    },
+    "packages/react-native-web-examples/node_modules/react-native-web": {
+      "version": "0.18.4",
+      "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.18.4.tgz",
+      "integrity": "sha512-DM8LMeE7jAc6WyoBu+Y03wYz6GryaOTqMibCzuKgHNexE1ANoKI/3BkQFG/sDLMYfM4YU/+CYnJ0qfr/nCkOMA==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.6",
+        "create-react-class": "^15.7.0",
+        "fbjs": "^3.0.0",
+        "inline-style-prefixer": "^6.0.0",
+        "normalize-css-color": "^1.0.2",
+        "postcss-value-parser": "^4.2.0",
+        "prop-types": "^15.6.0",
+        "styleq": "^0.1.2"
       },
-      "devDependencies": {
-        "@babel/core": "^7.18.6",
-        "@babel/preset-flow": "^7.18.6"
+      "peerDependencies": {
+        "react": ">=17.0.2",
+        "react-dom": ">=17.0.2"
       }
     }
   },
@@ -17181,14 +17190,14 @@
       }
     },
     "@testing-library/react": {
-      "version": "12.1.5",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-12.1.5.tgz",
-      "integrity": "sha512-OfTXCJUFgjd/digLUuPxa0+/3ZxsQmE7ub9kcbW/wi96Bh3o/p5vrETcBGfP17NWPGqeYYl5LTRpwyGoMC4ysg==",
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-13.3.0.tgz",
+      "integrity": "sha512-DB79aA426+deFgGSjnf5grczDPiL4taK3hFaa+M5q7q20Kcve9eQottOG5kZ74KEr55v0tU2CQormSSDK87zYQ==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5",
-        "@testing-library/dom": "^8.0.0",
-        "@types/react-dom": "<18.0.0"
+        "@testing-library/dom": "^8.5.0",
+        "@types/react-dom": "^18.0.0"
       }
     },
     "@tootallnate/once": {
@@ -17421,9 +17430,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "17.0.47",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.47.tgz",
-      "integrity": "sha512-mk0BL8zBinf2ozNr3qPnlu1oyVTYq+4V7WA76RgxUAtf0Em/Wbid38KN6n4abEkvO4xMTBWmnP1FtQzgkEiJoA==",
+      "version": "18.0.15",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.15.tgz",
+      "integrity": "sha512-iz3BtLuIYH1uWdsv6wXYdhozhqj20oD4/Hk2DNXIn1kFsmp9x8d9QB6FnPhfkbhd2PgEONt9Q1x/ebkwjfFLow==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -17432,12 +17441,12 @@
       }
     },
     "@types/react-dom": {
-      "version": "17.0.17",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.17.tgz",
-      "integrity": "sha512-VjnqEmqGnasQKV0CWLevqMTXBYG9GbwuE6x3VetERLh0cq2LTptFE73MrQi2S7GkKXCf2GgwItB/melLnxfnsg==",
+      "version": "18.0.6",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.6.tgz",
+      "integrity": "sha512-/5OFZgfIPSwy+YuIBP/FgJnQnsxhZhjjrnxudMddeblOouIodEQ75X14Rr4wGSG/bknL+Omy9iWlLo1u/9GzAA==",
       "dev": true,
       "requires": {
-        "@types/react": "^17"
+        "@types/react": "*"
       }
     },
     "@types/scheduler": {
@@ -23832,22 +23841,20 @@
       }
     },
     "react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "react-dom": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
-      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
       "requires": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
+        "scheduler": "^0.23.0"
       }
     },
     "react-is": {
@@ -23932,8 +23939,8 @@
         "@babel/preset-flow": "^7.18.6",
         "babel-plugin-react-native-web": "0.18.9",
         "next": "^12.2.0",
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2",
+        "react": "^17.0.2 || ^18.0.0-0",
+        "react-dom": "^17.0.2 || ^18.0.0-0",
         "react-native-web": "0.18.9"
       }
     },
@@ -24391,12 +24398,11 @@
       }
     },
     "scheduler": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
+      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
       "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.1.0"
       }
     },
     "schema-utils": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14952,7 +14952,7 @@
       "license": "MIT"
     },
     "packages/react-native-web": {
-      "version": "0.19.0",
+      "version": "0.18.6",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.6",
@@ -23939,8 +23939,8 @@
         "@babel/preset-flow": "^7.18.6",
         "babel-plugin-react-native-web": "0.18.9",
         "next": "^12.2.0",
-        "react": "^17.0.2 || ^18.0.0-0",
-        "react-dom": "^17.0.2 || ^18.0.0-0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0",
         "react-native-web": "0.18.9"
       }
     },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@babel/preset-env": "^7.18.6",
     "@babel/preset-flow": "^7.18.6",
     "@babel/preset-react": "^7.18.6",
-    "@testing-library/react": "^12.1.5",
+    "@testing-library/react": "^13.3.0",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^28.1.2",
     "babel-plugin-add-module-exports": "^1.0.4",

--- a/packages/benchmarks/src/index.js
+++ b/packages/benchmarks/src/index.js
@@ -71,4 +71,11 @@ const tests = {
   }))
 };
 
-ReactDOM.render(<App tests={tests} />, document.querySelector('.root'));
+const root = document.querySelector('.root');
+const element = <App tests={tests} />;
+
+if (React.version.startsWith('18')) {
+  ReactDOM.createRoot(root).render(element);
+} else {
+  ReactDOM.render(element, root);
+}

--- a/packages/benchmarks/src/index.js
+++ b/packages/benchmarks/src/index.js
@@ -74,8 +74,4 @@ const tests = {
 const root = document.querySelector('.root');
 const element = <App tests={tests} />;
 
-if (React.version.startsWith('18')) {
-  ReactDOM.createRoot(root).render(element);
-} else {
-  ReactDOM.render(element, root);
-}
+ReactDOM.createRoot(root).render(element);

--- a/packages/react-native-web-examples/package.json
+++ b/packages/react-native-web-examples/package.json
@@ -10,8 +10,8 @@
   "dependencies": {
     "babel-plugin-react-native-web": "0.18.9",
     "next": "^12.2.0",
-    "react": "^17.0.2 || ^18.0.0-0",
-    "react-dom": "^17.0.2 || ^18.0.0-0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "react-native-web": "0.18.9"
   },
   "devDependencies": {

--- a/packages/react-native-web-examples/package.json
+++ b/packages/react-native-web-examples/package.json
@@ -10,8 +10,8 @@
   "dependencies": {
     "babel-plugin-react-native-web": "0.18.9",
     "next": "^12.2.0",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "react": "^17.0.2 || ^18.0.0-0",
+    "react-dom": "^17.0.2 || ^18.0.0-0",
     "react-native-web": "0.18.9"
   },
   "devDependencies": {

--- a/packages/react-native-web/package.json
+++ b/packages/react-native-web/package.json
@@ -31,8 +31,8 @@
     "styleq": "^0.1.2"
   },
   "peerDependencies": {
-    "react": "^17.0.2 || ^18.0.0-0",
-    "react-dom": "^17.0.2 || ^18.0.0-0"
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
   },
   "author": "Nicolas Gallagher",
   "license": "MIT",

--- a/packages/react-native-web/package.json
+++ b/packages/react-native-web/package.json
@@ -3,7 +3,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "name": "react-native-web",
-  "version": "0.19.0",
+  "version": "0.18.4",
   "description": "React Native for Web",
   "module": "dist/index.js",
   "main": "dist/cjs/index.js",

--- a/packages/react-native-web/package.json
+++ b/packages/react-native-web/package.json
@@ -3,7 +3,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "name": "react-native-web",
-  "version": "0.18.9",
+  "version": "0.19.0",
   "description": "React Native for Web",
   "module": "dist/index.js",
   "main": "dist/cjs/index.js",
@@ -31,8 +31,8 @@
     "styleq": "^0.1.2"
   },
   "peerDependencies": {
-    "react": "^17.0.2 || ^18.0.0",
-    "react-dom": "^17.0.2 || ^18.0.0"
+    "react": "^17.0.2 || ^18.0.0-0",
+    "react-dom": "^17.0.2 || ^18.0.0-0"
   },
   "author": "Nicolas Gallagher",
   "license": "MIT",

--- a/packages/react-native-web/src/exports/ActivityIndicator/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/ActivityIndicator/__tests__/index-test.js
@@ -7,9 +7,8 @@
 
 import ActivityIndicator from '..';
 import React from 'react';
-import { act } from 'react-dom/test-utils';
 import { createEventTarget } from 'dom-event-testing-library';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 
 describe('components/ActivityIndicator', () => {
   describe('prop "accessibilityLabel"', () => {

--- a/packages/react-native-web/src/exports/AppRegistry/AppContainer.js
+++ b/packages/react-native-web/src/exports/AppRegistry/AppContainer.js
@@ -21,30 +21,40 @@ type Props = {
 
 const RootTagContext: React.Context<any> = React.createContext(null);
 
-export default function AppContainer(props: Props): React.Node {
-  const { children, WrapperComponent } = props;
+const AppContainer: React.AbstractComponent<Props> = React.forwardRef(
+  (props: Props, forwardedRef?: React.Ref<any>) => {
+    const { children, WrapperComponent } = props;
 
-  let innerView = (
-    <View
-      children={children}
-      key={1}
-      pointerEvents="box-none"
-      style={styles.appContainer}
-    />
-  );
+    let innerView = (
+      <View
+        children={children}
+        key={1}
+        pointerEvents="box-none"
+        style={styles.appContainer}
+      />
+    );
 
-  if (WrapperComponent) {
-    innerView = <WrapperComponent>{innerView}</WrapperComponent>;
+    if (WrapperComponent) {
+      innerView = <WrapperComponent>{innerView}</WrapperComponent>;
+    }
+
+    return (
+      <RootTagContext.Provider value={props.rootTag}>
+        <View
+          pointerEvents="box-none"
+          ref={forwardedRef}
+          style={styles.appContainer}
+        >
+          {innerView}
+        </View>
+      </RootTagContext.Provider>
+    );
   }
+);
 
-  return (
-    <RootTagContext.Provider value={props.rootTag}>
-      <View pointerEvents="box-none" style={styles.appContainer}>
-        {innerView}
-      </View>
-    </RootTagContext.Provider>
-  );
-}
+AppContainer.displayName = 'AppContainer';
+
+export default AppContainer;
 
 const styles = StyleSheet.create({
   appContainer: {

--- a/packages/react-native-web/src/exports/AppRegistry/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/AppRegistry/__tests__/index-test.js
@@ -7,10 +7,10 @@
 
 import AppRegistry from '..';
 import React from 'react';
-
+import { act } from '@testing-library/react';
 const NoopComponent = () => React.createElement('div');
 
-describe('AppRegistry', () => {
+describe.each([['concurrent'], ['legacy']])('AppRegistry', (mode) => {
   describe('runApplication', () => {
     let rootTag;
 
@@ -27,18 +27,22 @@ describe('AppRegistry', () => {
     test('callback after render', () => {
       const callback = jest.fn();
       AppRegistry.registerComponent('App', () => NoopComponent);
-      AppRegistry.runApplication('App', {
-        initialProps: {},
-        rootTag,
-        callback
+      act(() => {
+        AppRegistry.runApplication('App', {
+          initialProps: {},
+          rootTag,
+          callback,
+          mode
+        });
       });
       expect(callback).toHaveBeenCalledTimes(1);
     });
 
     test('styles roots in different documents', () => {
       AppRegistry.registerComponent('App', () => NoopComponent);
-      AppRegistry.runApplication('App', { initialProps: {}, rootTag });
-
+      act(() => {
+        AppRegistry.runApplication('App', { initialProps: {}, rootTag, mode });
+      });
       // Create iframe context
       const iframe = document.createElement('iframe');
       document.body.appendChild(iframe);
@@ -49,9 +53,12 @@ describe('AppRegistry', () => {
 
       // Run in iframe
       AppRegistry.registerComponent('App', () => NoopComponent);
-      AppRegistry.runApplication('App', {
-        initialProps: {},
-        rootTag: iframeRootTag
+      act(() => {
+        AppRegistry.runApplication('App', {
+          initialProps: {},
+          rootTag: iframeRootTag,
+          mode
+        });
       });
 
       const iframedoc = iframeRootTag.ownerDocument;

--- a/packages/react-native-web/src/exports/AppRegistry/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/AppRegistry/__tests__/index-test.js
@@ -38,6 +38,36 @@ describe.each([['concurrent'], ['legacy']])('AppRegistry', (mode) => {
       expect(callback).toHaveBeenCalledTimes(1);
     });
 
+    test('unmount ran application', () => {
+      const setMountedState = jest.fn();
+      const MountedStateComponent = () => {
+        React.useEffect(() => {
+          setMountedState(true);
+          return () => {
+            setMountedState(false);
+          };
+        }, []);
+        return <NoopComponent />;
+      };
+
+      AppRegistry.registerComponent('App', () => MountedStateComponent);
+      let application;
+      act(() => {
+        application = AppRegistry.runApplication('App', {
+          initialProps: {},
+          rootTag,
+          mode
+        });
+      });
+      expect(setMountedState).toHaveBeenCalledTimes(1);
+      expect(setMountedState).toHaveBeenLastCalledWith(true);
+      act(() => {
+        application.unmount();
+      });
+      expect(setMountedState).toHaveBeenCalledTimes(2);
+      expect(setMountedState).toHaveBeenLastCalledWith(false);
+    });
+
     test('styles roots in different documents', () => {
       AppRegistry.registerComponent('App', () => NoopComponent);
       act(() => {

--- a/packages/react-native-web/src/exports/AppRegistry/index.js
+++ b/packages/react-native-web/src/exports/AppRegistry/index.js
@@ -83,6 +83,7 @@ export default class AppRegistry {
           {
             hydrate: appParameters.hydrate || false,
             initialProps: appParameters.initialProps || emptyObject,
+            mode: appParameters.mode || 'legacy',
             rootTag: appParameters.rootTag
           }
         )

--- a/packages/react-native-web/src/exports/AppRegistry/index.js
+++ b/packages/react-native-web/src/exports/AppRegistry/index.js
@@ -13,6 +13,7 @@ import type { ComponentType, Node } from 'react';
 import invariant from 'fbjs/lib/invariant';
 import unmountComponentAtNode from '../unmountComponentAtNode';
 import renderApplication, { getApplication } from './renderApplication';
+import type { Application } from './renderApplication';
 
 type AppParams = Object;
 type Runnable = {|
@@ -75,7 +76,7 @@ export default class AppRegistry {
           appParameters ? appParameters.initialProps : emptyObject,
           wrapperComponentProvider && wrapperComponentProvider(appParameters)
         ),
-      run: (appParameters) =>
+      run: (appParameters): Application =>
         renderApplication(
           componentProviderInstrumentationHook(componentProvider),
           wrapperComponentProvider && wrapperComponentProvider(appParameters),
@@ -108,7 +109,7 @@ export default class AppRegistry {
     return appKey;
   }
 
-  static runApplication(appKey: string, appParameters: Object): void {
+  static runApplication(appKey: string, appParameters: Object): Application {
     const isDevelopment =
       process.env.NODE_ENV !== 'production' && process.env.NODE_ENV !== 'test';
     if (isDevelopment) {
@@ -129,7 +130,7 @@ export default class AppRegistry {
         'This is either due to an import error during initialization or failure to call AppRegistry.registerComponent.'
     );
 
-    runnables[appKey].run(appParameters);
+    return runnables[appKey].run(appParameters);
   }
 
   static setComponentProviderInstrumentationHook(

--- a/packages/react-native-web/src/exports/AppRegistry/renderApplication.js
+++ b/packages/react-native-web/src/exports/AppRegistry/renderApplication.js
@@ -16,6 +16,10 @@ import renderLegacy, { hydrateLegacy, render, hydrate } from '../render';
 import StyleSheet from '../StyleSheet';
 import React from 'react';
 
+export type Application = {
+  unmount: () => void
+};
+
 export default function renderApplication<Props: Object>(
   RootComponent: ComponentType<Props>,
   WrapperComponent?: ?ComponentType<*>,
@@ -26,7 +30,7 @@ export default function renderApplication<Props: Object>(
     mode: 'concurrent' | 'legacy',
     rootTag: any
   }
-) {
+): Application {
   const { hydrate: shouldHydrate, initialProps, mode, rootTag } = options;
   const renderFn = shouldHydrate
     ? mode === 'concurrent'
@@ -38,7 +42,7 @@ export default function renderApplication<Props: Object>(
 
   invariant(rootTag, 'Expect to have a valid rootTag, instead got ', rootTag);
 
-  renderFn(
+  return renderFn(
     <AppContainer
       WrapperComponent={WrapperComponent}
       ref={callback}

--- a/packages/react-native-web/src/exports/AppRegistry/renderApplication.js
+++ b/packages/react-native-web/src/exports/AppRegistry/renderApplication.js
@@ -12,7 +12,7 @@ import type { ComponentType, Node } from 'react';
 
 import AppContainer from './AppContainer';
 import invariant from 'fbjs/lib/invariant';
-import render, { hydrate } from '../render';
+import renderLegacy, { hydrateLegacy, render, hydrate } from '../render';
 import StyleSheet from '../StyleSheet';
 import React from 'react';
 
@@ -23,20 +23,30 @@ export default function renderApplication<Props: Object>(
   options: {
     hydrate: boolean,
     initialProps: Props,
+    mode: 'concurrent' | 'legacy',
     rootTag: any
   }
 ) {
-  const { hydrate: shouldHydrate, initialProps, rootTag } = options;
-  const renderFn = shouldHydrate ? hydrate : render;
+  const { hydrate: shouldHydrate, initialProps, mode, rootTag } = options;
+  const renderFn = shouldHydrate
+    ? mode === 'concurrent'
+      ? hydrate
+      : hydrateLegacy
+    : mode === 'concurrent'
+    ? render
+    : renderLegacy;
 
   invariant(rootTag, 'Expect to have a valid rootTag, instead got ', rootTag);
 
   renderFn(
-    <AppContainer WrapperComponent={WrapperComponent} rootTag={rootTag}>
+    <AppContainer
+      WrapperComponent={WrapperComponent}
+      ref={callback}
+      rootTag={rootTag}
+    >
       <RootComponent {...initialProps} />
     </AppContainer>,
-    rootTag,
-    callback
+    rootTag
   );
 }
 

--- a/packages/react-native-web/src/exports/Button/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/Button/__tests__/index-test.js
@@ -1,8 +1,7 @@
 import Button from '..';
 import React from 'react';
-import { act } from 'react-dom/test-utils';
 import { createEventTarget } from 'dom-event-testing-library';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 
 describe('components/Button', () => {
   test('prop "accessibilityLabel"', () => {

--- a/packages/react-native-web/src/exports/CheckBox/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/CheckBox/__tests__/index-test.js
@@ -7,9 +7,8 @@
 
 import CheckBox from '../';
 import React from 'react';
-import { act } from 'react-dom/test-utils';
 import { createEventTarget } from 'dom-event-testing-library';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 
 function findCheckbox(container) {
   return container.firstChild.querySelector('input');

--- a/packages/react-native-web/src/exports/Image/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/Image/__tests__/index-test.js
@@ -7,13 +7,12 @@
 
 /* eslint-disable react/jsx-no-bind */
 
-import { act } from 'react-dom/test-utils';
 import * as AssetRegistry from '../../../modules/AssetRegistry';
 import Image from '../';
 import ImageLoader, { ImageUriCache } from '../../../modules/ImageLoader';
 import PixelRatio from '../../PixelRatio';
 import React from 'react';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 
 const originalImage = window.Image;
 

--- a/packages/react-native-web/src/exports/Pressable/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/Pressable/__tests__/index-test.js
@@ -7,9 +7,8 @@
 
 import React from 'react';
 import Pressable from '../';
-import { act } from 'react-dom/test-utils';
 import { createEventTarget } from 'dom-event-testing-library';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 
 describe('components/Pressable', () => {
   test('default', () => {

--- a/packages/react-native-web/src/exports/ScrollView/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/ScrollView/__tests__/index-test.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import ScrollView from '../';
-import { act } from 'react-dom/test-utils';
 import { createEventTarget } from 'dom-event-testing-library';
 import { findDOMNode } from 'react-dom';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 
 describe('components/ScrollView', () => {
   describe('prop "centerContent"', () => {

--- a/packages/react-native-web/src/exports/Text/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/Text/__tests__/index-test.js
@@ -9,9 +9,8 @@
 
 import React from 'react';
 import Text from '../';
-import { act } from 'react-dom/test-utils';
 import { createEventTarget } from 'dom-event-testing-library';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 
 describe('components/Text', () => {
   test('default', () => {

--- a/packages/react-native-web/src/exports/TextInput/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/TextInput/__tests__/index-test.js
@@ -7,9 +7,8 @@
 
 import React from 'react';
 import TextInput from '..';
-import { act } from 'react-dom/test-utils';
 import { createEventTarget } from 'dom-event-testing-library';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 
 function findInput(container) {
   return container.querySelector('input');

--- a/packages/react-native-web/src/exports/View/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/View/__tests__/index-test.js
@@ -8,9 +8,8 @@
 import React from 'react';
 import View from '../';
 import StyleSheet from '../../StyleSheet';
-import { act } from 'react-dom/test-utils';
 import { createEventTarget } from 'dom-event-testing-library';
-import { render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 
 describe('components/View', () => {
   test('default', () => {

--- a/packages/react-native-web/src/exports/findNodeHandle/index.js
+++ b/packages/react-native-web/src/exports/findNodeHandle/index.js
@@ -10,6 +10,10 @@
 
 import { findDOMNode } from 'react-dom';
 
+/**
+ * @deprecated imperatively finding the DOM element of a react component has been deprecated in React 18.
+ * You should use ref properties on the component instead.
+ */
 const findNodeHandle = (component) => {
   let node;
 

--- a/packages/react-native-web/src/exports/render/index.js
+++ b/packages/react-native-web/src/exports/render/index.js
@@ -16,6 +16,7 @@ import {
   hydrateRoot as domHydrateRoot
 } from 'react-dom/client';
 
+import unmountComponentAtNode from '../unmountComponentAtNode';
 import { createSheet } from '../StyleSheet/dom';
 
 export function hydrate(element, root) {
@@ -32,10 +33,20 @@ export function render(element, root) {
 
 export function hydrateLegacy(element, root, callback) {
   createSheet(root);
-  return domLegacyHydrate(element, root, callback);
+  domLegacyHydrate(element, root, callback);
+  return {
+    unmount: function () {
+      return unmountComponentAtNode(root);
+    }
+  };
 }
 
 export default function renderLegacy(element, root, callback) {
   createSheet(root);
-  return domLegacyRender(element, root, callback);
+  domLegacyRender(element, root, callback);
+  return {
+    unmount: function () {
+      return unmountComponentAtNode(root);
+    }
+  };
 }

--- a/packages/react-native-web/src/exports/render/index.js
+++ b/packages/react-native-web/src/exports/render/index.js
@@ -20,13 +20,13 @@ import { createSheet } from '../StyleSheet/dom';
 
 export function hydrate(element, root) {
   createSheet(root);
-  return domHydrateRoot(element, root);
+  return domHydrateRoot(root, element);
 }
 
 export function render(element, root) {
   createSheet(root);
-  const reactRoot = domCreateRoot(element);
-  reactRoot.render(root);
+  const reactRoot = domCreateRoot(root);
+  reactRoot.render(element);
   return reactRoot;
 }
 

--- a/packages/react-native-web/src/exports/render/index.js
+++ b/packages/react-native-web/src/exports/render/index.js
@@ -7,15 +7,35 @@
  * @noflow
  */
 
-import { hydrate as domHydrate, render as domRender } from 'react-dom';
+import {
+  hydrate as domLegacyHydrate,
+  render as domLegacyRender
+} from 'react-dom';
+import {
+  createRoot as domCreateRoot,
+  hydrateRoot as domHydrateRoot
+} from 'react-dom/client';
+
 import { createSheet } from '../StyleSheet/dom';
 
-export function hydrate(element, root, callback) {
+export function hydrate(element, root) {
   createSheet(root);
-  return domHydrate(element, root, callback);
+  return domHydrateRoot(element, root);
 }
 
-export default function render(element, root, callback) {
+export function render(element, root) {
   createSheet(root);
-  return domRender(element, root, callback);
+  const reactRoot = domCreateRoot(element);
+  reactRoot.render(root);
+  return reactRoot;
+}
+
+export function hydrateLegacy(element, root, callback) {
+  createSheet(root);
+  return domLegacyHydrate(element, root, callback);
+}
+
+export default function renderLegacy(element, root, callback) {
+  createSheet(root);
+  return domLegacyRender(element, root, callback);
 }

--- a/packages/react-native-web/src/modules/ScrollResponder/index.js
+++ b/packages/react-native-web/src/modules/ScrollResponder/index.js
@@ -9,7 +9,6 @@
  */
 
 import Dimensions from '../../exports/Dimensions';
-import findNodeHandle from '../../exports/findNodeHandle';
 import invariant from 'fbjs/lib/invariant';
 import Platform from '../../exports/Platform';
 import TextInputState from '../TextInputState';
@@ -348,17 +347,6 @@ const ScrollResponderMixin = {
   },
 
   /**
-   * Returns the node that represents native view that can be scrolled.
-   * Components can pass what node to use by defining a `getScrollableNode`
-   * function otherwise `this` is used.
-   */
-  scrollResponderGetScrollableNode: function (): any {
-    return this.getScrollableNode
-      ? this.getScrollableNode()
-      : findNodeHandle(this);
-  },
-
-  /**
    * A helper function to scroll to a specific point in the scrollview.
    * This is currently used to help focus on child textviews, but can also
    * be used to quickly scroll to any element we want to focus. Syntax:
@@ -381,7 +369,7 @@ const ScrollResponderMixin = {
     } else {
       ({ x, y, animated } = x || emptyObject);
     }
-    const node = this.scrollResponderGetScrollableNode();
+    const node = this.getScrollableNode();
     const left = x || 0;
     const top = y || 0;
     if (typeof node.scroll === 'function') {
@@ -437,7 +425,7 @@ const ScrollResponderMixin = {
     this.preventNegativeScrollOffset = !!preventNegativeScrollOffset;
     UIManager.measureLayout(
       nodeHandle,
-      findNodeHandle(this.getInnerViewNode()),
+      this.getInnerViewNode(),
       this.scrollResponderTextInputFocusError,
       this.scrollResponderInputMeasureAndScrollToKeyboard
     );

--- a/packages/react-native-web/src/modules/createEventHandle/__tests__/index-test.js
+++ b/packages/react-native-web/src/modules/createEventHandle/__tests__/index-test.js
@@ -8,41 +8,11 @@
  */
 
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
-import * as ReactDOMClient from 'react-dom/client';
-import { act } from 'react-dom/test-utils';
+import { act, render } from '@testing-library/react';
 import { createEventTarget } from 'dom-event-testing-library';
 import createEventHandle from '..';
 
-function createRoot(rootNode) {
-  if (React.version.startsWith('18')) {
-    return ReactDOMClient.createRoot(rootNode);
-  } else {
-    return {
-      render(element) {
-        ReactDOM.render(element, rootNode);
-      }
-    };
-  }
-}
-
 describe('create-event-handle', () => {
-  let root;
-  let rootNode;
-
-  beforeEach(() => {
-    rootNode = document.createElement('div');
-    document.body.appendChild(rootNode);
-    root = createRoot(rootNode);
-  });
-
-  afterEach(() => {
-    root.render(null);
-    document.body.removeChild(rootNode);
-    rootNode = null;
-    root = null;
-  });
-
   describe('createEventTarget()', () => {
     test('event dispatched on target', () => {
       const listener = jest.fn();
@@ -56,9 +26,7 @@ describe('create-event-handle', () => {
         return <div ref={targetRef} />;
       }
 
-      act(() => {
-        root.render(<Component />);
-      });
+      render(<Component />);
 
       const target = createEventTarget(targetRef.current);
 
@@ -101,9 +69,7 @@ describe('create-event-handle', () => {
         );
       }
 
-      act(() => {
-        root.render(<Component />);
-      });
+      render(<Component />);
 
       const parent = createEventTarget(parentRef.current);
 
@@ -152,9 +118,7 @@ describe('create-event-handle', () => {
         );
       }
 
-      act(() => {
-        root.render(<Component />);
-      });
+      render(<Component />);
 
       const child = createEventTarget(childRef.current);
 
@@ -184,9 +148,7 @@ describe('create-event-handle', () => {
         );
       }
 
-      act(() => {
-        root.render(<Component />);
-      });
+      render(<Component />);
 
       const text = createEventTarget(childRef.current.firstChild);
 
@@ -209,9 +171,8 @@ describe('create-event-handle', () => {
         return <div ref={targetRef} />;
       }
 
-      act(() => {
-        root.render(<Component target={document} />);
-      });
+      render(<Component target={document} />);
+
       const target = createEventTarget(targetRef.current);
       act(() => {
         target.click();
@@ -232,9 +193,8 @@ describe('create-event-handle', () => {
         return <div ref={targetRef} />;
       }
 
-      act(() => {
-        root.render(<Component target={window} />);
-      });
+      render(<Component target={window} />);
+
       const target = createEventTarget(targetRef.current);
       act(() => {
         target.click();
@@ -255,9 +215,7 @@ describe('create-event-handle', () => {
         return <div ref={targetRef} />;
       }
 
-      act(() => {
-        root.render(<Component />);
-      });
+      render(<Component />);
 
       act(() => {
         const event = new CustomEvent('magic-event', { bubbles: true });
@@ -300,9 +258,7 @@ describe('create-event-handle', () => {
         );
       }
 
-      act(() => {
-        root.render(<Component />);
-      });
+      render(<Component />);
 
       const child = createEventTarget(childRef.current);
 
@@ -359,9 +315,7 @@ describe('create-event-handle', () => {
         );
       }
 
-      act(() => {
-        root.render(<Component />);
-      });
+      render(<Component />);
 
       const child = createEventTarget(childRef.current);
 
@@ -404,9 +358,7 @@ describe('create-event-handle', () => {
         );
       }
 
-      act(() => {
-        root.render(<Component />);
-      });
+      render(<Component />);
 
       const child = createEventTarget(childRef.current);
 
@@ -435,9 +387,7 @@ describe('create-event-handle', () => {
         return <div ref={targetRef} />;
       }
 
-      act(() => {
-        root.render(<Component />);
-      });
+      render(<Component />);
 
       const target = createEventTarget(targetRef.current);
 

--- a/packages/react-native-web/src/modules/createEventHandle/__tests__/index-test.js
+++ b/packages/react-native-web/src/modules/createEventHandle/__tests__/index-test.js
@@ -9,17 +9,21 @@
 
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-import * as ReactDOMServer from 'react-dom/server';
+import * as ReactDOMClient from 'react-dom/client';
 import { act } from 'react-dom/test-utils';
 import { createEventTarget } from 'dom-event-testing-library';
 import createEventHandle from '..';
 
 function createRoot(rootNode) {
-  return {
-    render(element) {
-      ReactDOM.render(element, rootNode);
-    }
-  };
+  if (React.version.startsWith('18')) {
+    return ReactDOMClient.createRoot(rootNode);
+  } else {
+    return {
+      render(element) {
+        ReactDOM.render(element, rootNode);
+      }
+    };
+  }
 }
 
 describe('create-event-handle', () => {
@@ -37,22 +41,6 @@ describe('create-event-handle', () => {
     document.body.removeChild(rootNode);
     rootNode = null;
     root = null;
-  });
-
-  test('can render correctly using ReactDOMServer', () => {
-    const listener = jest.fn();
-    const targetRef = React.createRef();
-    const addClickListener = createEventHandle('click');
-
-    function Component() {
-      React.useEffect(() => {
-        return addClickListener(targetRef.current, listener);
-      });
-      return <div ref={targetRef} />;
-    }
-
-    const output = ReactDOMServer.renderToString(<Component />);
-    expect(output).toBe('<div data-reactroot=""></div>');
   });
 
   describe('createEventTarget()', () => {

--- a/packages/react-native-web/src/modules/createEventHandle/__tests__/index-test.node.js
+++ b/packages/react-native-web/src/modules/createEventHandle/__tests__/index-test.node.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ */
+
+import * as React from 'react';
+import * as ReactDOMServer from 'react-dom/server';
+import createEventHandle from '..';
+
+describe('create-event-handle', () => {
+  test('can render correctly using ReactDOMServer', () => {
+    const listener = jest.fn();
+    const targetRef = React.createRef();
+    const addClickListener = createEventHandle('click');
+
+    function Component() {
+      React.useEffect(() => {
+        return addClickListener(targetRef.current, listener);
+      });
+      return <div ref={targetRef} />;
+    }
+
+    const output = ReactDOMServer.renderToString(<Component />);
+    expect(output).toBe('<div></div>');
+  });
+});

--- a/packages/react-native-web/src/modules/useEvent/__tests__/index-test.js
+++ b/packages/react-native-web/src/modules/useEvent/__tests__/index-test.js
@@ -8,41 +8,11 @@
  */
 
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
-import * as ReactDOMClient from 'react-dom/client';
-import { act } from 'react-dom/test-utils';
+import { act, render } from '@testing-library/react';
 import { createEventTarget } from 'dom-event-testing-library';
 import useEvent from '..';
 
-function createRoot(rootNode) {
-  if (React.version.startsWith('18')) {
-    return ReactDOMClient.createRoot(rootNode);
-  } else {
-    return {
-      render(element) {
-        ReactDOM.render(element, rootNode);
-      }
-    };
-  }
-}
-
 describe('use-event', () => {
-  let root;
-  let rootNode;
-
-  beforeEach(() => {
-    rootNode = document.createElement('div');
-    document.body.appendChild(rootNode);
-    root = createRoot(rootNode);
-  });
-
-  afterEach(() => {
-    root.render(null);
-    document.body.removeChild(rootNode);
-    rootNode = null;
-    root = null;
-  });
-
   describe('setListener()', () => {
     test('event dispatched on target', () => {
       const listener = jest.fn();
@@ -56,9 +26,7 @@ describe('use-event', () => {
         return <div ref={targetRef} />;
       }
 
-      act(() => {
-        root.render(<Component />);
-      });
+      render(<Component />);
 
       const target = createEventTarget(targetRef.current);
 
@@ -90,9 +58,7 @@ describe('use-event', () => {
         );
       }
 
-      act(() => {
-        root.render(<Component />);
-      });
+      render(<Component />);
 
       const parent = createEventTarget(parentRef.current);
 
@@ -130,9 +96,7 @@ describe('use-event', () => {
         );
       }
 
-      act(() => {
-        root.render(<Component />);
-      });
+      render(<Component />);
 
       const child = createEventTarget(childRef.current);
 
@@ -162,9 +126,7 @@ describe('use-event', () => {
         );
       }
 
-      act(() => {
-        root.render(<Component />);
-      });
+      render(<Component />);
 
       const text = createEventTarget(childRef.current.firstChild);
 
@@ -187,9 +149,8 @@ describe('use-event', () => {
         return <div ref={targetRef} />;
       }
 
-      act(() => {
-        root.render(<Component target={document} />);
-      });
+      render(<Component target={document} />);
+
       const target = createEventTarget(targetRef.current);
       act(() => {
         target.click();
@@ -210,9 +171,8 @@ describe('use-event', () => {
         return <div ref={targetRef} />;
       }
 
-      act(() => {
-        root.render(<Component target={window} />);
-      });
+      render(<Component target={window} />);
+
       const target = createEventTarget(targetRef.current);
       act(() => {
         target.click();
@@ -234,18 +194,16 @@ describe('use-event', () => {
         return <div ref={targetRef} />;
       }
 
-      act(() => {
-        root.render(<Component onClick={listener} />);
-      });
+      const { rerender } = render(<Component onClick={listener} />);
+
       const target = createEventTarget(targetRef.current);
       act(() => {
         target.click();
       });
       expect(listener).toBeCalledTimes(1);
-      act(() => {
-        // this should replace the listener
-        root.render(<Component onClick={listenerAlt} />);
-      });
+
+      rerender(<Component onClick={listenerAlt} />);
+
       act(() => {
         target.click();
       });
@@ -265,18 +223,17 @@ describe('use-event', () => {
         return <div ref={targetRef} />;
       }
 
-      act(() => {
-        root.render(<Component off={false} />);
-      });
+      const { unmount } = render(<Component off={false} />);
+
       const target = createEventTarget(targetRef.current);
       act(() => {
         target.click();
       });
       expect(listener).toBeCalledTimes(1);
-      act(() => {
-        // this should unset the listener
-        root.render(<Component off={true} />);
-      });
+
+      // this should unset the listener
+      unmount();
+
       listener.mockClear();
       act(() => {
         target.click();
@@ -296,9 +253,7 @@ describe('use-event', () => {
         return <div ref={targetRef} />;
       }
 
-      act(() => {
-        root.render(<Component />);
-      });
+      render(<Component />);
 
       act(() => {
         const event = new CustomEvent('magic-event', { bubbles: true });
@@ -340,9 +295,7 @@ describe('use-event', () => {
         );
       }
 
-      act(() => {
-        root.render(<Component />);
-      });
+      render(<Component />);
 
       const child = createEventTarget(childRef.current);
 
@@ -396,9 +349,7 @@ describe('use-event', () => {
         );
       }
 
-      act(() => {
-        root.render(<Component />);
-      });
+      render(<Component />);
 
       const child = createEventTarget(childRef.current);
 
@@ -430,10 +381,8 @@ describe('use-event', () => {
         return <div />;
       }
 
-      act(() => {
-        root.render(<Component />);
-        root.render(null);
-      });
+      const { unmount } = render(<Component />);
+      unmount();
 
       const target = createEventTarget(document);
 
@@ -467,9 +416,7 @@ describe('use-event', () => {
         );
       }
 
-      act(() => {
-        root.render(<Component />);
-      });
+      render(<Component />);
 
       const child = createEventTarget(childRef.current);
 
@@ -498,9 +445,7 @@ describe('use-event', () => {
         return <div ref={targetRef} />;
       }
 
-      act(() => {
-        root.render(<Component />);
-      });
+      render(<Component />);
 
       const target = createEventTarget(targetRef.current);
 

--- a/packages/react-native-web/src/modules/useEvent/__tests__/index-test.js
+++ b/packages/react-native-web/src/modules/useEvent/__tests__/index-test.js
@@ -9,16 +9,21 @@
 
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
+import * as ReactDOMClient from 'react-dom/client';
 import { act } from 'react-dom/test-utils';
 import { createEventTarget } from 'dom-event-testing-library';
 import useEvent from '..';
 
 function createRoot(rootNode) {
-  return {
-    render(element) {
-      ReactDOM.render(element, rootNode);
-    }
-  };
+  if (React.version.startsWith('18')) {
+    return ReactDOMClient.createRoot(rootNode);
+  } else {
+    return {
+      render(element) {
+        ReactDOM.render(element, rootNode);
+      }
+    };
+  }
 }
 
 describe('use-event', () => {

--- a/packages/react-native-web/src/modules/useHover/__tests__/index-test.js
+++ b/packages/react-native-web/src/modules/useHover/__tests__/index-test.js
@@ -8,6 +8,7 @@
 import { act } from 'react-dom/test-utils';
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
+import * as ReactDOMClient from 'react-dom/client';
 import {
   describeWithPointerEvent,
   clearPointers,
@@ -18,11 +19,15 @@ import useHover from '..';
 import { testOnly_resetActiveModality } from '../../modality';
 
 function createRoot(rootNode) {
-  return {
-    render(element) {
-      ReactDOM.render(element, rootNode);
-    }
-  };
+  if (React.version.startsWith('18')) {
+    return ReactDOMClient.createRoot(rootNode);
+  } else {
+    return {
+      render(element) {
+        ReactDOM.render(element, rootNode);
+      }
+    };
+  }
 }
 
 describeWithPointerEvent('useHover', (hasPointerEvents) => {

--- a/packages/react-native-web/src/modules/useHover/__tests__/index-test.js
+++ b/packages/react-native-web/src/modules/useHover/__tests__/index-test.js
@@ -5,10 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { act } from 'react-dom/test-utils';
+import { act, render } from '@testing-library/react';
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
-import * as ReactDOMClient from 'react-dom/client';
 import {
   describeWithPointerEvent,
   clearPointers,
@@ -18,34 +16,12 @@ import {
 import useHover from '..';
 import { testOnly_resetActiveModality } from '../../modality';
 
-function createRoot(rootNode) {
-  if (React.version.startsWith('18')) {
-    return ReactDOMClient.createRoot(rootNode);
-  } else {
-    return {
-      render(element) {
-        ReactDOM.render(element, rootNode);
-      }
-    };
-  }
-}
-
 describeWithPointerEvent('useHover', (hasPointerEvents) => {
-  let root;
-  let rootNode;
-
   beforeEach(() => {
     setPointerEvent(hasPointerEvents);
-    rootNode = document.createElement('div');
-    document.body.appendChild(rootNode);
-    root = createRoot(rootNode);
   });
 
   afterEach(() => {
-    root.render(null);
-    document.body.removeChild(rootNode);
-    rootNode = null;
-    root = null;
     testOnly_resetActiveModality();
     // make sure all tests reset state machine tracking pointers on the mock surface
     clearPointers();
@@ -75,9 +51,7 @@ describeWithPointerEvent('useHover', (hasPointerEvents) => {
           </div>
         );
       };
-      act(() => {
-        root.render(<Component />);
-      });
+      render(<Component />);
     };
 
     test('contains the hover gesture', () => {
@@ -116,9 +90,7 @@ describeWithPointerEvent('useHover', (hasPointerEvents) => {
         });
         return <div ref={ref} />;
       };
-      act(() => {
-        root.render(<Component />);
-      });
+      render(<Component />);
     };
 
     test('does not call callbacks', () => {
@@ -145,9 +117,7 @@ describeWithPointerEvent('useHover', (hasPointerEvents) => {
         useHover(ref, { onHoverStart });
         return <div ref={ref} />;
       };
-      act(() => {
-        root.render(<Component />);
-      });
+      render(<Component />);
     };
 
     test('is called for mouse pointers', () => {
@@ -191,9 +161,7 @@ describeWithPointerEvent('useHover', (hasPointerEvents) => {
         useHover(ref, { onHoverChange });
         return <div ref={ref} />;
       };
-      act(() => {
-        root.render(<Component />);
-      });
+      render(<Component />);
     };
 
     test('is called for mouse pointers', () => {
@@ -237,9 +205,7 @@ describeWithPointerEvent('useHover', (hasPointerEvents) => {
           </div>
         );
       };
-      act(() => {
-        root.render(<Component />);
-      });
+      render(<Component />);
     };
 
     test('is called for mouse pointers', () => {
@@ -283,9 +249,7 @@ describeWithPointerEvent('useHover', (hasPointerEvents) => {
         useHover(ref, { onHoverUpdate });
         return <div ref={ref} />;
       };
-      act(() => {
-        root.render(<Component />);
-      });
+      render(<Component />);
 
       const target = createEventTarget(ref.current);
       act(() => {
@@ -315,9 +279,7 @@ describeWithPointerEvent('useHover', (hasPointerEvents) => {
         });
         return <div ref={ref} />;
       };
-      act(() => {
-        root.render(<Component />);
-      });
+      render(<Component />);
     };
 
     test('callbacks are called each time', () => {

--- a/packages/react-native-web/src/modules/useMergeRefs/__tests__/index-test.js
+++ b/packages/react-native-web/src/modules/useMergeRefs/__tests__/index-test.js
@@ -6,8 +6,7 @@
  */
 
 import * as React from 'react';
-import { act } from 'react-dom/test-utils';
-import { cleanup, render } from '@testing-library/react';
+import { act, render } from '@testing-library/react';
 import useMergeRefs from '..';
 
 describe('modules/useMergeRefs', () => {
@@ -15,8 +14,6 @@ describe('modules/useMergeRefs', () => {
     const mergedRef = useMergeRefs(...refs);
     return <div ref={mergedRef} {...rest} />;
   }
-
-  afterEach(cleanup);
 
   test('handles no refs', () => {
     act(() => {

--- a/packages/react-native-web/src/modules/useResponderEvents/__tests__/index-test.js
+++ b/packages/react-native-web/src/modules/useResponderEvents/__tests__/index-test.js
@@ -8,6 +8,7 @@
 import { act } from 'react-dom/test-utils';
 import React, { createRef } from 'react';
 import ReactDOM from 'react-dom';
+import ReactDOMClient from 'react-dom/client';
 import useResponderEvents from '..';
 import { getResponderNode, terminateResponder } from '../ResponderSystem';
 import {
@@ -22,7 +23,11 @@ describe('useResponderEvents', () => {
   let container;
 
   function render(element) {
-    ReactDOM.render(element, container);
+    if (React.version.startsWith('18')) {
+      ReactDOMClient.createRoot(container).render(element);
+    } else {
+      ReactDOM.render(element, container);
+    }
   }
 
   beforeEach(() => {

--- a/packages/react-native-web/src/modules/useResponderEvents/__tests__/index-test.js
+++ b/packages/react-native-web/src/modules/useResponderEvents/__tests__/index-test.js
@@ -5,10 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { act } from 'react-dom/test-utils';
+import { act, render } from '@testing-library/react';
 import React, { createRef } from 'react';
-import ReactDOM from 'react-dom';
-import ReactDOMClient from 'react-dom/client';
 import useResponderEvents from '..';
 import { getResponderNode, terminateResponder } from '../ResponderSystem';
 import {
@@ -20,25 +18,7 @@ import {
 } from 'dom-event-testing-library';
 
 describe('useResponderEvents', () => {
-  let container;
-
-  function render(element) {
-    if (React.version.startsWith('18')) {
-      ReactDOMClient.createRoot(container).render(element);
-    } else {
-      ReactDOM.render(element, container);
-    }
-  }
-
-  beforeEach(() => {
-    container = document.createElement('div');
-    document.body.appendChild(container);
-  });
-
   afterEach(() => {
-    render(null);
-    document.body.removeChild(container);
-    container = null;
     // make sure all tests end with the current responder being reset
     terminateResponder();
     // make sure all tests reset state machine tracking pointers on the mock surface
@@ -57,9 +37,7 @@ describe('useResponderEvents', () => {
       };
 
       // render
-      act(() => {
-        render(<Component />);
-      });
+      render(<Component />);
       const target = createEventTarget(targetRef.current);
       // gesture
       act(() => {
@@ -81,9 +59,7 @@ describe('useResponderEvents', () => {
     };
 
     // render
-    act(() => {
-      render(<Component />);
-    });
+    render(<Component />);
     const target = createEventTarget(targetRef.current);
     const buttons = [1, 2, 3, 4];
     // gesture
@@ -110,9 +86,7 @@ describe('useResponderEvents', () => {
     };
 
     // render
-    act(() => {
-      render(<Component />);
-    });
+    render(<Component />);
     const target = createEventTarget(targetRef.current);
     const acceptedModifierKeys = ['metaKey', 'shiftKey'];
     const ignoredModifierKeys = ['altKey', 'ctrlKey'];
@@ -144,9 +118,7 @@ describe('useResponderEvents', () => {
     };
 
     // render
-    act(() => {
-      render(<Component />);
-    });
+    render(<Component />);
     const target = createEventTarget(targetRef.current);
     // touch gesture
     act(() => {
@@ -191,9 +163,7 @@ describe('useResponderEvents', () => {
     };
 
     // render
-    act(() => {
-      render(<Component />);
-    });
+    render(<Component />);
     const target = createEventTarget(targetRef.current);
     // gesture
     act(() => {
@@ -250,9 +220,7 @@ describe('useResponderEvents', () => {
         };
 
         // render
-        act(() => {
-          render(<Component />);
-        });
+        render(<Component />);
         const target = createEventTarget(targetRef.current);
         // gesture start
         act(() => {
@@ -307,9 +275,7 @@ describe('useResponderEvents', () => {
       };
 
       // render
-      act(() => {
-        render(<Component />);
-      });
+      render(<Component />);
       const target = createEventTarget(targetRef.current);
       // gesture start
       act(() => {
@@ -360,9 +326,7 @@ describe('useResponderEvents', () => {
       };
 
       // render
-      act(() => {
-        render(<Component />);
-      });
+      render(<Component />);
       const target = createEventTarget(targetRef.current);
       // gesture start
       act(() => {
@@ -431,9 +395,7 @@ describe('useResponderEvents', () => {
       };
 
       // render
-      act(() => {
-        render(<Component />);
-      });
+      render(<Component />);
       const target = createEventTarget(targetRef.current);
       // gesture start
       act(() => {
@@ -480,9 +442,7 @@ describe('useResponderEvents', () => {
       };
 
       // render
-      act(() => {
-        render(<Component />);
-      });
+      render(<Component />);
       const target = createEventTarget(targetRef.current);
       // gesture start
       act(() => {
@@ -531,9 +491,7 @@ describe('useResponderEvents', () => {
         };
 
         // render
-        act(() => {
-          render(<Component />);
-        });
+        render(<Component />);
         const target = createEventTarget(targetRef.current);
         // gesture start
         act(() => {
@@ -601,9 +559,7 @@ describe('useResponderEvents', () => {
         };
 
         // render
-        act(() => {
-          render(<Component />);
-        });
+        render(<Component />);
         const target = createEventTarget(targetRef.current);
         // gesture start & move
         act(() => {
@@ -658,9 +614,7 @@ describe('useResponderEvents', () => {
       };
 
       // render
-      act(() => {
-        render(<Component />);
-      });
+      render(<Component />);
       const target = createEventTarget(targetRef.current);
       // gesture start & move
       act(() => {
@@ -712,9 +666,7 @@ describe('useResponderEvents', () => {
       };
 
       // render
-      act(() => {
-        render(<Component />);
-      });
+      render(<Component />);
       const target = createEventTarget(targetRef.current);
       // gesture start & move
       act(() => {
@@ -784,9 +736,7 @@ describe('useResponderEvents', () => {
       };
 
       // render
-      act(() => {
-        render(<Component />);
-      });
+      render(<Component />);
       const target = createEventTarget(targetRef.current);
       // gesture start & move
       act(() => {
@@ -835,9 +785,7 @@ describe('useResponderEvents', () => {
       };
 
       // render
-      act(() => {
-        render(<Component />);
-      });
+      render(<Component />);
       const target = createEventTarget(targetRef.current);
       // gesture start & move
       act(() => {
@@ -887,9 +835,7 @@ describe('useResponderEvents', () => {
         };
 
         // render
-        act(() => {
-          render(<Component />);
-        });
+        render(<Component />);
         const target = createEventTarget(targetRef.current);
         // gesture start & move
         act(() => {
@@ -948,9 +894,7 @@ describe('useResponderEvents', () => {
         };
 
         // render
-        act(() => {
-          render(<Component />);
-        });
+        render(<Component />);
         const target = createEventTarget(targetRef.current);
         // gesture start
         act(() => {
@@ -992,9 +936,7 @@ describe('useResponderEvents', () => {
         };
 
         // render
-        act(() => {
-          render(<Component />);
-        });
+        render(<Component />);
         const target = createEventTarget(targetRef.current);
         // gesture start
         act(() => {
@@ -1043,9 +985,7 @@ describe('useResponderEvents', () => {
       };
 
       // render
-      act(() => {
-        render(<Component />);
-      });
+      render(<Component />);
       const target = createEventTarget(targetRef.current);
       // gesture start
       act(() => {
@@ -1072,9 +1012,7 @@ describe('useResponderEvents', () => {
         };
 
         // render
-        act(() => {
-          render(<Component />);
-        });
+        render(<Component />);
         const target = createEventTarget(targetRef.current);
         // gesture start
         act(() => {
@@ -1139,9 +1077,7 @@ describe('useResponderEvents', () => {
         };
 
         // render
-        act(() => {
-          render(<Component />);
-        });
+        render(<Component />);
         const target = createEventTarget(targetRef.current);
         // gesture start
         act(() => {
@@ -1186,9 +1122,7 @@ describe('useResponderEvents', () => {
             };
 
             // render
-            act(() => {
-              render(<Component />);
-            });
+            render(<Component />);
             const target = createEventTarget(targetRef.current);
             // gesture start & move
             act(() => {
@@ -1233,9 +1167,7 @@ describe('useResponderEvents', () => {
         };
 
         // render
-        act(() => {
-          render(<Component />);
-        });
+        render(<Component />);
         const target = createEventTarget(targetRef.current);
         // gesture start & end
         act(() => {
@@ -1278,9 +1210,7 @@ describe('useResponderEvents', () => {
         };
 
         // render
-        act(() => {
-          render(<Component />);
-        });
+        render(<Component />);
         const target = createEventTarget(targetRef.current);
         // gesture
         act(() => {
@@ -1325,9 +1255,7 @@ describe('useResponderEvents', () => {
       };
 
       // render
-      act(() => {
-        render(<Component />);
-      });
+      render(<Component />);
       const target = createEventTarget(targetRef.current);
       // gesture start & cancel
       act(() => {
@@ -1364,9 +1292,7 @@ describe('useResponderEvents', () => {
       };
 
       // render
-      act(() => {
-        render(<Component />);
-      });
+      render(<Component />);
       const target = createEventTarget(targetRef.current);
       const input = createEventTarget(inputRef.current);
       // getSelection is not supported in jest
@@ -1394,9 +1320,7 @@ describe('useResponderEvents', () => {
         };
 
         // render
-        act(() => {
-          render(<Component />);
-        });
+        render(<Component />);
         const target = createEventTarget(targetRef.current);
         const doc = createEventTarget(document);
         // getSelection is not supported in jest
@@ -1442,9 +1366,7 @@ describe('useResponderEvents', () => {
       };
 
       // render
-      act(() => {
-        render(<Component />);
-      });
+      render(<Component />);
       const target = createEventTarget(targetRef.current);
       const parent = createEventTarget(parentRef.current);
       // gesture start & scroll
@@ -1478,9 +1400,7 @@ describe('useResponderEvents', () => {
       };
 
       // render
-      act(() => {
-        render(<Component />);
-      });
+      render(<Component />);
       const target = createEventTarget(targetRef.current);
       const doc = createEventTarget(document);
       // gesture start & scroll
@@ -1515,9 +1435,7 @@ describe('useResponderEvents', () => {
       };
 
       // render
-      act(() => {
-        render(<Component />);
-      });
+      render(<Component />);
       const target = createEventTarget(targetRef.current);
       const sibling = createEventTarget(siblingRef.current);
       // gesture start & scroll
@@ -1546,9 +1464,7 @@ describe('useResponderEvents', () => {
       };
 
       // render
-      act(() => {
-        render(<Component />);
-      });
+      render(<Component />);
       const target = createEventTarget(targetRef.current);
       const doc = createEventTarget(document);
       // gesture start & blur
@@ -1576,9 +1492,7 @@ describe('useResponderEvents', () => {
       };
 
       // render
-      act(() => {
-        render(<Component />);
-      });
+      render(<Component />);
       const target = createEventTarget(targetRef.current);
       const win = createEventTarget(window);
       // gesture start & blur
@@ -1612,9 +1526,7 @@ describe('useResponderEvents', () => {
       };
 
       // render
-      act(() => {
-        render(<Component />);
-      });
+      render(<Component />);
       const target = createEventTarget(targetRef.current);
       const sibling = createEventTarget(siblingRef.current);
       // gesture start & blur
@@ -1645,9 +1557,7 @@ describe('useResponderEvents', () => {
       };
 
       // render
-      act(() => {
-        render(<Component />);
-      });
+      render(<Component />);
       const target = createEventTarget(targetRef.current);
       // contextmenu sequence includes pointerdown "start"
       act(() => {
@@ -1680,9 +1590,7 @@ describe('useResponderEvents', () => {
       }
 
       // render
-      act(() => {
-        render(<Component />);
-      });
+      render(<Component />);
       const target = createEventTarget(targetRef.current);
       const doc = createEventTarget(document);
       // contextmenu
@@ -1865,9 +1773,7 @@ describe('useResponderEvents', () => {
       };
 
       // render
-      act(() => {
-        render(<Component />);
-      });
+      render(<Component />);
       const target = createEventTarget(targetRef.current);
 
       // gesture start
@@ -2039,9 +1945,7 @@ describe('useResponderEvents', () => {
       };
 
       // render
-      act(() => {
-        render(<Component />);
-      });
+      render(<Component />);
       const target = createEventTarget(targetRef.current);
 
       // gesture start
@@ -2204,9 +2108,7 @@ describe('useResponderEvents', () => {
       };
 
       // render
-      act(() => {
-        render(<Component />);
-      });
+      render(<Component />);
       const parent = createEventTarget(parentRef.current);
       const target = createEventTarget(targetRef.current);
 
@@ -2392,9 +2294,7 @@ describe('useResponderEvents', () => {
       };
 
       // render
-      act(() => {
-        render(<Component />);
-      });
+      render(<Component />);
       const target = createEventTarget(targetRef.current);
       const sibling = createEventTarget(siblingRef.current);
       // gesture start on target
@@ -2535,9 +2435,7 @@ describe('useResponderEvents', () => {
       };
 
       // render
-      act(() => {
-        render(<Component />);
-      });
+      render(<Component />);
       const target = createEventTarget(targetRef.current);
       const sibling = createEventTarget(siblingRef.current);
       // gesture start and move on target
@@ -2641,9 +2539,7 @@ describe('useResponderEvents', () => {
       };
 
       // render
-      act(() => {
-        render(<Component />);
-      });
+      render(<Component />);
       const target = createEventTarget(targetRef.current);
       // first touch
       act(() => {
@@ -2778,9 +2674,7 @@ describe('useResponderEvents', () => {
       };
 
       // render
-      act(() => {
-        render(<Component />);
-      });
+      render(<Component />);
       const target = createEventTarget(targetRef.current);
       const parent = createEventTarget(parentRef.current);
       // first touch
@@ -2881,9 +2775,7 @@ describe('useResponderEvents', () => {
       };
 
       // render
-      act(() => {
-        render(<Component />);
-      });
+      render(<Component />);
       const target = createEventTarget(targetRef.current);
       act(() => {
         target.pointerdown({ pointerType });

--- a/packages/react-native-web/src/modules/useStable/__tests__/index-test.js
+++ b/packages/react-native-web/src/modules/useStable/__tests__/index-test.js
@@ -9,15 +9,20 @@
 
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
+import * as ReactDOMClient from 'react-dom/client';
 import { act } from 'react-dom/test-utils';
 import useStable from '..';
 
 function createRoot(rootNode) {
-  return {
-    render(element) {
-      ReactDOM.render(element, rootNode);
-    }
-  };
+  if (React.version.startsWith('18')) {
+    return ReactDOMClient.createRoot(rootNode);
+  } else {
+    return {
+      render(element) {
+        ReactDOM.render(element, rootNode);
+      }
+    };
+  }
 }
 
 describe('useStable', () => {

--- a/packages/react-native-web/src/modules/useStable/__tests__/index-test.js
+++ b/packages/react-native-web/src/modules/useStable/__tests__/index-test.js
@@ -8,26 +8,10 @@
  */
 
 import * as React from 'react';
-import * as ReactDOM from 'react-dom';
-import * as ReactDOMClient from 'react-dom/client';
-import { act } from 'react-dom/test-utils';
+import { render } from '@testing-library/react';
 import useStable from '..';
 
-function createRoot(rootNode) {
-  if (React.version.startsWith('18')) {
-    return ReactDOMClient.createRoot(rootNode);
-  } else {
-    return {
-      render(element) {
-        ReactDOM.render(element, rootNode);
-      }
-    };
-  }
-}
-
 describe('useStable', () => {
-  let root;
-  let rootNode;
   let spy = {};
 
   const TestComponent = ({ initialValueCallback }): React.Node => {
@@ -38,59 +22,33 @@ describe('useStable', () => {
 
   beforeEach(() => {
     spy = {};
-    rootNode = document.createElement('div');
-    document.body.appendChild(rootNode);
-    root = createRoot(rootNode);
-  });
-
-  afterEach(() => {
-    root.render(null);
-    document.body.removeChild(rootNode);
-    rootNode = null;
-    root = null;
   });
 
   test('correctly sets the initial value', () => {
     const initialValueCallback = () => 5;
-    act(() => {
-      root.render(
-        <TestComponent initialValueCallback={initialValueCallback} />
-      );
-    });
+    render(<TestComponent initialValueCallback={initialValueCallback} />);
     expect(spy.value).toBe(5);
   });
 
   test('does not change the value', () => {
     let counter = 0;
     const initialValueCallback = () => counter++;
-    act(() => {
-      root.render(
-        <TestComponent initialValueCallback={initialValueCallback} />
-      );
-    });
+    const { rerender } = render(
+      <TestComponent initialValueCallback={initialValueCallback} />
+    );
     expect(spy.value).toBe(0);
-    act(() => {
-      root.render(
-        <TestComponent initialValueCallback={initialValueCallback} />
-      );
-    });
+    rerender(<TestComponent initialValueCallback={initialValueCallback} />);
     expect(spy.value).toBe(0);
   });
 
   test('only calls the callback once', () => {
     let counter = 0;
     const initialValueCallback = () => counter++;
-    act(() => {
-      root.render(
-        <TestComponent initialValueCallback={initialValueCallback} />
-      );
-    });
+    const { rerender } = render(
+      <TestComponent initialValueCallback={initialValueCallback} />
+    );
     expect(counter).toBe(1);
-    act(() => {
-      root.render(
-        <TestComponent initialValueCallback={initialValueCallback} />
-      );
-    });
+    rerender(<TestComponent initialValueCallback={initialValueCallback} />);
     expect(counter).toBe(1);
   });
 
@@ -103,17 +61,11 @@ describe('useStable', () => {
       }
       return counter++;
     };
-    act(() => {
-      root.render(
-        <TestComponent initialValueCallback={initialValueCallback} />
-      );
-    });
+    const { rerender } = render(
+      <TestComponent initialValueCallback={initialValueCallback} />
+    );
     expect(spy.value).toBe(null);
-    act(() => {
-      root.render(
-        <TestComponent initialValueCallback={initialValueCallback} />
-      );
-    });
+    rerender(<TestComponent initialValueCallback={initialValueCallback} />);
     expect(spy.value).toBe(null);
   });
 });

--- a/packages/react-native-web/src/vendor/react-native/Animated/AnimatedEvent.js
+++ b/packages/react-native-web/src/vendor/react-native/Animated/AnimatedEvent.js
@@ -12,7 +12,6 @@
 
 import AnimatedValue from './nodes/AnimatedValue';
 import NativeAnimatedHelper from './NativeAnimatedHelper';
-import findNodeHandle from '../../../exports/findNodeHandle';
 
 import invariant from 'fbjs/lib/invariant';
 
@@ -58,11 +57,10 @@ export function attachNativeEvent(
   // Assume that the event containing `nativeEvent` is always the first argument.
   traverse(argMapping[0].nativeEvent, []);
 
-  const viewTag = findNodeHandle(viewRef);
-  if (viewTag != null) {
+  if (viewRef != null) {
     eventMappings.forEach(mapping => {
       NativeAnimatedHelper.API.addAnimatedEventToView(
-        viewTag,
+        viewRef,
         eventName,
         mapping,
       );
@@ -71,10 +69,10 @@ export function attachNativeEvent(
 
   return {
     detach() {
-      if (viewTag != null) {
+      if (viewRef != null) {
         eventMappings.forEach(mapping => {
           NativeAnimatedHelper.API.removeAnimatedEventFromView(
-            viewTag,
+            viewRef,
             eventName,
             // $FlowFixMe[incompatible-call]
             mapping.animatedValueTag,

--- a/packages/react-native-web/src/vendor/react-native/Animated/nodes/AnimatedProps.js
+++ b/packages/react-native-web/src/vendor/react-native/Animated/nodes/AnimatedProps.js
@@ -14,7 +14,6 @@ import {AnimatedEvent} from '../AnimatedEvent';
 import AnimatedNode from './AnimatedNode';
 import AnimatedStyle from './AnimatedStyle';
 import NativeAnimatedHelper from '../NativeAnimatedHelper';
-import findNodeHandle from '../../../../exports/findNodeHandle';
 
 import invariant from 'fbjs/lib/invariant';
 
@@ -119,9 +118,7 @@ class AnimatedProps extends AnimatedNode {
 
   __connectAnimatedView(): void {
     invariant(this.__isNative, 'Expected node to be marked as "native"');
-    const nativeViewTag: ?number = findNodeHandle(
-      this._animatedView,
-    );
+    const nativeViewTag: ?number = this._animatedView
     invariant(
       nativeViewTag != null,
       'Unable to locate attached view in the native tree',
@@ -134,9 +131,7 @@ class AnimatedProps extends AnimatedNode {
 
   __disconnectAnimatedView(): void {
     invariant(this.__isNative, 'Expected node to be marked as "native"');
-    const nativeViewTag: ?number = findNodeHandle(
-      this._animatedView,
-    );
+    const nativeViewTag: ?number = this._animatedView
     invariant(
       nativeViewTag != null,
       'Unable to locate attached view in the native tree',

--- a/packages/react-native-web/src/vendor/react-native/VirtualizedList/index.js
+++ b/packages/react-native-web/src/vendor/react-native/VirtualizedList/index.js
@@ -10,7 +10,6 @@
 
 import Batchinator from '../Batchinator';
 import FillRateHelper from '../FillRateHelper';
-import findNodeHandle from '../../../exports/findNodeHandle';
 import RefreshControl from '../../../exports/RefreshControl';
 import ScrollView from '../../../exports/ScrollView';
 import StyleSheet from '../../../exports/StyleSheet';
@@ -573,7 +572,7 @@ class VirtualizedList extends React.PureComponent<Props, State> {
     if (this._scrollRef && this._scrollRef.getScrollableNode) {
       return this._scrollRef.getScrollableNode();
     } else {
-      return findNodeHandle(this._scrollRef);
+      return this._scrollRef;
     }
   }
 


### PR DESCRIPTION
Looking to resolve the issues pointed out by https://github.com/necolas/react-native-web/issues/1529

The breaking changes come from the deprecation / removal of findNodeHandle, which doesn't appear to be a strictly necessary change to support React 18.  Let me know if I should revert those changes.

- Bump React dependency to 18.

- Remove uses of `findNodeHandle`.  Remove direct uses of `findDOMNode`.  Marked `findNodeHandle` as deprecated for uses outside of this library
  - TouchableMixin has a new required function on the user - `getTouchableNode` - which returns the dom node of the touchable element.
  -  ScrollResponderMixin no longer has the imperative `findNodeHandle` fallback, the dom node must be provided by `getScrollableNode`
- Support for concurrent mode in `AppRegistry`
  - This required swapping to a callback ref on `AppContainer `as the callback parameter to the new render/hydrate calls was removed.
- Using react testing library's render and act functions in tests 
  - Using the legacy render functions caused a React deprecation warning on every test
  - Using the new render functions directly caused this warning: https://github.com/testing-library/react-testing-library/issues/1061