### PR TITLE
Fix centerContent on ScrollView

### DIFF
--- a/packages/react-native-web/src/exports/ScrollView/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/react-native-web/src/exports/ScrollView/__tests__/__snapshots__/index-test.js.snap
@@ -1,5 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`components/ScrollView prop "centerContent" with 1`] = `
+<div
+  class="css-view-175oi2r r-WebkitOverflowScrolling-150rngu r-flexDirection-eqz5dr r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-overflowX-11yh6sk r-overflowY-1rnoaur r-transform-1sncvnh"
+  style="background-color: rgb(0, 0, 255);"
+>
+  <div
+    class="css-view-175oi2r r-flexGrow-16y2uox r-justifyContent-1777fci"
+  />
+</div>
+`;
+
+exports[`components/ScrollView prop "centerContent" without 1`] = `
+<div
+  class="css-view-175oi2r r-WebkitOverflowScrolling-150rngu r-flexDirection-eqz5dr r-flexGrow-16y2uox r-flexShrink-1wbh5a2 r-overflowX-11yh6sk r-overflowY-1rnoaur r-transform-1sncvnh"
+  style="background-color: rgb(0, 0, 255);"
+>
+  <div
+    class="css-view-175oi2r"
+  />
+</div>
+`;
+
 exports[`components/ScrollView prop "refreshControl" with 1`] = `
 <div
   id="refresh-control"

--- a/packages/react-native-web/src/exports/ScrollView/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/ScrollView/__tests__/index-test.js
@@ -6,6 +6,23 @@ import { findDOMNode } from 'react-dom';
 import { render } from '@testing-library/react';
 
 describe('components/ScrollView', () => {
+  describe('prop "centerContent"', () => {
+    test('without', () => {
+      const { container } = render(
+        <ScrollView style={{ backgroundColor: 'blue' }} />
+      );
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
+    test('with', () => {
+      const { container } = render(
+        <ScrollView centerContent style={{ backgroundColor: 'blue' }} />
+      );
+
+      expect(container.firstChild).toMatchSnapshot();
+    });
+  });
+
   describe('prop "onScroll"', () => {
     test('is called when element scrolls', () => {
       const onScroll = jest.fn();

--- a/packages/react-native-web/src/exports/ScrollView/index.js
+++ b/packages/react-native-web/src/exports/ScrollView/index.js
@@ -31,7 +31,8 @@ type ScrollViewProps = {
   refreshControl?: any,
   scrollEnabled?: boolean,
   scrollEventThrottle?: number,
-  stickyHeaderIndices?: Array<number>
+  stickyHeaderIndices?: Array<number>,
+  centerContent?: boolean
 };
 
 const emptyObject = {};
@@ -136,6 +137,7 @@ const ScrollView = ((createReactClass({
       forwardedRef,
       keyboardDismissMode,
       onScroll,
+      centerContent,
       /* eslint-enable */
       ...other
     } = this.props;
@@ -189,10 +191,11 @@ const ScrollView = ((createReactClass({
         children={children}
         collapsable={false}
         ref={this._setInnerViewRef}
-        style={StyleSheet.compose(
+        style={[
           horizontal && styles.contentContainerHorizontal,
+          centerContent && styles.contentContainerCenterContent,
           contentContainerStyle
-        )}
+        ]}
       />
     );
 
@@ -328,6 +331,10 @@ const styles = StyleSheet.create({
   },
   contentContainerHorizontal: {
     flexDirection: 'row'
+  },
+  contentContainerCenterContent: {
+    justifyContent: 'center',
+    flexGrow: 1
   },
   stickyHeader: {
     position: 'sticky',


### PR DESCRIPTION
Closes #2331.

I tried to naïvely add a unit test, but I don't have experience writing them, so I'm clearly missing something.

I attempted this:

```js
  describe('prop "centerContent"', () => {
    test('without', () => {
      const { container } = render(
        <ScrollView style={{ backgroundColor: 'blue' }} />
      );
      expect(container.firstChild).toMatchSnapshot();
    });

    test('with', () => {
      const { container } = render(
        <ScrollView centerContent style={{ backgroundColor: 'blue' }} />
      );

      expect(container.firstChild).toMatchSnapshot();
      expect(container.firstChild).toHaveStyle('justify-content', 'center');
      expect(container.firstChild).toHaveStyle('flex-grow', '1');
    });
  });
```

However, it seems that `toHaveStyle` doesn't exist. I came across that API from searching online for `jest-dom` + `@testing-library/react`, but I wasn't really sure where to go from there.

I've tested it in my app and it's working well for me. Happy to add/update a unit test if you have any guidance for updating my broken test.