### PR TITLE
fix: replace fbjs performanceNow

### DIFF
--- a/packages/react-native-web/src/vendor/react-native/JSEventLoopWatchdog/index.js
+++ b/packages/react-native-web/src/vendor/react-native/JSEventLoopWatchdog/index.js
@@ -38,7 +38,7 @@ const JSEventLoopWatchdog = {
     totalStallTime = 0;
     stallCount = 0;
     longestStall = 0;
-    lastInterval = global.performance.now();
+    lastInterval = window.performance.now();
   },
   addHandler: function(handler: Handler) {
     handlers.push(handler);
@@ -49,9 +49,9 @@ const JSEventLoopWatchdog = {
       return;
     }
     installed = true;
-    lastInterval = global.performance.now();
+    lastInterval = window.performance.now();
     function iteration() {
-      const now = global.performance.now();
+      const now = window.performance.now();
       const busyTime = now - lastInterval;
       if (busyTime >= thresholdMS) {
         const stallTime = busyTime - thresholdMS;

--- a/packages/react-native-web/src/vendor/react-native/JSEventLoopWatchdog/index.js
+++ b/packages/react-native-web/src/vendor/react-native/JSEventLoopWatchdog/index.js
@@ -11,7 +11,6 @@
 'use strict';
 
 import infoLog from '../infoLog';
-import performanceNow from 'fbjs/lib/performanceNow';
 
 type Handler = {
   onIterate?: () => void,
@@ -39,7 +38,7 @@ const JSEventLoopWatchdog = {
     totalStallTime = 0;
     stallCount = 0;
     longestStall = 0;
-    lastInterval = performanceNow();
+    lastInterval = global.performance.now();
   },
   addHandler: function(handler: Handler) {
     handlers.push(handler);
@@ -50,9 +49,9 @@ const JSEventLoopWatchdog = {
       return;
     }
     installed = true;
-    lastInterval = performanceNow();
+    lastInterval = global.performance.now();
     function iteration() {
-      const now = performanceNow();
+      const now = global.performance.now();
       const busyTime = now - lastInterval;
       if (busyTime >= thresholdMS) {
         const stallTime = busyTime - thresholdMS;


### PR DESCRIPTION
Addresses part of #2333.  Replaces fbjs's `performanceNow` with `global.performance.now`