### PR TITLE
[fix] Add CodeSandBox devDependencies and Renew examples app url

### DIFF
--- a/packages/react-native-web-examples/package.json
+++ b/packages/react-native-web-examples/package.json
@@ -14,5 +14,9 @@
     "react-dom": "^17.0.2",
     "react-native-web": "0.18.6"
   },
+  "devDependencies": {
+    "@babel/core": "^7.18.6",
+    "@babel/preset-flow": "^7.18.6"
+  },
   "license": "MIT"
 }

--- a/packages/react-native-web/README.md
+++ b/packages/react-native-web/README.md
@@ -10,7 +10,7 @@ The [documentation site](https://necolas.github.io/react-native-web/) ([source](
 
 ## Example
 
-The [examples app](https://pk4zn6v4o0.sse.codesandbox.io/) ([source](https://github.com/necolas/react-native-web/blob/master/packages/react-native-web-examples)) demonstrates many available features. Fork the [codesandbox](https://codesandbox.io/s/github/necolas/react-native-web/tree/master/packages/react-native-web-examples) to make changes and see the results.
+The [examples app](https://p9t5cp.sse.codesandbox.io/) ([source](https://github.com/necolas/react-native-web/blob/master/packages/react-native-web-examples)) demonstrates many available features. Fork the [codesandbox](https://codesandbox.io/s/github/necolas/react-native-web/tree/master/packages/react-native-web-examples) to make changes and see the results.
 
 You'll notice that there is no reference to `react-dom` in components. The `App` component that is shown below is defined using the APIs and Components of React Native, but it can also be rendered on the web using React Native for Web.
 


### PR DESCRIPTION
After remove babel devDependencies in https://github.com/necolas/react-native-web/commit/341a9fc5c426579335aac2841c852a09a220d8b1#diff-7444cdf6d9a0c34324768bbc497597fcf61cd8c25b9c133decd022610ae4b18d , codesandbox is broken. So I add it back.
<img width="619" alt="image" src="https://user-images.githubusercontent.com/14990734/178093311-0a6469c5-bb79-4ed4-95b2-87c0e923f2c5.png">


And renew the examples app url after monorepo structure changed.