### PR TITLE
Update react peer dependency in react-native-web

### DIFF
--- a/packages/react-native-web/package.json
+++ b/packages/react-native-web/package.json
@@ -31,8 +31,8 @@
     "styleq": "^0.1.2"
   },
   "peerDependencies": {
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react": "^17.0.2 || ^18.0.0",
+    "react-dom": "^17.0.2 || ^18.0.0"
   },
   "author": "Nicolas Gallagher",
   "license": "MIT",


### PR DESCRIPTION
This helps react-native-web play nicely with npm 7+ and react-native@0.69 / react@18. We are working on releasing Expo SDK 46 which uses react-native@0.69.1 and react@18.0.0, and without this change users will have to use `--legacy-peer-deps` to initialize their projects: `EXPO_BETA=1 npx create-expo-app -- --legacy-peer-deps`