### PR TITLE
fix: submit event on text input

### DIFF
--- a/packages/react-native-web/src/exports/TextInput/index.js
+++ b/packages/react-native-web/src/exports/TextInput/index.js
@@ -296,7 +296,7 @@ const TextInput: React.AbstractComponent<
         onSubmitEditing(e);
       }
       if (shouldBlurOnSubmit && hostNode != null) {
-        hostNode.blur();
+        setTimeout(() => hostNode.blur(), 0);
       }
     }
   }


### PR DESCRIPTION
### Context
I was trying to create a form element with `<View accessibilityRole="form">`. I know we are following the react native way to handle such cases but this will be useful in some cases at least the user will have an option. As it does not support `onSubmit` prop we can attach the same with `ref`.

### Issue
When enter is pressed on `input` element submit event is not dispatched to form element. As the `onKeyDown` is executed first and when `shouldBlurOnSubmit` is `true` it immediately calls ` hostNode.blur()` which cancels the submit event dispatched to the form element.

### Related Issue
https://github.com/necolas/react-native-web/issues/1034

### Workaround

If we pass `blurOnSubmit={false}` to `TextInput` it works as expected and the submit event is dispatched to form element. 

### Fix
This PR tries to fix this issue by not calling `blur` synchronously and giving it time to dispatch the submit event.



