### PR TITLE
[fix] export useLocaleContext as default export

### DIFF
--- a/packages/babel-plugin-react-native-web/src/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/babel-plugin-react-native-web/src/__tests__/__snapshots__/index-test.js.snap
@@ -35,6 +35,7 @@ exports[`Rewrite react-native to react-native-web import from "native-native": i
 import ReactNative from 'react-native';
 import { View } from 'react-native';
 import { Invalid, View as MyView } from 'react-native';
+import { useLocaleContext } from 'react-native';
 import * as ReactNativeModules from 'react-native';
 
       ↓ ↓ ↓ ↓ ↓ ↓
@@ -43,6 +44,7 @@ import ReactNative from 'react-native-web/dist/index';
 import View from 'react-native-web/dist/exports/View';
 import { Invalid } from 'react-native-web/dist/index';
 import MyView from 'react-native-web/dist/exports/View';
+import useLocaleContext from 'react-native-web/dist/exports/useLocaleContext';
 import * as ReactNativeModules from 'react-native-web/dist/index';
 
 

--- a/packages/babel-plugin-react-native-web/src/__tests__/index-test.js
+++ b/packages/babel-plugin-react-native-web/src/__tests__/index-test.js
@@ -8,6 +8,7 @@ const tests = [
     code: `import ReactNative from 'react-native';
 import { View } from 'react-native';
 import { Invalid, View as MyView } from 'react-native';
+import { useLocaleContext } from 'react-native';
 import * as ReactNativeModules from 'react-native';`,
     snapshot: true
   },

--- a/packages/react-native-web/src/exports/useLocaleContext/index.js
+++ b/packages/react-native-web/src/exports/useLocaleContext/index.js
@@ -7,4 +7,5 @@
  * @flow strict
  */
 
-export { useLocaleContext } from '../../modules/useLocale';
+import { useLocaleContext } from '../../modules/useLocale';
+export default useLocaleContext;

--- a/packages/react-native-web/src/index.js
+++ b/packages/react-native-web/src/index.js
@@ -77,5 +77,5 @@ export { default as DeviceEventEmitter } from './exports/DeviceEventEmitter';
 
 // hooks
 export { default as useColorScheme } from './exports/useColorScheme';
-export { useLocaleContext } from './exports/useLocaleContext';
+export { default as useLocaleContext } from './exports/useLocaleContext';
 export { default as useWindowDimensions } from './exports/useWindowDimensions';


### PR DESCRIPTION
**Problem**
babel-plugin-react-native-web rewrites `import { useLocaleContext } from 'react-native'` to `import useLocaleContext from 'react-native-web/dist/exports/useLocaleContext';`

This rewrite seems to assume there is a default export in every `exports/` file. But that's not the case for useLocaleContext, whose [file](https://github.com/necolas/react-native-web/blob/master/packages/react-native-web/src/exports/useLocaleContext/index.js) looks like this:
```
export { useLocaleContext } from '../../modules/useLocale';
```
**Solution**
Set `useLocaleContext` as the default export in [exports/useLocaleContext/index.js](https://github.com/necolas/react-native-web/blob/master/packages/react-native-web/src/exports/useLocaleContext/index.js). 