### PR TITLE
Fix artificial scroll limit expanding on scroll to un-measured area (2nd of 4 problems that cause #1254)

### DIFF
--- a/packages/react-native-web/src/vendor/react-native/VirtualizedList/index.js
+++ b/packages/react-native-web/src/vendor/react-native/VirtualizedList/index.js
@@ -1058,10 +1058,16 @@ class VirtualizedList extends React.PureComponent<Props, State> {
           ? itemCount - 1
           : Math.min(itemCount - 1, this._highestMeasuredFrameIndex);
         const endFrame = this._getFrameMetricsApprox(end);
-        const tailSpacerLength =
+        // On some updates, tailSpacerLength is a negative value, which is an invalid value. 
+        // $tail-spacer’s height will ignore invalid values and  will 
+        // preserve the valid value of the previous state, instead of setting it to zero.
+        let tailSpacerLength =
           endFrame.offset +
           endFrame.length -
           (lastFrame.offset + lastFrame.length);
+        if(tailSpacerLength < 0) {
+            tailSpacerLength = 0
+        }
         cells.push(
           <View key="$tail_spacer" style={{[spacerKey]: tailSpacerLength}} />,
         );


### PR DESCRIPTION
I found 4 problems that cause the [Inverted VirtualizedList to go wild (#1254)](https://github.com/necolas/react-native-web/issues/1254). This PR will explain and fix the **2nd** of **4** problems found.

If we fix the following 4 problems, issue #1254 will be fixed and FlatList’s scroll will be more stable:

1. Inverted VirtualizedList has incorrect baseline measurement for its items’ offset  —> [Problem Explanation and Solution in this PR](https://github.com/necolas/react-native-web/pull/2412). 

---
### **Update:** ### 

PR 2, 3, and 4 will fix ['Flatlist with expensive items breaks scroll' issue](https://github.com/necolas/react-native-web/issues/2432). PR 1 is enough to fix the [Inverted Flatlist issue](https://github.com/necolas/react-native-web/issues/1254) if your Flatlist's items are cheap to mount.

---


2. $lead_spacer expands scroll artificially when Inverted VirtualizedList is mounting new items —> **Problem Explanation and Solution below**.

3. VirtualizedList skip items for offset measuring when the user scrolls very fast while new items are mounted and measured (this happens also for normal lists) —> [Problem Explanation and Solution in this PR](https://github.com/necolas/react-native-web/pull/2414).

4. VirtualizedList gets offsets equal to zero for items that are not the list's first item (this happens also for normal lists) —> [Problem Explanation and Solution in this PR](https://github.com/necolas/react-native-web/pull/2415).

#### Video of Inverted FlatList with all problems fixed: ####

https://user-images.githubusercontent.com/48106652/197422021-7b53767b-41db-4014-b00a-28d7537e706c.mp4

## 2nd Problem ##
### $lead_spacer expands scroll limit artificially when Inverted VirtualizedList is mounting new items. (2nd of 4 problems that cause #1254) ###

In a FlatList with items with different heights, the scroll is limited to the last measured item. That’s because `VirtualizedList` (the inner `FlatList`'s component) must measure the offset of mounted items before it tries to mount new items. In this way, all items in the virtual area are measured and the `_frames` object is complete.

The scroll limit should be only expanded when the user tries to scroll beyond the scroll limit (unmeasured area) and then new items are mounted and their offsets are measured and saved in `_frames`. When recently mounted items are measured, the scroll limit is expanded to the new latest measured item, then the user will be ready to keep scrolling to unmeasured area and repeat the process to keep expanding the scroll limit until the last item is met.

Sometimes users may “overscroll” to unmeasured areas while previously mounted items haven't been measured yet, and `VirtualizedList` starts skipping items for measuring and measures others that shouldn’t be measured yet, leading to a fragmented map of offsets (e.g. we have offset values for …31, 32, 33, then jumps to 37, 38…).

**Why do users “overscroll”?**

Flaltlist constantly mounts and unmounts items. There is a white space mounted on our list called `$tail_spacer`. It helps us to fill with white space the top outside of our virtual area (because it’s an inverted list, for normal lists it fills the bottom), where items were previously mounted and measured but unmounted afterward, so the scroll limit sticks to our latest measured item offset.

![Screen Shot 2022-10-12 at 18 02 58](https://user-images.githubusercontent.com/48106652/195463601-f7dc7396-5df8-49da-aa6f-049c3d2f7921.png)

`$tail_spacer` height depends on how much area we had measured, but it reduces to zero when the latest measured item is mounted and the user pretends to scroll to an unmeasured area looking for more items. When `$tail_spacer`'s height is zero, the scroll is limited and prevents the user from “overscroll”. This gives time to VirtualizedList to properly mount and measure new items to then use their offsets as our new scroll limit.

Sometimes `$tail_spacer` has a height greater than zero when it should be zero, allowing the user to “overscroll”.

**Why sometimes `$tail_spacer` has a height greater than zero when it should be zero?**

On some updates, `$tail_spacer` gets a negative value for its height, which is an invalid value. Invalid values will be ignored and $tail-spacer’s height will set the valid value of the previous state, instead of setting it to zero.

### Solution: ###

The solution is simple. Check `tailSpacerLenght`, if it is below zero then set it to zero:

[react-native-web/src/vendor/react-native/VirtualizedList/index.js](https://github.com/necolas/react-native-web/compare/master...Lucio-s-Forks:react-native-web:fix-tailSpacer-artificial-expanding#diff-a250e90659d45d2a93179da0bf6968e6f561a742ed0f74e097b84fb40a13ed50R1061-R1070)

[![Screen Shot 2022-10-13 at 16 05 46](https://user-images.githubusercontent.com/48106652/195710708-6e177f5b-1a33-41ae-a288-7448da598b17.png)](https://github.com/necolas/react-native-web/compare/master...Lucio-s-Forks:react-native-web:fix-tailSpacer-artificial-expanding#diff-a250e90659d45d2a93179da0bf6968e6f561a742ed0f74e097b84fb40a13ed50R1061-R1070)