### PR TITLE
Fix VirtualizedList skips items for offset measuring when the user scrolls very fast (3rd of 4 problems that cause #1254)

### DIFF
--- a/packages/react-native-web/src/vendor/react-native/VirtualizedList/index.js
+++ b/packages/react-native-web/src/vendor/react-native/VirtualizedList/index.js
@@ -1709,9 +1709,28 @@ class VirtualizedList extends React.PureComponent<Props, State> {
     // starving the renderer from actually laying out the objects and computing _averageCellLength.
     // If this is triggered in an `componentDidUpdate` followed by a hiPri cellToRenderUpdate
     // We shouldn't do another hipri cellToRenderUpdate
+
+    // We should trigger only high pirority updates on area with cells already measured or if measure new cells
+    // is keeping it up with scroll toward unmeasured area. Otherwise scrolling too fast toward unmeasured area  
+    // while new items are being measured may skip cells to be measured and cause scroll issues on scroll back to skipped area.
+    // 'visibleLength / 2' represents a balanced ‘bar check’ to be sure that all items 
+    // are gonna be measured and mounted as fast as possible when user scrolls quickly towards unmeasured area.
+    const isScrollOffsetMeasured = this._totalCellLength > (offset + Math.floor(visibleLength / 2));
+
+    // Allows High Priority updates as usual if the FlatList doesn't have 
+    // enough rendered items to fill both the visible area and the initialNumToRender items
+    const shouldCheckOffset = (
+        first > this.props.initialNumToRender && 
+        this._totalCellLength > visibleLength
+        ) ? (
+            isScrollOffsetMeasured
+        ) : (
+            this._averageCellLength
+        );
+
     if (
       hiPri &&
-      (this._averageCellLength || this.props.getItemLayout) &&
+      (shouldCheckOffset || this.props.getItemLayout) &&
       !this._hiPriInProgress
     ) {
       this._hiPriInProgress = true;


### PR DESCRIPTION
I found 4 problems that cause the [Inverted VirtualizedList to go wild (#1254)](https://github.com/necolas/react-native-web/issues/1254). This PR will explain and fix the **3rd** of **4** problems found.

If we fix the following 4 problems, issue #1254 will be fixed and FlatList’s scroll will be more stable:

1. Inverted VirtualizedList has incorrect baseline measurement for its items’ offset  —> [Problem Explanation and Solution in this PR](https://github.com/necolas/react-native-web/pull/2412). 

---
### **Update:** ### 

PR 2, 3, and 4 will fix ['Flatlist with expensive items breaks scroll' issue](https://github.com/necolas/react-native-web/issues/2432). PR 1 is enough to fix the [Inverted Flatlist issue](https://github.com/necolas/react-native-web/issues/1254) if your Flatlist's items are cheap to mount.

---

2. $lead_spacer expands scroll artificially when Inverted VirtualizedList is mounting new items —>  [Problem Explanation and Solution in this PR](https://github.com/necolas/react-native-web/pull/2413).

3. VirtualizedList skip items for offset measuring when the user scrolls very fast while new items are mounted and measured (this happens also for normal lists) —> **Problem Explanation and Solution below**.

4. VirtualizedList gets offsets equal to zero for items that are not the list's first item (this happens also for normal lists) —> [Problem Explanation and Solution in this PR](https://github.com/necolas/react-native-web/pull/2415).

#### Video of Inverted FlatList with all problems fixed: ####

https://user-images.githubusercontent.com/48106652/197422021-7b53767b-41db-4014-b00a-28d7537e706c.mp4

## 3rd Problem ##
### VirtualizedList skip items for offset measuring when the user scrolls very fast while new items are mounted and measured (this happens also for normal lists, 3rd of 4 problems that cause #1254) ###
There are two important variables (react states of VirtualizedList) that determine the virtual area: `first` and `last`. These variables represent a range of values from the `data` array (which is raw information of items provided to FlatList as `data` prop) that we use to render items on the virtual area.

On every scroll, `first` and `last` get updated according to two priority updates: **Low Priority** and **High Priority**. 

**Low Priority** updates help us to wait for new items to be mounted and measured. These updates are scheduled in a queue and are useful when the user is scrolling on unmeasured area.

**High Priority** updates help us to mount items as fast as possible. These updates occur when users scroll fast: if a High Priority update is triggered, every Low Priority update on the queue is canceled.

When the user scrolls up to unmeasured area, ideally (on every update) the **prev `last`** should be greater than the **next `first`**. This ensures that every item is measured and saved in `_frames`, like this:

![Screen Shot 2022-10-12 at 18 06 56](https://user-images.githubusercontent.com/48106652/195463964-b19c76d7-5928-496c-8842-97a531333c1d.png)

But If we scroll very fast towards unmeasured area and the list is still rendering new items, a race condition happens between measuring new items in `onLayout` and the High Priority update. This is because `onLayout` (executed on unmeasured items) takes some time to return the offset value that we need after the item is mounted. If High Priority wins, the **next `first`** will be greater than **prev `last`**, and as a consequence, some items will be skipped for measuring:

![Screen Shot 2022-10-12 at 17 25 01](https://user-images.githubusercontent.com/48106652/195459901-097b1e4c-ba8b-4894-9414-5020e7636094.png)

More than one item can be skipped, which makes the problem worse. The more items are skipped to be measured, the greater the probability to experiment scroll issues (like weird jumps or white space in the visible area).

### Solution: ###

[packages/react-native-web/src/vendor/react-native/VirtualizedList/index.js](https://github.com/necolas/react-native-web/compare/master...Lucio-s-Forks:react-native-web:fix-VirtualizedList-skips-items-offset-measure#diff-a250e90659d45d2a93179da0bf6968e6f561a742ed0f74e097b84fb40a13ed50R1712-R1733)
[![image13](https://user-images.githubusercontent.com/48106652/195427383-38c5e0f4-e558-449c-a8eb-3544792323ce.png)](https://github.com/necolas/react-native-web/compare/master...Lucio-s-Forks:react-native-web:fix-VirtualizedList-skips-items-offset-measure#diff-a250e90659d45d2a93179da0bf6968e6f561a742ed0f74e097b84fb40a13ed50R1712-R1733)

1.-**Description of the first line of code**: 

![image1](https://user-images.githubusercontent.com/48106652/195427522-52bd3714-11c1-44ff-aa5b-b1dce55fbdba.png)

We use a variable called `totalCellLength`, it represents the sum of heights of all items measured.
If `totalCellLength` is greater than **scroll offset + visibleLength / 2**  (half of our Visible Area) it means the measure of new items is keeping up with the scroll toward unmeasured area or that we are in an area where the cells had been already measured so we allow High Priority updates as usual:

![Screen Shot 2022-10-12 at 18 13 08](https://user-images.githubusercontent.com/48106652/195464616-04bb5232-8a1a-48ed-a1a7-739b961b6701.png)

If `totalCellLength` is not greater than scroll **offset + visibleLength / 2** then `VirtulizedList` prevents High Priority updates, allowing Low Priority updates on queue to complete so measure of items can catch up with scroll and prevents subsequent updates where **next `first`** is greater than **prev `last`**:

![Screen Shot 2022-10-12 at 18 14 41](https://user-images.githubusercontent.com/48106652/195464794-a54d67de-1b15-4fa1-84c4-23b49b6fc3f4.png)

Why **visibleLength / 2**?

It represents a balanced ‘bar check’ to be sure that all items are gonna be measured and mounted as fast as possible (when user scrolls quickly towards unmeasured area). I tested with other two approaches:
- totalCellLength > offset + visibleLength
- totalCellLength > offset

With **offset + visibleLength** (top of Visible Area) we set the ‘bar check’ too high: the check will be false as soon as a new item is mounted. This denies any margin to make High Priority Updates when users keep scrolling up to unmeasured area. 

With **totalCellLength > offset** (bottom of Visible Area), the check will be true only if one new item is measured in our visible area. This will trigger more High Priority updates than it should, Low Priority updates will be canceled more often, and we lose the certainty that no items are gonna skip measure.

I tested previous scenarios and I conclude scroll **offset + visibleLength / 2** is the fastest way to scroll safely toward unmeasured area.

2.-**Description of the second line of code**:

![image11](https://user-images.githubusercontent.com/48106652/195428440-f3af2013-5ab8-4b63-8821-f2f3c3863693.png)

Prevents the checking of the first line of code (allows High Priority updates as usual) if the FlatList doesn't have enough rendered items to fill both the Visible Area and the `initialNumToRender` items (the number of items at the beginning of FlatList that never unmount). This preserves a fast list initialization.