### PR TITLE
Prevent VirtualizedList to save offsets equal to zero if item is not the first item of list (4th of 4 problems that cause #1254)

### DIFF
--- a/packages/react-native-web/src/vendor/react-native/VirtualizedList/index.js
+++ b/packages/react-native-web/src/vendor/react-native/VirtualizedList/index.js
@@ -1323,6 +1323,14 @@ class VirtualizedList extends React.PureComponent<Props, State> {
       inLayout: true,
     };
     const curr = this._frames[cellKey];
+
+    // Measures on discarded Low Priority updates will return zero for dimensions    
+    // no cell should have an offset of zero on frames, except for first cell
+    if (next.offset === 0 && index !== 0) {
+      this._scheduleCellsToRenderUpdate();
+      return;
+    }
+
     if (
       !curr ||
       next.offset !== curr.offset ||


### PR DESCRIPTION
I found 4 problems that cause the [Inverted VirtualizedList to go wild (#1254)](https://github.com/necolas/react-native-web/issues/1254). This PR will explain and fix the **4th** of **4** problems found.

If we fix the following 4 problems, issue #1254 will be fixed and FlatList’s scroll will be more stable:

1. Inverted VirtualizedList has incorrect baseline measurement for its items’ offset  —> [Problem Explanation and Solution in this PR](https://github.com/necolas/react-native-web/pull/2412). 

---
### **Update:** ### 

PR 2, 3, and 4 will fix ['Flatlist with expensive items breaks scroll' issue](https://github.com/necolas/react-native-web/issues/2432). PR 1 is enough to fix the [Inverted Flatlist issue](https://github.com/necolas/react-native-web/issues/1254) if your Flatlist's items are cheap to mount.

---


2. $lead_spacer expands scroll artificially when Inverted VirtualizedList is mounting new items —>  [Problem Explanation and Solution in this PR](https://github.com/necolas/react-native-web/pull/2413).

3. VirtualizedList skip items for offset measuring when the user scrolls very fast while new items are mounted and measured (this happens also for normal lists) —> [Problem Explanation and Solution in this PR](https://github.com/necolas/react-native-web/pull/2414).

4. VirtualizedList gets offsets equal to zero for items that are not the list's first item (this happens also for normal lists) —> **Problem Explanation and Solution below**. 

#### Video of Inverted FlatList with all problems fixed: ####

https://user-images.githubusercontent.com/48106652/197422021-7b53767b-41db-4014-b00a-28d7537e706c.mp4

## 4th Problem ##
### VirtualizedList gets offsets equal to zero for items that are not the list's first item (this happens also for normal lists, 4th of 4 problems that cause #1254) ###
As explained in the 3rd PR, a High Priority update cancels every Low Priority update. A canceled Low Priority update will make `onLayout` returns offset and height equal to zero for the items this update pretended to mount. These zero values will be saved in `_frames`, associated with the canceled item, even if that item was properly measured on previous updates.

`_frames` object with offsets equal to zero will cause a miss calculation to get items for the virtual area. Because it does not make sense that items in higher positions than the bottom of the list have an offset equal to zero.

### Solution: ###

Skip the action to save values on our `_frames` and trigger another update if two conditions happen: 1) `onLayout` returns zero for offset and 2) the item measured is not the first item of the FlatList.

[react-native-web/src/vendor/react-native/VirtualizedList/index.js](https://github.com/necolas/react-native-web/compare/master...Lucio-s-Forks:react-native-web:prevent-VirtualizedList-saves-offsets-equal-zero#diff-a250e90659d45d2a93179da0bf6968e6f561a742ed0f74e097b84fb40a13ed50R1326-R1333) → Inside: `_onCellLayout` function.
[![image6](https://user-images.githubusercontent.com/48106652/195429004-111d4b36-37f5-4ed8-8fa8-c7acbef46af7.png)](https://github.com/necolas/react-native-web/compare/master...Lucio-s-Forks:react-native-web:prevent-VirtualizedList-saves-offsets-equal-zero#diff-a250e90659d45d2a93179da0bf6968e6f561a742ed0f74e097b84fb40a13ed50R1326-R1333)