### PR TITLE
[change] Remove backgroundClip prefix workaround

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "gen-flow-files": "^0.4.11",
         "glob": "^8.0.3",
         "husky": "^8.0.0",
-        "inline-style-prefixer": "^6.0.0",
+        "inline-style-prefixer": "^6.0.2",
         "jest": "^28.1.2",
         "jest-environment-jsdom": "^28.1.2",
         "lint-staged": "^13.0.3",
@@ -5248,12 +5248,11 @@
       }
     },
     "node_modules/css-in-js-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz",
-      "license": "MIT",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-3.1.0.tgz",
+      "integrity": "sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==",
       "dependencies": {
-        "hyphenate-style-name": "^1.0.2",
-        "isobject": "^3.0.1"
+        "hyphenate-style-name": "^1.0.3"
       }
     },
     "node_modules/css-loader": {
@@ -6863,6 +6862,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-loops": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fast-loops/-/fast-loops-1.1.3.tgz",
+      "integrity": "sha512-8EZzEP0eKkEEVX+drtd9mtuQ+/QrlfW/5MlwcwK5Nds6EkZ/tRzEexkzUY2mIssnAyVLT+TKHuRXmFNNXYUd6g=="
+    },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
@@ -7832,8 +7836,7 @@
     "node_modules/hyphenate-style-name": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
-      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ==",
-      "license": "BSD-3-Clause"
+      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -7975,11 +7978,12 @@
       "license": "ISC"
     },
     "node_modules/inline-style-prefixer": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-6.0.1.tgz",
-      "integrity": "sha512-AsqazZ8KcRzJ9YPN1wMH2aNM7lkWQ8tSPrW5uDk1ziYwiAPWSZnUsC7lfZq+BDqLqz0B4Pho5wscWcJzVvRzDQ==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-6.0.2.tgz",
+      "integrity": "sha512-c5eWrqAuiV9eIz8pymR8+mjPsKewylrLmU3oZkqBSEoVPlQf6Fr+Jg/oGQbbCZYFNulFzDoxnlm4wyLiomOO2w==",
       "dependencies": {
-        "css-in-js-utils": "^2.0.0"
+        "css-in-js-utils": "^3.1.0",
+        "fast-loops": "^1.1.3"
       }
     },
     "node_modules/internal-slot": {
@@ -8362,6 +8366,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -14952,7 +14957,7 @@
         "@babel/runtime": "^7.18.6",
         "create-react-class": "^15.7.0",
         "fbjs": "^3.0.4",
-        "inline-style-prefixer": "^6.0.1",
+        "inline-style-prefixer": "^6.0.2",
         "normalize-css-color": "^1.0.2",
         "postcss-value-parser": "^4.2.0",
         "styleq": "^0.1.2"
@@ -18846,11 +18851,11 @@
       }
     },
     "css-in-js-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-3.1.0.tgz",
+      "integrity": "sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==",
       "requires": {
-        "hyphenate-style-name": "^1.0.2",
-        "isobject": "^3.0.1"
+        "hyphenate-style-name": "^1.0.3"
       }
     },
     "css-loader": {
@@ -19982,6 +19987,11 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-loops": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fast-loops/-/fast-loops-1.1.3.tgz",
+      "integrity": "sha512-8EZzEP0eKkEEVX+drtd9mtuQ+/QrlfW/5MlwcwK5Nds6EkZ/tRzEexkzUY2mIssnAyVLT+TKHuRXmFNNXYUd6g=="
+    },
     "fastest-levenshtein": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
@@ -20767,11 +20777,12 @@
       "dev": true
     },
     "inline-style-prefixer": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-6.0.1.tgz",
-      "integrity": "sha512-AsqazZ8KcRzJ9YPN1wMH2aNM7lkWQ8tSPrW5uDk1ziYwiAPWSZnUsC7lfZq+BDqLqz0B4Pho5wscWcJzVvRzDQ==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-6.0.2.tgz",
+      "integrity": "sha512-c5eWrqAuiV9eIz8pymR8+mjPsKewylrLmU3oZkqBSEoVPlQf6Fr+Jg/oGQbbCZYFNulFzDoxnlm4wyLiomOO2w==",
       "requires": {
-        "css-in-js-utils": "^2.0.0"
+        "css-in-js-utils": "^3.1.0",
+        "fast-loops": "^1.1.3"
       }
     },
     "internal-slot": {
@@ -21028,7 +21039,8 @@
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true
     },
     "istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -23840,7 +23852,7 @@
         "@babel/runtime": "^7.18.6",
         "create-react-class": "^15.7.0",
         "fbjs": "^3.0.4",
-        "inline-style-prefixer": "^6.0.1",
+        "inline-style-prefixer": "^6.0.2",
         "normalize-css-color": "^1.0.2",
         "postcss-value-parser": "^4.2.0",
         "styleq": "^0.1.2"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "gen-flow-files": "^0.4.11",
     "glob": "^8.0.3",
     "husky": "^8.0.0",
-    "inline-style-prefixer": "^6.0.0",
+    "inline-style-prefixer": "^6.0.2",
     "jest": "^28.1.2",
     "jest-environment-jsdom": "^28.1.2",
     "lint-staged": "^13.0.3",

--- a/packages/react-native-web/package.json
+++ b/packages/react-native-web/package.json
@@ -25,7 +25,7 @@
     "@babel/runtime": "^7.18.6",
     "create-react-class": "^15.7.0",
     "fbjs": "^3.0.4",
-    "inline-style-prefixer": "^6.0.1",
+    "inline-style-prefixer": "^6.0.2",
     "normalize-css-color": "^1.0.2",
     "postcss-value-parser": "^4.2.0",
     "styleq": "^0.1.2"

--- a/packages/react-native-web/src/exports/StyleSheet/compiler/createReactDOMStyle.js
+++ b/packages/react-native-web/src/exports/StyleSheet/compiler/createReactDOMStyle.js
@@ -128,13 +128,6 @@ const createReactDOMStyle = (style: Style, isInline?: boolean): Style => {
 
     if (prop === 'aspectRatio') {
       resolvedStyle[prop] = value.toString();
-    } else if (prop === 'backgroundClip') {
-      // TODO: remove once this issue is fixed
-      // https://github.com/rofrischmann/inline-style-prefixer/issues/159
-      if (value === 'text') {
-        resolvedStyle.backgroundClip = value;
-        resolvedStyle.WebkitBackgroundClip = value;
-      }
     } else if (prop === 'flex') {
       if (value === -1) {
         resolvedStyle.flexGrow = 0;

--- a/packages/react-native-web/src/modules/prefixStyles/static.js
+++ b/packages/react-native-web/src/modules/prefixStyles/static.js
@@ -1,4 +1,3 @@
-import backgroundClip from 'inline-style-prefixer/lib/plugins/backgroundClip';
 import crossFade from 'inline-style-prefixer/lib/plugins/crossFade';
 import cursor from 'inline-style-prefixer/lib/plugins/cursor';
 import filter from 'inline-style-prefixer/lib/plugins/filter';
@@ -15,7 +14,6 @@ const wmms = ['Webkit', 'Moz', 'ms'];
 
 export default {
   plugins: [
-    backgroundClip,
     crossFade,
     cursor,
     filter,


### PR DESCRIPTION
The PR continues re-implement #2254 and now targets `0.19-dev`.

https://github.com/robinweser/inline-style-prefixer/pull/221 has been merged and released in 6.0.2, the PR bumps the version of `inline-style-prefixer` and removes the workaround for `background-clip` when prefixing.