### PR TITLE
Fix: iOS not firing `resize` event

### DIFF
--- a/packages/react-native-web/src/exports/Dimensions/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/Dimensions/__tests__/index-test.js
@@ -55,3 +55,60 @@ describe('apis/Dimensions', () => {
     expect(handler).toHaveBeenCalledTimes(0);
   });
 });
+
+describe('apis/Dimensions(VisualViewport)', () => {
+  window.visualViewport = {
+    width: window.innerWidth,
+    height: window.innerHeight,
+    scale: 1,
+    dispatchEvent: (event) => window.dispatchEvent(event)
+  };
+
+  test('get(VisualViewport)', () => {
+    const handler = jest.fn();
+    Dimensions.addEventListener('change', handler);
+    expect(Dimensions.get('screen')).toMatchInlineSnapshot(`
+      {
+        "fontScale": 1,
+        "height": 0,
+        "scale": 1,
+        "width": 0,
+      }
+    `);
+    expect(Dimensions.get('window')).toMatchInlineSnapshot(`
+      {
+        "fontScale": 1,
+        "height": 768,
+        "scale": 1,
+        "width": 1024,
+      }
+    `);
+    expect(handler).toHaveBeenCalledTimes(0);
+  });
+
+  test('set(VisualViewport)', () => {
+    expect(() => Dimensions.set({})).toThrow();
+  });
+
+  test('addEventListener(VisualViewport)', () => {
+    const handler = jest.fn();
+    const subscription = Dimensions.addEventListener('change', handler);
+    console.log('window.visualViewport', window.visualViewport);
+    window.visualViewport.dispatchEvent(new Event('resize'));
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenLastCalledWith({
+      window: Dimensions.get('window'),
+      screen: Dimensions.get('screen')
+    });
+    subscription.remove();
+    window.visualViewport.dispatchEvent(new Event('resize'));
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  test('removeEventListener(VisualViewport)', () => {
+    const handler = jest.fn();
+    Dimensions.removeEventListener('change', handler);
+    window.visualViewport.dispatchEvent(new Event('resize'));
+    expect(handler).toHaveBeenCalledTimes(0);
+  });
+});

--- a/packages/react-native-web/src/exports/Dimensions/index.js
+++ b/packages/react-native-web/src/exports/Dimensions/index.js
@@ -52,13 +52,13 @@ function update() {
   }
 
   const win = window;
-  const docEl = win.document.documentElement;
+  const visualViewport = win.visualViewport;
 
   dimensions.window = {
     fontScale: 1,
-    height: docEl.clientHeight,
+    height: Math.round(visualViewport.height),
     scale: win.devicePixelRatio || 1,
-    width: docEl.clientWidth
+    width: Math.round(visualViewport.width)
   };
 
   dimensions.screen = {
@@ -128,5 +128,5 @@ export default class Dimensions {
 }
 
 if (canUseDOM) {
-  window.addEventListener('resize', handleResize, false);
+  window.visualViewport.addEventListener('resize', handleResize, false);
 }

--- a/packages/react-native-web/src/exports/Dimensions/index.js
+++ b/packages/react-native-web/src/exports/Dimensions/index.js
@@ -52,13 +52,24 @@ function update() {
   }
 
   const win = window;
-  const visualViewport = win.visualViewport;
+  let height;
+  let width;
+
+  if (win.visualViewport) {
+    const visualViewport = win.visualViewport;
+    height = Math.round(visualViewport.height);
+    width = Math.round(visualViewport.width);
+  } else {
+    const docEl = win.document.documentElement;
+    height = docEl.clientHeight;
+    width = docEl.clientWidth;
+  }
 
   dimensions.window = {
     fontScale: 1,
-    height: Math.round(visualViewport.height),
+    height,
     scale: win.devicePixelRatio || 1,
-    width: Math.round(visualViewport.width)
+    width
   };
 
   dimensions.screen = {
@@ -128,5 +139,9 @@ export default class Dimensions {
 }
 
 if (canUseDOM) {
-  window.visualViewport.addEventListener('resize', handleResize, false);
+  if (window.visualViewport) {
+    window.visualViewport.addEventListener('resize', handleResize, false);
+  } else {
+    window.addEventListener('resize', handleResize, false);
+  }
 }


### PR DESCRIPTION
Fixes #2430 

This is related to iOS devices not firing `resize` event when keyboard opens/closes.

The workaround is listening to `window.visualViewport` `resize` event and updating the height and width by the values returned by `window.visualViewport`