### PR TITLE
Add cursor position to TextInput onChange event

### DIFF
--- a/packages/react-native-web/src/exports/TextInput/index.js
+++ b/packages/react-native-web/src/exports/TextInput/index.js
@@ -232,6 +232,7 @@ const TextInput: React.AbstractComponent<
     const hostNode = e.target;
     const text = hostNode.value;
     e.nativeEvent.text = text;
+    e.nativeEvent.cursorPosition = hostNode.selectionStart;
     handleContentSizeChange(hostNode);
     if (onChange) {
       onChange(e);


### PR DESCRIPTION
I raised a [PR](https://github.com/facebook/react-native/pull/35616) to react-native that makes it possible to get the cursor position inside the [onChange](https://reactnative.dev/docs/textinput#onchange) callback, and since `react-native-web` and `react-native` have the same thing it will be good to implement it to `react-native-web` as well. I hope the react native team merge it and I will notify you once it gets merged otherwise I will close this PR.


https://user-images.githubusercontent.com/108357004/207131702-be96a329-af3f-4c5d-8595-d48429c649bd.mov


