### PR TITLE
[docs] correct Expo usage steps, update links, fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is the development monorepo for "React Native for Web" and related projects
   * Contains workflows used by GitHub Actions.
   * Contains issue templates.
 * `configs`
-  * Contains configration files used by the monorepo tooling (compiling, linting, testing, etc.)
+  * Contains configuration files used by the monorepo tooling (compiling, linting, testing, etc.)
 * `packages`
   * [react-native-web](https://github.com/necolas/react-native-web/blob/master/packages/react-native-web)
   * Contains the individual packages managed in the monorepo.

--- a/packages/react-native-web-docs/src/includes/layouts/home.html
+++ b/packages/react-native-web-docs/src/includes/layouts/home.html
@@ -51,7 +51,7 @@ section: page
       ></iframe>
 
       <div class="callout">
-        <p><strong>Did you know?</strong> React Native for Web is used in production web apps by <a href="https://twitter.com">Twitter</a>, <a href="https://twitter.com/naqvitalha/status/969577892991549440">Flipkart</a>, <a href="https://www.youtube.com/watch?v=RV9rxrNIxnY">Uber</a>, <a href="https://matchcenter.mlssoccer.com">Major League Soccer</a>, and many others. It also powers web support in multi-platform React projects such as <a href="https://expo.io">Expo</a>, <a href="https://reactnativeelements.com/">React Native Elements</a>, <a href="https://callstack.github.io/react-native-paper/using-on-the-web.html">React Native Paper</a>, and <a href="https://docs.nativebase.io/getting-started">React Native Base</a>.
+        <p><strong>Did you know?</strong> React Native for Web is used in production web apps by <a href="https://twitter.com">Twitter</a>, <a href="https://twitter.com/naqvitalha/status/969577892991549440">Flipkart</a>, <a href="https://www.youtube.com/watch?v=RV9rxrNIxnY">Uber</a>, <a href="https://matchcenter.mlssoccer.com">Major League Soccer</a>, and many others. It also powers web support in multi-platform React projects such as <a href="https://expo.dev">Expo</a>, <a href="https://reactnativeelements.com/">React Native Elements</a>, <a href="https://callstack.github.io/react-native-paper/using-on-the-web.html">React Native Paper</a>, and <a href="https://docs.nativebase.io/getting-started">React Native Base</a>.
       </div>
 
       <div style="height:2rem"><!-- spacer --></div>

--- a/packages/react-native-web-docs/src/pages/docs/getting-started/installation.md
+++ b/packages/react-native-web-docs/src/pages/docs/getting-started/installation.md
@@ -30,13 +30,13 @@ npm install --save-dev babel-plugin-react-native-web
 
 ### Expo
 
-[Expo](https://expo.io) is a framework and a platform for universal React applications. [Expo for Web](https://docs.expo.io/workflow/web/) uses React Native for Web, provides dozens of additional cross-platform APIs, includes web build optimizations, and is compatibile with the broader React Native ecosystem.
+[Expo](https://expo.dev) is a framework and a platform for universal React applications. [Expo for Web](https://docs.expo.dev/workflow/web/) uses React Native for Web, provides dozens of additional cross-platform APIs, includes web build optimizations, and is compatible with the broader React Native ecosystem.
 
 ```shell
-npx expo-cli init my-app
+npx create-expo-app my-app
 cd my-app
-npm install react-dom react-native-web
-npx expo-cli start
+npx expo install react-dom react-native-web @expo/webpack-config
+npx expo start --web
 ```
 
 ### Create React App

--- a/packages/react-native-web-docs/src/pages/docs/getting-started/multi-platform.md
+++ b/packages/react-native-web-docs/src/pages/docs/getting-started/multi-platform.md
@@ -14,7 +14,7 @@ How to integrate React Native for Web into an existing React Native codebase.
 
 Please read the [setup]({{ '/docs/setup' | url }}) guide first. If you have an existing React Native application, there are more areas that require attention and customization before most web bundlers can consume the non-standard JavaScript in packages produced by the React Native ecosystem. Additionally, 3rd party React Native packages with web support are listed in the [React Native Directory](https://reactnative.directory/?web=true).
 
-If you are interested in making a multi-platform app it is *strongly recommended* that you use [Expo](https://expo.io) (or learn from the source code for the Web integration). Expo includes [web support](https://docs.expo.io/versions/v35.0.0/guides/running-in-the-browser/) and takes care of all the configuration work required.
+If you are interested in making a multi-platform app it is *strongly recommended* that you use [Expo](https://expo.dev) (or learn from the source code for the Web integration). Expo includes [web support](https://docs.expo.dev/workflow/web/) and takes care of all the configuration work required.
 
 ---
 


### PR DESCRIPTION
# Why

The main intent was to update the Expo usage example, but in the process I have also spotted that all links are using our old domain.

# How

Update Expo usage commands to reflect the current recommended steps, correct all Expo related links to use new domain, fix few typos in the process.