### PR TITLE
[github] update actions used in workflows to fix warnings

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -16,6 +16,6 @@ body:
   - type: textarea
     attributes:
       label: Describe the feature request
-      description: Please provide a concise description of the request, potential solutions, and addtional context.
+      description: Please provide a concise description of the request, potential solutions, and additional context.
     validations:
       required: true

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -9,7 +9,7 @@ jobs:
   label-actions:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: hramos/label-actions@v1
         with:
           configuration-path: .github/labels-config.yml

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -6,7 +6,7 @@ jobs:
   compressed-size:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: necolas/compressed-size-action@master
       with:
         build-script: "compile"

--- a/.github/workflows/react-integration.yml
+++ b/.github/workflows/react-integration.yml
@@ -9,10 +9,10 @@ jobs:
   react-next:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
       with:
-        node-version: '16.x'
+        node-version: 16
     - run: npm install
     # Update react-native-web to use react@next
     - run: npm install react@next react-dom@next -w react-native-web

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,39 +11,39 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
       with:
-        node-version: '16.x'
+        node-version: 16
     - run: npm install
     - run: npm run format
 
   type-check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
       with:
-        node-version: '16.x'
+        node-version: 16
     - run: npm install
     - run: npm run flow
 
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
       with:
-        node-version: '16.x'
+        node-version: 16
     - run: npm install
     - run: npm run lint
 
   unit-test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
       with:
-        node-version: '16.x'
+        node-version: 16
     - run: npm install
     - run: npm run unit


### PR DESCRIPTION
# Why

Fixes warnings from:
* https://github.com/necolas/react-native-web/actions/runs/3788572079
* https://github.com/necolas/react-native-web/actions/runs/3781121787

# How

Update `checkout` and `node-setup` action to the latest version, which makes those action run on newest version of Node.

Unfortunately, the same problem affects:
* forked `compressed-size-action` - fork sync should be enough, since base action already switched Node version:
  * https://github.com/preactjs/compressed-size-action/blob/master/action.yml#L43
* `hramos/label-actions` - this action now uses the different name, there is a `v2` but it still runs on Node 12, it might be worth to prepare PR and ping Hector, but alternatively you can switch to https://github.com/dessant/label-actions to address the issue