### PR TITLE
Excluded body from getting tabIndex

### DIFF
--- a/packages/react-native-web/src/exports/UIManager/index.js
+++ b/packages/react-native-web/src/exports/UIManager/index.js
@@ -34,6 +34,7 @@ const measureLayout = (node, relativeToNativeNode, callback) => {
 };
 
 const focusableElements = {
+  BODY: true,
   A: true,
   INPUT: true,
   SELECT: true,


### PR DESCRIPTION
The goal of this PR is to exclude `<body>` from having the `tabIndex` attribute added for the following reasons:
1. It messes up with modal accessibility, as if you open a modal with `<body>` having `tabIndex="-1"` you won't be able to select any text on that modal.
2. It's unnecessary, although `body` is not really a focusable element, it's pretty much treated as if it is ([source](https://allyjs.io/data-tables/focusable.html#document-elements))
3. There is no case where adding `tabIndex` to `body` is something that the user would want / expect

___
Alternative solution:
After setting focus to the element, remove the added `tabIndex` attribute. But I think this is only a complementary solution as excluding body still seems required.