### PR TITLE
Fix `scrollResponderScrollTo`

### DIFF
--- a/packages/react-native-web/src/modules/ScrollResponder/index.js
+++ b/packages/react-native-web/src/modules/ScrollResponder/index.js
@@ -384,11 +384,13 @@ const ScrollResponderMixin = {
     const node = this.scrollResponderGetScrollableNode();
     const left = x || 0;
     const top = y || 0;
-    if (typeof node.scroll === 'function') {
-      node.scroll({ top, left, behavior: !animated ? 'auto' : 'smooth' });
-    } else {
-      node.scrollLeft = left;
-      node.scrollTop = top;
+    if (node) {
+      if (typeof node.scroll === 'function') {
+        node.scroll({ top, left, behavior: !animated ? 'auto' : 'smooth' });
+      } else {
+        node.scrollLeft = left;
+        node.scrollTop = top;
+      }
     }
   },
 


### PR DESCRIPTION
I've been getting Sentry errors forever with this method, and finally realized it's from `react-native-web` when the `node` is `null` when calling `scrollResponderScrollTo`. This PR adds a simple null check for `node`.

<img width="372" alt="Screenshot 2023-03-08 at 11 15 14 AM" src="https://user-images.githubusercontent.com/13172299/223768376-1a148489-c94a-41c6-8f80-57c4469a9488.png">