### PR TITLE
Ignore transformation and cancel callback measure for unmounted elements

### DIFF
--- a/packages/react-native-web/src/exports/UIManager/index.js
+++ b/packages/react-native-web/src/exports/UIManager/index.js
@@ -7,28 +7,38 @@
  * @noflow
  */
 
-import getBoundingClientRect from '../../modules/getBoundingClientRect';
 import setValueForStyles from '../../modules/setValueForStyles';
 
 const getRect = (node) => {
-  // Unlike the DOM's getBoundingClientRect, React Native layout measurements
-  // for "height" and "width" ignore scale transforms.
-  // https://developer.mozilla.org/en-US/docs/Web/API/CSS_Object_Model/Determining_the_dimensions_of_elements
-  const { x, y, top, left } = getBoundingClientRect(node);
-  const width = node.offsetWidth;
   const height = node.offsetHeight;
-  return { x, y, width, height, top, left };
+  const width = node.offsetWidth;
+  let left = node.offsetLeft;
+  let top = node.offsetTop;
+  node = node.offsetParent;
+
+  while (node && node.nodeType === 1 /* Node.ELEMENT_NODE */) {
+    left += node.offsetLeft + node.clientLeft - node.scrollLeft;
+    top += node.offsetTop + node.clientTop - node.scrollTop;
+    node = node.offsetParent;
+  }
+
+  top -= window.scrollY;
+  left -= window.scrollX;
+
+  return { width, height, top, left };
 };
 
 const measureLayout = (node, relativeToNativeNode, callback) => {
   const relativeNode = relativeToNativeNode || (node && node.parentNode);
   if (node && relativeNode) {
     setTimeout(() => {
-      const relativeRect = getBoundingClientRect(relativeNode);
-      const { height, left, top, width } = getRect(node);
-      const x = left - relativeRect.left;
-      const y = top - relativeRect.top;
-      callback(x, y, width, height, left, top);
+      if (node.isConnected && relativeNode.isConnected) {
+        const relativeRect = getRect(relativeNode);
+        const { height, left, top, width } = getRect(node);
+        const x = left - relativeRect.left;
+        const y = top - relativeRect.top;
+        callback(x, y, width, height, left, top);
+      }
     }, 0);
   }
 };


### PR DESCRIPTION
Hello again @necolas, this the updated proposal to fix the VirtualizedList in web.

After investigation and feedback I have a new proposal of pull requests to fix the Inverted VirtualizedList in web. Some of the root issues are in react-native-web's end, another issue is fixed updating [VirtualizedList from react-native](https://github.com/facebook/react-native/tree/main/packages/virtualized-lists/Lists):

- **Problem 1**: VirtualizedList's code relies on that `onLayout` measures items without considering transformations **—>** **Problem Explanation and Solution below.**

- **Problem 2**: Exists inaccurate measures in onLayout when the setTimeout is executed and any of the targeted nodes (node or relativeNode) for measure are unmounted. **—>** **Problem Explanation and Solution below.**

- **Problem 3**: The scroll position can be forced to areas where items have not been measured and the list skips measuring items if the user scrolls too fast. **—>** [Problem Explanation and Solution in this PR](https://github.com/necolas/react-native-web/pull/2502).

---

### Problem 1 ###

VirtualizedList's code relies on that `onLayout` measures items without considering transformations 

React-native-web's onLayout, unlike its native counterpart, accounts for element transformations and its ancestors which leads to inaccurate measures for Inverted VirtualizedList with "scaleY / X: -1" transformation.

**Solution:**

Compose onLayout with only Web measurement API that ignores transformation following the W3C and WHATGH standards.

<img width="643" alt="Screenshot 2023-03-22 at 13 52 37" src="https://user-images.githubusercontent.com/48106652/227020872-ef70605a-5781-4840-b61b-42ebefce483b.png">

#### I know the solution is similar to [@davepack's PR](https://github.com/necolas/react-native-web/pull/955/files) so Why should we merge it now? What is different? ####

The @davepack's solution is good, the problem back then was a bug in Firefox. Firefox [wasn't following the standard specification for offsetTop](https://w3c.github.io/csswg-drafts/cssom-view/#dom-htmlelement-offsettop). It wasn't fixed until Firefox >71 (the @davepack PR was tested in Firefox 61).

Now I can confirm the PR's changes works in Firefox >71 and in the rest of the browsers including the mobile versions. I [tested multiple scenarios here](https://test-new-measure-implementation-luciochavezfuentes.vercel.app/) and also tested in the @davepack sandbox.

The solution works the same as getBoundingclientrect but without considering transformations with a margin of error of +/- 1 pixel because the variables like offsetTop and clientTop round the values and return integers only.

#### How should we handle problems like this? ####

[WHATGH](https://html.spec.whatwg.org/multipage/) is a standard specification for browsers created by the browsers' creators (Mozilla, apple, Microsoft). It reached an [agreement with W3C ](https://www.w3.org/2019/04/WHATWG-W3C-MOU.html)and now both standards [reference each other](https://html.spec.whatwg.org/multipage/references.html) and recommend how the browser API should work.

Different results among browsers with the same code is likely that some them are not following the WHATGH and W3C specifications and can be reported as a bug in the browser's end.

### Problem 2 ###

Exists inaccurate measures in onLayout when the [setTimeout](https://github.com/necolas/react-native-web/blob/master/packages/react-native-web/src/exports/UIManager/index.js#L26) is executed and any of the targeted nodes (node or relativeNode) for measure are unmounted.

**Solution**

Check if the layout boxes of nodes are still present inside the setTimeout callback.
<img width="622" alt="Screenshot 2023-03-27 at 11 59 35" src="https://user-images.githubusercontent.com/48106652/228026990-1596cf9c-0bf8-440c-8ef8-7998a761da9d.png">



### Problem 3 **—>** [Problem Explanation and Solution in this PR](https://github.com/necolas/react-native-web/pull/2502).


With all problems resolved and updating VirtualizedList from react-native we have a solid VirtualizedList in web, inverted or non-inverted.

Thank you for reading @necolas, if you have any questions or concerns please let me know how I can help.





