### PR TITLE
Implement TurboModuleRegistry

### DIFF
--- a/packages/react-native-web/src/exports/TurboModuleRegistry/index.js
+++ b/packages/react-native-web/src/exports/TurboModuleRegistry/index.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Nicolas Gallagher.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ *
+ */
+
+const NativeModules = require('../NativeModules');
+
+import invariant from 'invariant';
+
+function requireModule(name) {
+  const legacyModule = NativeModules[name];
+  if (legacyModule != null) {
+    return legacyModule;
+  }
+
+  return null;
+}
+
+function get(name) {
+  return requireModule(name);
+}
+
+function getEnforcing(name) {
+  const module = requireModule(name);
+  invariant(
+    module != null,
+    `TurboModuleRegistry.getEnforcing(...): '${name}' could not be found. ` +
+    'Verify that a module by this name is registered in the native binary.',
+  );
+  return module;
+}
+
+var TurboModuleRegistry = {
+  get,
+  getEnforcing,
+};
+
+export default TurboModuleRegistry;

--- a/packages/react-native-web/src/index.js
+++ b/packages/react-native-web/src/index.js
@@ -5,6 +5,7 @@ export { default as processColor } from './exports/processColor';
 export { default as render } from './exports/render';
 export { default as unmountComponentAtNode } from './exports/unmountComponentAtNode';
 export { default as NativeModules } from './exports/NativeModules';
+export { default as TurrboModuleRegistry } from './exports/TurboModuleRegistry';
 
 // APIs
 export { default as AccessibilityInfo } from './exports/AccessibilityInfo';


### PR DESCRIPTION
This is a super naive implementation. I don't have any native experience.

I based this on the react-native implementation, which falls back to native based on the bridge type.
I remove all the checking code and always fall back to nativemodules.

From what I can tell, we could probably get by just having ```get``` always return null;

This was enough to get `react-native-vector-icons`, which recently got new arch support, to work in storybook.