### PR TITLE
[Dimensions] consistent measurements with window zoom

### DIFF
--- a/packages/react-native-web/src/exports/Dimensions/index.js
+++ b/packages/react-native-web/src/exports/Dimensions/index.js
@@ -62,8 +62,14 @@ function update() {
    */
   if (win.visualViewport) {
     const visualViewport = win.visualViewport;
-    height = Math.round(visualViewport.height);
-    width = Math.round(visualViewport.width);
+    /**
+     * We are multiplying by scale because height and width from visual viewport
+     * also react to pinch zoom, and become smaller when zoomed. But it is not desired
+     * behaviour, since originally documentElement client height and width were used,
+     * and they do not react to pinch zoom.
+     */
+    height = Math.round(visualViewport.height * visualViewport.scale);
+    width = Math.round(visualViewport.width * visualViewport.scale);
   } else {
     const docEl = win.document.documentElement;
     height = docEl.clientHeight;


### PR DESCRIPTION
# Details
We are fixing `window.height` and `window.width` not change when pinch zoomed, since it is expected behavior. This issue was introduced with https://github.com/necolas/react-native-web/pull/2438 where `documentElement` measures where replaced by measures from `visualViewport`
### After 

https://github.com/Expensify/react-native-web/assets/59907218/59cd5c1e-e0e8-4a2f-9cc6-de69405e4d36

### Before

https://github.com/Expensify/react-native-web/assets/59907218/d54c865e-e3bf-4542-afa1-45d69bf59ee5



