### PR TITLE
fix(AnimatedStyle): runtime error when passing undefined transform style

### DIFF
--- a/packages/react-native-web/src/vendor/react-native/Animated/nodes/AnimatedStyle.js
+++ b/packages/react-native-web/src/vendor/react-native/Animated/nodes/AnimatedStyle.js
@@ -24,7 +24,7 @@ function createAnimatedStyle(inputStyle: any): Object {
   const animatedStyles = {}
   for (const key in style) {
     const value = style[key];
-    if (key === 'transform') {
+    if (key === 'transform' && value) {
       animatedStyles[key] = new AnimatedTransform(value);
     }
     else if (value instanceof AnimatedNode) {


### PR DESCRIPTION
Fixes: #2523 
If passing undefined to Animated.View transform style, there will be a runtime error. This issue does not happen on react-native-web 0.18.

