### PR TITLE
(fix) Make children interactive when parent pressable is disabled

### DIFF
--- a/packages/react-native-web/src/exports/Pressable/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/react-native-web/src/exports/Pressable/__tests__/__snapshots__/index-test.js.snap
@@ -153,7 +153,7 @@ exports[`components/Pressable prop "accessibilityRole" value is set 1`] = `
 exports[`components/Pressable prop "disabled" 1`] = `
 <div
   aria-disabled="true"
-  class="css-view-175oi2r r-pointerEvents-633pao"
+  class="css-view-175oi2r r-pointerEvents-12vffkv"
   tabindex="-1"
 />
 `;

--- a/packages/react-native-web/src/exports/Pressable/index.js
+++ b/packages/react-native-web/src/exports/Pressable/index.js
@@ -229,7 +229,7 @@ const styles = StyleSheet.create({
     touchAction: 'manipulation'
   },
   disabled: {
-    pointerEvents: 'none'
+    pointerEvents: 'box-none'
   }
 });
 

--- a/packages/react-native-web/src/exports/TouchableHighlight/index.js
+++ b/packages/react-native-web/src/exports/TouchableHighlight/index.js
@@ -175,7 +175,7 @@ function TouchableHighlight(props: Props, forwardedRef): React.Node {
       {...pressEventHandlers}
       accessibilityDisabled={disabled}
       focusable={!disabled && focusable !== false}
-      pointerEvents={disabled ? 'none' : undefined}
+      pointerEvents={disabled ? 'box-none' : undefined}
       ref={setRef}
       style={[
         styles.root,

--- a/packages/react-native-web/src/exports/TouchableOpacity/index.js
+++ b/packages/react-native-web/src/exports/TouchableOpacity/index.js
@@ -132,7 +132,7 @@ function TouchableOpacity(props: Props, forwardedRef): React.Node {
       {...pressEventHandlers}
       accessibilityDisabled={disabled}
       focusable={!disabled && focusable !== false}
-      pointerEvents={disabled ? 'none' : undefined}
+      pointerEvents={disabled ? 'box-none' : undefined}
       ref={setRef}
       style={[
         styles.root,


### PR DESCRIPTION
This PR addresses the following issue: https://github.com/necolas/react-native-web/issues/2391.

It fixes the inconsistency between native builds and react-native-web, where when disabling Pressables and other tappable elements, the children on native builds are still interactable (swiping, tapping, etc) but un-interactable in react-native-web. On react-native-web, the pointerEvents were set to 'none'  to address https://github.com/necolas/react-native-web/commit/094bd0efc5ac1c566a81dec7ee825deae2c5a9a7, which causes this inconsistency.

The solution was to change from 'none' to 'box-none', which maintains the desired behavior of the original issue and addresses the current.