### PR TITLE
fix: add support for caretHidden prop in TextInput

### DIFF
--- a/packages/react-native-web-examples/pages/text-input/index.js
+++ b/packages/react-native-web-examples/pages/text-input/index.js
@@ -75,7 +75,11 @@ export default function TextInputPage() {
           rows={3}
           style={styles.multiline}
         />
-        <TextInput caretHidden defaultValue="caretHidden" />
+        <TextInput
+          caretHidden
+          defaultValue="caretHidden"
+          style={styles.textinput}
+        />
       </View>
     </Example>
   );

--- a/packages/react-native-web-examples/pages/text-input/index.js
+++ b/packages/react-native-web-examples/pages/text-input/index.js
@@ -75,6 +75,7 @@ export default function TextInputPage() {
           rows={3}
           style={styles.multiline}
         />
+        <TextInput caretHidden defaultValue="caretHidden" />
       </View>
     </Example>
   );

--- a/packages/react-native-web/src/exports/TextInput/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/TextInput/__tests__/index-test.js
@@ -105,6 +105,14 @@ describe('components/TextInput', () => {
     });
   });
 
+  describe('prop "caretHidden"', () => {
+    test('value "true"', () => {
+      const { container } = render(<TextInput caretHidden />);
+      const style = window.getComputedStyle(container.firstChild);
+      expect(style.caretColor).toEqual('transparent');
+    });
+  });
+
   describe('prop "clearTextOnFocus"', () => {
     const defaultValue = 'defaultValue';
 

--- a/packages/react-native-web/src/exports/TextInput/index.js
+++ b/packages/react-native-web/src/exports/TextInput/index.js
@@ -99,6 +99,7 @@ const TextInput: React.AbstractComponent<
     autoCompleteType,
     autoCorrect = true,
     blurOnSubmit,
+    caretHidden,
     clearTextOnFocus,
     dir,
     editable,
@@ -402,6 +403,7 @@ const TextInput: React.AbstractComponent<
     { '--placeholderTextColor': placeholderTextColor },
     styles.textinput$raw,
     styles.placeholder,
+    caretHidden && styles.caretHidden,
     props.style
   ];
   supportedProps.type = multiline ? undefined : type;
@@ -448,6 +450,9 @@ const styles = StyleSheet.create({
   },
   placeholder: {
     placeholderTextColor: 'var(--placeholderTextColor)'
+  },
+  caretHidden: {
+    caretColor: 'transparent'
   }
 });
 

--- a/packages/react-native-web/src/exports/TextInput/types.js
+++ b/packages/react-native-web/src/exports/TextInput/types.js
@@ -25,6 +25,7 @@ export type TextInputProps = {
   autoCorrect?: ?boolean,
   autoFocus?: ?boolean,
   blurOnSubmit?: ?boolean,
+  caretHidden?: ?boolean,
   clearTextOnFocus?: ?boolean,
   defaultValue?: ?string,
   dir?: ?('auto' | 'ltr' | 'rtl'),


### PR DESCRIPTION
## Details

This PR adds support for `caretHidden` prop in TextInput component. 

Adding `caretHidden` prop should ideally hide the text insertion caret on browsers. This is not working right now. This PR intends to fix the issue by setting `caretColor` as `transparent` while this prop is used.

fixes #2541 