### PR TITLE
fix: color support for all the types of colors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2949,6 +2949,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@react-native/normalize-color": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-color/-/normalize-color-2.1.0.tgz",
+      "integrity": "sha512-Z1jQI2NpdFJCVgpY+8Dq/Bt3d+YUi1928Q+/CZm/oh66fzM0RUl54vvuXlPJKybH4pdCZey1eDTPaLHkMPNgWA=="
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.24.51",
       "dev": true,
@@ -15484,10 +15489,10 @@
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.6",
+        "@react-native/normalize-color": "^2.1.0",
         "fbjs": "^3.0.4",
         "inline-style-prefixer": "^6.0.1",
         "memoize-one": "^6.0.0",
-        "normalize-css-color": "^1.0.2",
         "nullthrows": "^1.1.1",
         "postcss-value-parser": "^4.2.0",
         "styleq": "^0.1.3"
@@ -17336,6 +17341,11 @@
     "@polka/url": {
       "version": "1.0.0-next.21",
       "dev": true
+    },
+    "@react-native/normalize-color": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-color/-/normalize-color-2.1.0.tgz",
+      "integrity": "sha512-Z1jQI2NpdFJCVgpY+8Dq/Bt3d+YUi1928Q+/CZm/oh66fzM0RUl54vvuXlPJKybH4pdCZey1eDTPaLHkMPNgWA=="
     },
     "@sinclair/typebox": {
       "version": "0.24.51",
@@ -23635,10 +23645,10 @@
       "version": "file:packages/react-native-web",
       "requires": {
         "@babel/runtime": "^7.18.6",
+        "@react-native/normalize-color": "^2.1.0",
         "fbjs": "^3.0.4",
         "inline-style-prefixer": "^6.0.1",
         "memoize-one": "^6.0.0",
-        "normalize-css-color": "^1.0.2",
         "nullthrows": "^1.1.1",
         "postcss-value-parser": "^4.2.0",
         "styleq": "^0.1.3"

--- a/packages/react-native-web/package.json
+++ b/packages/react-native-web/package.json
@@ -23,10 +23,10 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.18.6",
+    "@react-native/normalize-color": "^2.1.0",
     "fbjs": "^3.0.4",
     "inline-style-prefixer": "^6.0.1",
     "memoize-one": "^6.0.0",
-    "normalize-css-color": "^1.0.2",
     "nullthrows": "^1.1.1",
     "postcss-value-parser": "^4.2.0",
     "styleq": "^0.1.3"

--- a/packages/react-native-web/src/exports/processColor/index.js
+++ b/packages/react-native-web/src/exports/processColor/index.js
@@ -8,7 +8,7 @@
  * @flow
  */
 
-import normalizeColor from 'normalize-css-color';
+import normalizeColor from '@react-native/normalize-color';
 
 const processColor = (color?: string | number): ?number => {
   if (color === undefined || color === null) {


### PR DESCRIPTION
This PR fixes #2525 , the color support for al the types of colors.  
I have entirely changed the package `normalize-css-color` to use `@react-native/normalize-color` instead because `normalize-css-color` seems little outdated. Please suggest the better approach to do the same if any.