### PR TITLE
Remove StyleSheet.compose(a, b) instances in favor of lists

### DIFF
--- a/packages/react-native-web/src/vendor/react-native/FlatList/index.js
+++ b/packages/react-native-web/src/vendor/react-native/FlatList/index.js
@@ -627,7 +627,7 @@ class FlatList<ItemT> extends React.PureComponent<Props<ItemT>, void> {
           'Expected array of items with numColumns > 1',
         );
         return (
-          <View style={StyleSheet.compose(styles.row, columnWrapperStyle)}>
+          <View style={[styles.row, columnWrapperStyle]}>
             {item.map((it, kk) => {
               const element = render({
                 // $FlowFixMe[incompatible-call]


### PR DESCRIPTION
`StyleSheet.compose(a, b) is deprecated; use array syntax, i.e., [a,b]. `