### PR TITLE
Fix Modal onDismiss callback is called too early

### DIFF
--- a/packages/react-native-web/src/exports/Modal/ModalAnimation.js
+++ b/packages/react-native-web/src/exports/Modal/ModalAnimation.js
@@ -37,6 +37,7 @@ function ModalAnimation(props: ModalAnimationProps): React.Node {
 
   const [isRendering, setIsRendering] = React.useState(false);
   const wasVisible = React.useRef(false);
+  const wasRendering = React.useRef(false);
 
   const isAnimated = animationType && animationType !== 'none';
 
@@ -54,13 +55,17 @@ function ModalAnimation(props: ModalAnimationProps): React.Node {
         }
       } else {
         setIsRendering(false);
-        if (onDismiss) {
-          onDismiss();
-        }
       }
     },
-    [onDismiss, onShow, visible]
+    [onShow, visible]
   );
+
+  React.useEffect(() => {
+    if (wasRendering.current && !isRendering && onDismiss) {
+      onDismiss();
+    }
+    wasRendering.current = isRendering;
+  }, [isRendering, onDismiss]);
 
   React.useEffect(() => {
     if (visible) {

--- a/packages/react-native-web/src/exports/Modal/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/Modal/__tests__/index-test.js
@@ -309,6 +309,32 @@ describe('components/Modal', () => {
     expect(document.activeElement).toBe(insideElement);
   });
 
+  test('focus is not trapped after closing modal', () => {
+    const { rerender } = render(
+      <>
+        <a data-testid={'outside'} href={'#outside'}>
+          Outside
+        </a>
+        <Modal visible={true} />
+      </>
+    );
+
+    const outsideElement = document.querySelector('[data-testid="outside"]');
+    const onDismissCallback = jest.fn(() => outsideElement.focus());
+
+    rerender(
+      <>
+        <a data-testid={'outside'} href={'#outside'}>
+          Outside
+        </a>
+        <Modal onDismiss={onDismissCallback} visible={false} />
+      </>
+    );
+
+    expect(onDismissCallback).toBeCalledTimes(1);
+    expect(document.activeElement).toBe(outsideElement);
+  });
+
   test('focus is brought back to the element that triggered modal after closing', () => {
     const { rerender } = render(
       <>


### PR DESCRIPTION
### Description
Currently, `onDismiss` is called right after setting the `isRendered` state to `false` which leads to `onDismiss` being called before the modal is completely dismissed. This makes chaining action after the modal is dismissed fails, for example, focusing an input.

### Test plan
1. Add a text input to the modal example
2. Add `onDismiss` props to the Modal which will focus the text input
3. Open the modal. Verify the modal shows
4. Close the modal
5. Verify the modal closes and the text input is focused

Currently, the 5th step fails and this PR is trying to fix it.

**Before:**

https://github.com/necolas/react-native-web/assets/50919443/40c72c36-2354-48f6-a5a6-997a6dfdba9f


**After:**

https://github.com/necolas/react-native-web/assets/50919443/49452b30-e9d0-4176-9d9f-5462da4cb9c7

