### PR TITLE
fix(Switch): aria-label prop not applying to native control

### DIFF
--- a/packages/react-native-web/src/exports/Switch/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/Switch/__tests__/index-test.js
@@ -23,7 +23,7 @@ function findSwitchThumb(container) {
 
 describe('components/Switch', () => {
   test('accessibilityLabel is applied to native checkbox', () => {
-    const { container } = render(<Switch accessibilityLabel="switch" />);
+    const { container } = render(<Switch aria-label="switch" />);
     expect(findCheckbox(container).getAttribute('aria-label')).toBe('switch');
   });
 

--- a/packages/react-native-web/src/exports/Switch/index.js
+++ b/packages/react-native-web/src/exports/Switch/index.js
@@ -44,6 +44,7 @@ const Switch: React.AbstractComponent<
   React.ElementRef<typeof View>
 > = React.forwardRef((props, forwardedRef) => {
   const {
+    'aria-label': ariaLabel,
     accessibilityLabel,
     activeThumbColor,
     activeTrackColor,
@@ -166,7 +167,7 @@ const Switch: React.AbstractComponent<
   ];
 
   const nativeControl = createElement('input', {
-    accessibilityLabel,
+    'aria-label': ariaLabel || accessibilityLabel,
     checked: value,
     disabled: disabled,
     onBlur: handleFocusState,


### PR DESCRIPTION
Fixes: https://github.com/necolas/react-native-web/issues/2549

Fix accessibility issue in Switch component by applying the `aria-label` prop to the native control component