### PR TITLE
fix: handle undefined for aspect ratio

### DIFF
--- a/packages/react-native-web/src/exports/StyleSheet/__tests__/preprocess-test.js
+++ b/packages/react-native-web/src/exports/StyleSheet/__tests__/preprocess-test.js
@@ -99,6 +99,8 @@ describe('StyleSheet/preprocess', () => {
       expect(preprocess({ aspectRatio: 9 / 16 })).toEqual({
         aspectRatio: '0.5625'
       });
+
+      expect(preprocess({ aspectRatio: undefined })).toEqual({});
     });
 
     test('fontVariant', () => {

--- a/packages/react-native-web/src/exports/StyleSheet/preprocess.js
+++ b/packages/react-native-web/src/exports/StyleSheet/preprocess.js
@@ -182,7 +182,7 @@ export const preprocess = <T: {| [key: string]: any |}>(
       continue;
     }
 
-    if (prop === 'aspectRatio') {
+    if (prop === 'aspectRatio' && value !== undefined) {
       nextStyle[prop] = value.toString();
     } else if (prop === 'fontVariant') {
       if (Array.isArray(value) && value.length > 0) {


### PR DESCRIPTION
## Summary
[AspectRatio can technically be passed as `undefined` in the stylesheet](https://github.com/facebook/react-native/blob/080a3d300dc357fec62d767d140f964f9db66b2e/packages/react-native/Libraries/StyleSheet/StyleSheetTypes.d.ts#L46) and that is handled on ios/android.

Passing `undefined` to `aspectRatio` on web leads to the following error:
`TypeError: Cannot read properties of undefined (reading 'toString')`

While it does not make sense as to why you might explicitly want to pass undefined to aspectRatio, my use case is that I had a custom component that was setting the aspectRatio as well as accepting styles prop that overrides the defined styles so I had to pass undefined for aspectRatio. This works fine or ios/android but crashed on web.

I also added a test case