### PR TITLE
Remove collapsable props from Animated componnet

### DIFF
--- a/packages/react-native-web/src/vendor/react-native/Animated/useAnimatedProps.js
+++ b/packages/react-native-web/src/vendor/react-native/Animated/useAnimatedProps.js
@@ -24,16 +24,11 @@ import {
 
 import useLayoutEffect from '../../../modules/useLayoutEffect';
 
-type ReducedProps<TProps> = {
-  ...TProps,
-  collapsable: boolean,
-  ...
-};
 type CallbackRef<T> = T => mixed;
 
 export default function useAnimatedProps<TProps: {...}, TInstance>(
   props: TProps,
-): [ReducedProps<TProps>, CallbackRef<TInstance | null>] {
+): [TProps, CallbackRef<TInstance | null>] {
   const [, scheduleUpdate] = useReducer(count => count + 1, 0);
   const onUpdateRef = useRef<?() => void>(null);
 
@@ -102,12 +97,9 @@ export default function useAnimatedProps<TProps: {...}, TInstance>(
 
 function reduceAnimatedProps<TProps>(
   node: AnimatedProps,
-): ReducedProps<TProps> {
-  // Force `collapsable` to be false so that the native view is not flattened.
-  // Flattened views cannot be accurately referenced by the native driver.
+): TProps {
   return {
     ...node.__getValue(),
-    collapsable: false,
   };
 }
 


### PR DESCRIPTION
As per https://github.com/necolas/react-native-web/issues/1703.

Since `collapsable` does nothing anywhere. This PR will remove the prop from `reduceAnimatedProps` function, which will help us to avoid warnings like these.

https://github.com/software-mansion/react-native-svg/issues/1484