### PR TITLE
fix(web)[TextInput]: cursor jumps to the start when secureTextEntry is toggled

### DIFF
--- a/packages/react-native-web/src/exports/TextInput/index.js
+++ b/packages/react-native-web/src/exports/TextInput/index.js
@@ -332,8 +332,7 @@ const TextInput: React.AbstractComponent<
 
   function handleSelectionChange(e) {
     try {
-      const node = e.target;
-      const { selectionStart, selectionEnd } = node;
+      const { selectionStart, selectionEnd } = e.target;
       const selection = {
         start: selectionStart,
         end: selectionEnd

--- a/packages/react-native-web/src/exports/TextInput/index.js
+++ b/packages/react-native-web/src/exports/TextInput/index.js
@@ -193,11 +193,11 @@ const TextInput: React.AbstractComponent<
 
   const dimensions = React.useRef({ height: null, width: null });
   const hostRef = React.useRef(null);
-  const prevSelection = React.useRef({ start: 0, end: 0 });
+  const prevSelection = React.useRef(null);
   const prevSecureTextEntry = React.useRef(false);
 
   React.useEffect(() => {
-    if (hostRef.current) {
+    if (hostRef.current && prevSelection.current) {
       setSelection(hostRef.current, prevSelection.current);
     }
     prevSecureTextEntry.current = secureTextEntry;

--- a/packages/react-native-web/src/exports/TextInput/index.js
+++ b/packages/react-native-web/src/exports/TextInput/index.js
@@ -193,11 +193,13 @@ const TextInput: React.AbstractComponent<
 
   const dimensions = React.useRef({ height: null, width: null });
   const hostRef = React.useRef(null);
-  const prevSelection = React.useRef({start: 0, end: 0});
+  const prevSelection = React.useRef({ start: 0, end: 0 });
   const prevSecureTextEntry = React.useRef(false);
 
   React.useEffect(() => {
-    setSelection(hostRef.current, prevSelection.current);
+    if (hostRef.current) {
+      setSelection(hostRef.current, prevSelection.current);
+    }
     prevSecureTextEntry.current = secureTextEntry;
   }, [secureTextEntry]);
 

--- a/packages/react-native-web/src/exports/TextInput/index.js
+++ b/packages/react-native-web/src/exports/TextInput/index.js
@@ -193,6 +193,13 @@ const TextInput: React.AbstractComponent<
 
   const dimensions = React.useRef({ height: null, width: null });
   const hostRef = React.useRef(null);
+  const prevSelection = React.useRef({start: 0, end: 0});
+  const prevSecureTextEntry = React.useRef(false);
+
+  React.useEffect(() => {
+    setSelection(hostRef.current, prevSelection.current);
+    prevSecureTextEntry.current = secureTextEntry;
+  }, [secureTextEntry]);
 
   const handleContentSizeChange = React.useCallback(
     (hostNode) => {
@@ -324,18 +331,22 @@ const TextInput: React.AbstractComponent<
   }
 
   function handleSelectionChange(e) {
-    if (onSelectionChange) {
-      try {
-        const node = e.target;
-        const { selectionStart, selectionEnd } = node;
-        e.nativeEvent.selection = {
-          start: selectionStart,
-          end: selectionEnd
-        };
+    try {
+      const node = e.target;
+      const { selectionStart, selectionEnd } = node;
+      const selection = {
+        start: selectionStart,
+        end: selectionEnd
+      };
+      if (onSelectionChange) {
+        e.nativeEvent.selection = selection;
         e.nativeEvent.text = e.target.value;
         onSelectionChange(e);
-      } catch (e) {}
-    }
+      }
+      if (prevSecureTextEntry.current === secureTextEntry) {
+        prevSelection.current = selection;
+      }
+    } catch (e) {}
   }
 
   useLayoutEffect(() => {


### PR DESCRIPTION
This PR fixes https://github.com/Expensify/App/issues/21727

# Problem

On web, the cursor jumps to the start of the input when `secureTextEntry` is toggled.

# Solution

Preserve and restore previous selection after `secureTextEntry` is toggled.

The proposal and demo are available in this comment: https://github.com/Expensify/App/issues/21727#issuecomment-1642507490

