### PR TITLE
[fix] Restore PermissionsAndroid compat api

### DIFF
--- a/packages/react-native-web/src/exports/PermissionsAndroid/index.js
+++ b/packages/react-native-web/src/exports/PermissionsAndroid/index.js
@@ -1,0 +1,1 @@
+export default {}

--- a/packages/react-native-web/src/index.js
+++ b/packages/react-native-web/src/index.js
@@ -68,3 +68,6 @@ export { default as DeviceEventEmitter } from './exports/DeviceEventEmitter';
 export { default as useColorScheme } from './exports/useColorScheme';
 export { default as useLocaleContext } from './exports/useLocaleContext';
 export { default as useWindowDimensions } from './exports/useWindowDimensions';
+
+// compat apis
+export { default as PermissionsAndroid } from './exports/PermissionsAndroid';


### PR DESCRIPTION
### Description
On https://github.com/necolas/react-native-web/releases/tag/0.19.0 on https://github.com/necolas/react-native-web/commit/3a024ee308e06857307b9cf80da1517c5f860c13 there was: 

`[change] Remove previously deprecated Android/iOS platform-specific exports.`



But AFAIK at least PermissionsAndroid is not deprecated as you can see https://reactnative.dev/docs/permissionsandroid

This is causing a warning like: 

```
export 'PermissionsAndroid' (imported as 'PermissionsAndroid') was not found in 'react-native-web' (possible exports: AccessibilityInfo, ActivityIndicator, Alert, Animated, AppRegistry, AppState, Appearance, BackHandler, Button, CheckBox, Clipboard, DeviceEventEmitter, Dimensions, Easing, FlatList, I18nManager, Image, ImageBackground, InteractionManager, Keyboard, KeyboardAvoidingView, LayoutAnimation, Linking, LogBox, Modal, NativeEventEmitter, NativeModules, PanResponder, Picker, PixelRatio, Platform, Pressable, ProgressBar, RefreshControl, SafeAreaView, ScrollView, SectionList, Share, StatusBar, StyleSheet, Switch, Text, TextInput, Touchable, TouchableHighlight, TouchableNativeFeedback, TouchableOpacity, TouchableWithoutFeedback, UIManager, Vibration, View, VirtualizedList, YellowBox, findNodeHandle, processColor, render, unmountComponentAtNode, unstable_createElement, useColorScheme, useLocaleContext, useWindowDimensions)
```

This PR restores PermissionsAndroid compat api so the warning disappears.

### Affected Issues
https://github.com/necolas/react-native-web/issues/2577