### PR TITLE
Fix: Multiline `Text` though clipped can be scrolled into view

### DIFF
--- a/packages/react-native-web/src/exports/Text/index.js
+++ b/packages/react-native-web/src/exports/Text/index.js
@@ -219,7 +219,7 @@ const styles = StyleSheet.create({
   textMultiLine: {
     display: '-webkit-box',
     maxWidth: '100%',
-    overflow: 'hidden',
+    overflow: 'clip',
     textOverflow: 'ellipsis',
     WebkitBoxOrient: 'vertical'
   },


### PR DESCRIPTION
### Details

Fixes https://github.com/necolas/react-native-web/issues/2582.

On mobile Web, multiline `Text`'s clipped part can be scrolled into view by dragging selection cursor. This PR blocks scrolling entirely, through any mechanism, over overflown text.

### Tests

1. Create a long `Text` with `numberOfLines > 1`
2. On mWeb, long press the text to toggle text selection cursor
3. Drag the selection cursor vertically
4. Observe that the clipped text cannot be scrolled into view


### Screenshots/Videos


https://github.com/necolas/react-native-web/assets/113963320/07214db6-29b3-4bc6-bdc5-de2bad63267b

