### PR TITLE
Implement maintainVisibleContentPosition

### DIFF
--- a/packages/react-native-web-examples/pages/scroll-view/index.js
+++ b/packages/react-native-web-examples/pages/scroll-view/index.js
@@ -3,29 +3,39 @@ import { ScrollView, StyleSheet, Text, Pressable, View } from 'react-native';
 import Button from '../../shared/button';
 import Example from '../../shared/example';
 
-const ITEMS = [...Array(12)].map((_, i) => `Item ${i}`);
+const ITEMS = [...Array(12)].map((_, i) => ({ id: i, text: `Item ${i}` }));
 
-function createItemRow(msg, index) {
+function createItemRow(msg) {
   return (
-    <Pressable key={index} style={[styles.item]}>
-      <Text style={styles.text}>{msg}</Text>
+    <Pressable key={msg.id} style={[styles.item]}>
+      <Text style={styles.text}>{msg.text}</Text>
     </Pressable>
   );
 }
 
-function Divider() {
-  return <View style={styles.divider} />;
-}
-
 export default function ScrollViewPage() {
   const [scrollEnabled, setEnabled] = React.useState(true);
+  const [horizontal, setHorizontal] = React.useState(false);
   const [throttle, setThrottle] = React.useState(16);
+  const [maintainVisibleContentPosition, setMaintainVisibleContentPosition] =
+    React.useState(false);
+  const [autoscrollToTop, setAutoScrollToTop] = React.useState(false);
+  const [items, setItems] = React.useState(ITEMS);
   const scrollRef = React.useRef(null);
 
   return (
     <Example title="ScrollView">
       <View style={styles.container}>
         <ScrollView
+          horizontal={horizontal}
+          maintainVisibleContentPosition={
+            maintainVisibleContentPosition
+              ? {
+                  minIndexForVisible: 0,
+                  autoscrollToTopThreshold: autoscrollToTop ? 100 : null
+                }
+              : null
+          }
           onScroll={() => {
             console.log('onScroll');
           }}
@@ -34,44 +44,86 @@ export default function ScrollViewPage() {
           scrollEventThrottle={throttle}
           style={[styles.scrollView, !scrollEnabled && styles.disabled]}
         >
-          {ITEMS.map(createItemRow)}
+          {items.map(createItemRow)}
         </ScrollView>
 
         <View style={styles.buttons}>
+          <Button
+            onPress={() => {
+              setHorizontal((val) => !val);
+            }}
+            title={horizontal ? 'Vertical' : 'Horizontal'}
+          />
           <Button
             onPress={() => {
               setEnabled((val) => !val);
             }}
             title={scrollEnabled ? 'Disable' : 'Enable'}
           />
-          <Divider />
           <Button
             onPress={() => {
               setThrottle((val) => (val !== 16 ? 16 : 1000));
             }}
             title="Throttle"
           />
-        </View>
-        <View style={styles.buttons}>
           <Button
             onPress={() => {
               scrollRef.current.scrollTo({ y: 0 });
             }}
             title="To start"
           />
-          <Divider />
           <Button
             onPress={() => {
               scrollRef.current.scrollTo({ y: 50 });
             }}
             title="To 50px"
           />
-          <Divider />
           <Button
             onPress={() => {
               scrollRef.current.scrollToEnd({ animated: true });
             }}
             title="To end"
+          />
+          <Button
+            onPress={() => {
+              setMaintainVisibleContentPosition((val) => !val);
+            }}
+            title={
+              maintainVisibleContentPosition ? 'Disable MVCP' : 'Enable MVCP'
+            }
+          />
+          {maintainVisibleContentPosition && (
+            <Button
+              onPress={() => {
+                setAutoScrollToTop((val) => !val);
+              }}
+              title={
+                autoscrollToTop
+                  ? 'Disable auto scroll top'
+                  : 'Enable auto scroll top'
+              }
+            />
+          )}
+          <Button
+            onPress={() => {
+              setItems((items) => [
+                { id: items[0].id - 1, text: `Item ${items[0].id - 1}` },
+                ...items
+              ]);
+            }}
+            title="Add item start"
+          />
+          <Button
+            onPress={() => {
+              setItems((items) => [
+                ...items,
+                {
+                  id: items[items.length - 1].id + 1,
+                  text: `Item ${items[items.length - 1].id + 1}`
+                }
+              ]);
+            }}
+            title="Add item end"
           />
         </View>
       </View>
@@ -105,9 +157,8 @@ const styles = StyleSheet.create({
   buttons: {
     flexDirection: 'row',
     justifyContent: 'center',
+    gap: '1rem',
+    flexWrap: 'wrap',
     marginVertical: '1rem'
-  },
-  divider: {
-    width: '1rem'
   }
 });

--- a/packages/react-native-web/src/exports/ScrollView/index.js
+++ b/packages/react-native-web/src/exports/ScrollView/index.js
@@ -624,6 +624,7 @@ class ScrollView extends React.Component<ScrollViewProps> {
 
     const props = {
       ...other,
+      horizontal,
       style: [baseStyle, pagingEnabled && pagingEnabledStyle, this.props.style],
       onTouchStart: this.scrollResponderHandleTouchStart,
       onTouchMove: this.scrollResponderHandleTouchMove,


### PR DESCRIPTION
This implements the `maintainVisibleContentPosition` prop on `ScrollView` (https://reactnative.dev/docs/scrollview#maintainvisiblecontentposition), as well as normalizing the scrolling behavior when adding items at the top of a ScrollView.

Currently the behavior varies depending on the browser. In Chrome the content position is maintained if the scroll position is > 0, while on Safari it is never maintained. The Chrome behavior diverges from react-native so this also makes sure it is consistent, which is that by default the content position is not maintained, and that when the `maintainVisibleContentPosition` prop is set it is.

The general logic is adapted from the iOS implementation in react-native (https://github.com/facebook/react-native/blob/main/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm#L723-L787). The general idea is to get the position of the first visible view before changes to the view hierarchy, compare it to its position after the changes and adjust the scroll position accordingly.  In react-native there are UIManager hooks that are executed before / after a transaction is committed. On the web we can use `MutationObserver` to detect changes to the subtree of the `ScrollView`, but sadly I don't think there are any way to have a callback executed before the changes are committed so instead we update the first visible view on scroll events.

To fix the Chrome behavior that automatically preserves the scroll position we save the last scroll position from scroll events and reset it to that last value in the `MutationObserver` callback. This successfully reverts the adjustment Chrome did.

I also updated the example app to include these new features in the `ScrollView` example.

Here's a few videos of the example before and after the changes

#### Before

Chrome maintains scroll position when not scrolled at the top, Safari doesn't.

Chrome:

https://github.com/necolas/react-native-web/assets/2677334/9b1c182f-d3ab-4130-9ab5-f3061fcf23c4

Safari:

https://github.com/necolas/react-native-web/assets/2677334/28909f2d-4b8a-44ba-83c9-333b64c6fbd9

#### After

Same behavior in Chrome and Safari, shows without mvcp, then with mvcp, then with autoscrollToTopThreshold.

Chrome:

https://github.com/necolas/react-native-web/assets/2677334/aa6e6fbc-c9b4-4e94-b249-770a538935b6

Safari:

https://github.com/necolas/react-native-web/assets/2677334/32f448a5-2369-4691-9fa9-a61cc3401e99


