### PR TITLE
fix: role='label' not changing element to label.

### DIFF
--- a/packages/react-native-web/src/modules/AccessibilityUtil/propsToAccessibilityComponent.js
+++ b/packages/react-native-web/src/modules/AccessibilityUtil/propsToAccessibilityComponent.js
@@ -37,7 +37,7 @@ const propsToAccessibilityComponent = (
   props: Object = emptyObject
 ): void | string => {
   // special-case for "label" role which doesn't map to an ARIA role
-  if (props.accessibilityRole === 'label') {
+  if (props.accessibilityRole === 'label' || props.role === 'label') {
     return 'label';
   }
 


### PR DESCRIPTION
### Problem Statement
with `accessibilityRole="label`
Code
```
<View accessibilityRole="label">
```
OutPut
```
<label />
```

with `role="label`

Code
```
<View role="label">
```
OutPut
```
<div />
```
### Solution

- Added condition for `role="label"`.