### PR TITLE
Fix: `VirtualizedList` passive event listener warning

### DIFF
--- a/packages/react-native-web/src/modules/addEventListener/index.js
+++ b/packages/react-native-web/src/modules/addEventListener/index.js
@@ -20,7 +20,7 @@ export type EventOptions = {
 
 const emptyFunction = () => {};
 
-export function supportsPassiveEvents(): boolean {
+function supportsPassiveEvents(): boolean {
   let supported = false;
   // Check if browser supports event with passive listeners
   // https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#Safely_detecting_option_support

--- a/packages/react-native-web/src/modules/addEventListener/index.js
+++ b/packages/react-native-web/src/modules/addEventListener/index.js
@@ -20,7 +20,7 @@ export type EventOptions = {
 
 const emptyFunction = () => {};
 
-function supportsPassiveEvents(): boolean {
+export function supportsPassiveEvents(): boolean {
   let supported = false;
   // Check if browser supports event with passive listeners
   // https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#Safely_detecting_option_support

--- a/packages/react-native-web/src/vendor/react-native/VirtualizedList/index.js
+++ b/packages/react-native-web/src/vendor/react-native/VirtualizedList/index.js
@@ -49,12 +49,14 @@ import {
 import invariant from 'fbjs/lib/invariant';
 import nullthrows from 'nullthrows';
 import * as React from 'react';
+import { supportsPassiveEvents } from '../../../modules/addEventListener';
 
 export type {RenderItemProps, RenderItemType, Separators};
 
 const __DEV__ = process.env.NODE_ENV !== 'production';
 
 const ON_EDGE_REACHED_EPSILON = 0.001;
+const canUsePassiveEvents = supportsPassiveEvents();
 
 let _usedIndexForKey = false;
 let _keylessItemComponentName: string = '';
@@ -746,7 +748,8 @@ class VirtualizedList extends StateSafePureComponent<Props, State> {
   setupWebWheelHandler() {
     if (this._scrollRef && this._scrollRef.getScrollableNode) {
       this._scrollRef.getScrollableNode().addEventListener('wheel',
-          this.invertedWheelEventHandler
+          this.invertedWheelEventHandler,
+          canUsePassiveEvents ? { passive: true } : false
       );
     } else {
       setTimeout(() => this.setupWebWheelHandler(), 50);

--- a/packages/react-native-web/src/vendor/react-native/VirtualizedList/index.js
+++ b/packages/react-native-web/src/vendor/react-native/VirtualizedList/index.js
@@ -49,14 +49,12 @@ import {
 import invariant from 'fbjs/lib/invariant';
 import nullthrows from 'nullthrows';
 import * as React from 'react';
-import { supportsPassiveEvents } from '../../../modules/addEventListener';
 
 export type {RenderItemProps, RenderItemType, Separators};
 
 const __DEV__ = process.env.NODE_ENV !== 'production';
 
 const ON_EDGE_REACHED_EPSILON = 0.001;
-const canUsePassiveEvents = supportsPassiveEvents();
 
 let _usedIndexForKey = false;
 let _keylessItemComponentName: string = '';
@@ -749,7 +747,7 @@ class VirtualizedList extends StateSafePureComponent<Props, State> {
     if (this._scrollRef && this._scrollRef.getScrollableNode) {
       this._scrollRef.getScrollableNode().addEventListener('wheel',
           this.invertedWheelEventHandler,
-          canUsePassiveEvents ? { passive: true } : false
+          { passive: true },
       );
     } else {
       setTimeout(() => this.setupWebWheelHandler(), 50);


### PR DESCRIPTION
### Details

Fixes https://github.com/necolas/react-native-web/issues/2598.

Passive event warning `[Violation] Added non-passive event listener to a scroll-blocking 'wheel' event` appears when using `VirtualizedList`. Happens on Chrome 51 or later which support passive event listener. This PR eliminates the warning by adding passive event listener support for `VitualizedList`.

### Tests

1. Use a `VirtualizedList` component
2. Verify the warning does not appear in Chrome 51 or later
