### PR TITLE
[fix] forward name prop

### DIFF
--- a/packages/react-native-web/src/modules/forwardedProps/index.js
+++ b/packages/react-native-web/src/modules/forwardedProps/index.js
@@ -12,6 +12,7 @@ export const defaultProps = {
   dataSet: true,
   dir: true,
   id: true,
+  name: true,
   ref: true,
   suppressHydrationWarning: true,
   tabIndex: true,


### PR DESCRIPTION
Fix  https://github.com/necolas/react-native-web/issues/2596

Add `name` to the list of forwarded props. This is important to have `input` element be compatible with standards:
- `FormData` web standard ([doc](https://developer.mozilla.org/en-US/docs/Web/API/FormData))
- new React `useFormStatus` hook ([doc](https://react.dev/reference/react-dom/hooks/useFormStatus))
- new React `useFormState` hook ([doc](https://react.dev/reference/react-dom/hooks/useFormState))