### PR TITLE
fix: use getBondingClientRect instead of getRect for measureInWindow

### DIFF
--- a/packages/react-native-web/src/exports/UIManager/index.js
+++ b/packages/react-native-web/src/exports/UIManager/index.js
@@ -82,7 +82,7 @@ const UIManager = {
   measureInWindow(node, callback) {
     if (node) {
       setTimeout(() => {
-        const { height, left, top, width } = getRect(node);
+        const { height, left, top, width } = node.getBoundingClientRect();
         callback(left, top, width, height);
       }, 0);
     }


### PR DESCRIPTION

### Details
Fixes https://github.com/necolas/react-native-web/issues/2589