### PR TITLE
remove transform style warning since the native alternative doesn't work for most cases.

### DIFF
--- a/packages/react-native-web/src/exports/StyleSheet/preprocess.js
+++ b/packages/react-native-web/src/exports/StyleSheet/preprocess.js
@@ -203,10 +203,6 @@ export const preprocess = <T: {| [key: string]: any |}>(
       }
     } else if (prop === 'transform') {
       if (Array.isArray(value)) {
-        warnOnce(
-          'transform',
-          '"transform" style array value is deprecated. Use space-separated string functions, e.g., "scaleX(2) rotateX(15deg)".'
-        );
         value = createTransformValue(value);
       }
       nextStyle.transform = value;


### PR DESCRIPTION
The string interpolation system doesn't appear to work with React Animated as the string would convert the animated object to `[Object object]`.