### PR TITLE
Fix onPress is called twice when activated with keyboard and set to disabled (blurred)

### DIFF
--- a/packages/react-native-web/src/exports/Pressable/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/react-native-web/src/exports/Pressable/__tests__/__snapshots__/index-test.js.snap
@@ -61,14 +61,14 @@ exports[`components/Pressable hover interaction 3`] = `
 />
 `;
 
-exports[`components/Pressable press interaction (keyboard) 1`] = `
+exports[`components/Pressable press interaction (keyboard) trigger press when keyup is on the same element 1`] = `
 <div
   class="css-view-175oi2r r-cursor-1loqt21 r-touchAction-1otgn73"
   tabindex="0"
 />
 `;
 
-exports[`components/Pressable press interaction (keyboard) 2`] = `
+exports[`components/Pressable press interaction (keyboard) trigger press when keyup is on the same element 2`] = `
 <div
   class="css-view-175oi2r r-cursor-1loqt21 r-touchAction-1otgn73"
   style="outline: press-ring;"
@@ -80,7 +80,7 @@ exports[`components/Pressable press interaction (keyboard) 2`] = `
 </div>
 `;
 
-exports[`components/Pressable press interaction (keyboard) 3`] = `null`;
+exports[`components/Pressable press interaction (keyboard) trigger press when keyup is on the same element 3`] = `null`;
 
 exports[`components/Pressable press interaction (pointer) 1`] = `
 <div

--- a/packages/react-native-web/src/modules/usePressEvents/PressResponder.js
+++ b/packages/react-native-web/src/modules/usePressEvents/PressResponder.js
@@ -233,7 +233,7 @@ export default class PressResponder {
     pageY: number
   |}>;
   _touchState: TouchState = NOT_RESPONDER;
-  _responderElement: HTMLElement;
+  _responderElement: ?HTMLElement = null;
 
   constructor(config: PressResponderConfig) {
     this.configure(config);

--- a/packages/react-native-web/src/modules/usePressEvents/PressResponder.js
+++ b/packages/react-native-web/src/modules/usePressEvents/PressResponder.js
@@ -326,6 +326,8 @@ export default class PressResponder {
         if (onPress != null && !isNativeInteractiveElement && isActiveElement) {
           onPress(event);
         }
+
+        this._responderElement = null;
       }
     };
 

--- a/packages/react-native-web/src/modules/usePressEvents/PressResponder.js
+++ b/packages/react-native-web/src/modules/usePressEvents/PressResponder.js
@@ -233,6 +233,7 @@ export default class PressResponder {
     pageY: number
   |}>;
   _touchState: TouchState = NOT_RESPONDER;
+  _responderElement: HTMLElement;
 
   constructor(config: PressResponderConfig) {
     this.configure(config);
@@ -320,8 +321,9 @@ export default class PressResponder {
           elementType === 'input' ||
           elementType === 'select' ||
           elementType === 'textarea';
+        const isActiveElement = this._responderElement === target;
 
-        if (onPress != null && !isNativeInteractiveElement) {
+        if (onPress != null && !isNativeInteractiveElement && isActiveElement) {
           onPress(event);
         }
       }
@@ -345,6 +347,7 @@ export default class PressResponder {
         if (!disabled && isValidKeyPress(event)) {
           if (this._touchState === NOT_RESPONDER) {
             start(event, false);
+            this._responderElement = target;
             // Listen to 'keyup' on document to account for situations where
             // focus is moved to another element during 'keydown'.
             document.addEventListener('keyup', keyupHandler);


### PR DESCRIPTION
### Description
Fixes https://github.com/necolas/react-native-web/issues/2605

We are attaching the `keyup` listener to the document.
https://github.com/necolas/react-native-web/blob/5f9c32eba0f840bde7b462a57d0748358ff866f6/packages/react-native-web/src/modules/usePressEvents/PressResponder.js#L348-L350

If the Pressable (with a button role) is disabled after the first `onPress` is triggered, the focus is transferred to `body` and `isNativeInteractiveElement` will be false when releasing the press, thus the `onPress` is called for the second time.
https://github.com/necolas/react-native-web/blob/5f9c32eba0f840bde7b462a57d0748358ff866f6/packages/react-native-web/src/modules/usePressEvents/PressResponder.js#L316-L326

### Test plan
1. On the pressable example code, disable the pressable in`onPress`
2. Run the pressable example
3. Hold down the pressable using a keyboard. Verify the `onPress` is called
4. Release the press. Verify the `onPress` isn't called.

Currently, the 4th step fails and this PR is trying to fix it.

**Before:**


https://github.com/necolas/react-native-web/assets/50919443/26a9a3f2-d220-4b0f-8642-8cfdba2370d0



**After:**


https://github.com/necolas/react-native-web/assets/50919443/44ca0796-9a2e-4efa-98b8-485b2dd6a285


