### PR TITLE
Remove the default black color of Text component

### DIFF
--- a/packages/react-native-web/src/exports/Text/index.js
+++ b/packages/react-native-web/src/exports/Text/index.js
@@ -186,7 +186,6 @@ const textStyle = {
   backgroundColor: 'transparent',
   border: '0 solid black',
   boxSizing: 'border-box',
-  color: 'black',
   display: 'inline',
   font: '14px System',
   listStyle: 'none',


### PR DESCRIPTION
issues [#2634](https://github.com/necolas/react-native-web/issues/2634)