### PR TITLE
fix: export InputAccessoryView

### DIFF
--- a/packages/react-native-web/src/index.js
+++ b/packages/react-native-web/src/index.js
@@ -38,6 +38,7 @@ export { default as CheckBox } from './exports/CheckBox';
 export { default as FlatList } from './exports/FlatList';
 export { default as Image } from './exports/Image';
 export { default as ImageBackground } from './exports/ImageBackground';
+export { default as InputAccessoryView } from './exports/InputAccessoryView';
 export { default as KeyboardAvoidingView } from './exports/KeyboardAvoidingView';
 export { default as Modal } from './exports/Modal';
 export { default as Picker } from './exports/Picker';


### PR DESCRIPTION
### Issue

When `InputAccessoryView` is used, web build fails because it is not exported.

###  Fix

This PR exports the `InputAccessoryView` component. 