### PR TITLE
Add missing method `Keyboard.isVisible()`

### DIFF
--- a/packages/react-native-web/src/exports/Keyboard/index.js
+++ b/packages/react-native-web/src/exports/Keyboard/index.js
@@ -10,7 +10,11 @@
 
 import dismissKeyboard from '../../modules/dismissKeyboard';
 
+// in the future we can use https://github.com/w3c/virtual-keyboard
 const Keyboard = {
+  isVisible() {
+    return false;
+  },
   addListener(): {| remove: () => void |} {
     return { remove: () => {} };
   },


### PR DESCRIPTION
The method [`Keyboard.isVisible`](https://reactnative.dev/docs/keyboard#isvisible) is missing in web implementation. Keyboard API on web is currently a dummy implementation so I returned `false` as static value.