### PR TITLE
revert: passive wheel event listener in virtualized list

### DIFF
--- a/packages/react-native-web/src/vendor/react-native/VirtualizedList/index.js
+++ b/packages/react-native-web/src/vendor/react-native/VirtualizedList/index.js
@@ -747,7 +747,6 @@ class VirtualizedList extends StateSafePureComponent<Props, State> {
     if (this._scrollRef && this._scrollRef.getScrollableNode) {
       this._scrollRef.getScrollableNode().addEventListener('wheel',
           this.invertedWheelEventHandler,
-          { passive: true },
       );
     } else {
       setTimeout(() => this.setupWebWheelHandler(), 50);

--- a/packages/react-native-web/src/vendor/react-native/VirtualizedList/index.js
+++ b/packages/react-native-web/src/vendor/react-native/VirtualizedList/index.js
@@ -746,7 +746,7 @@ class VirtualizedList extends StateSafePureComponent<Props, State> {
   setupWebWheelHandler() {
     if (this._scrollRef && this._scrollRef.getScrollableNode) {
       this._scrollRef.getScrollableNode().addEventListener('wheel',
-          this.invertedWheelEventHandler,
+          this.invertedWheelEventHandler
       );
     } else {
       setTimeout(() => this.setupWebWheelHandler(), 50);


### PR DESCRIPTION
### Details

Fixes https://github.com/necolas/react-native-web/issues/2658

We used custom logic for `wheel` event in `VirtualizedList` thus enabling `passive` event is not possible.