### PR TITLE
[fix] Make sure `AppState.isAvailable` is a boolean

### DIFF
--- a/packages/react-native-web/src/exports/AppState/index.js
+++ b/packages/react-native-web/src/exports/AppState/index.js
@@ -34,7 +34,7 @@ const AppStates = {
 let changeEmitter = null;
 
 export default class AppState {
-  static isAvailable = canUseDOM && document[VISIBILITY_STATE_PROPERTY];
+  static isAvailable = canUseDOM && !!document[VISIBILITY_STATE_PROPERTY];
 
   static get currentState() {
     if (!AppState.isAvailable) {


### PR DESCRIPTION
Fixes https://github.com/necolas/react-native-web/issues/2673

Converts `AppState.isAvailable` to a boolean. Currently it's just `document[VISIBILITY_STATE_PROPERTY]`, this makes sure it's a bool by adding `!!`.