### PR TITLE
Align tintColor transparent color behaviour with native

### DIFF
--- a/packages/react-native-web/src/exports/Image/__tests__/__snapshots__/index-test.js.snap
+++ b/packages/react-native-web/src/exports/Image/__tests__/__snapshots__/index-test.js.snap
@@ -343,7 +343,7 @@ exports[`components/Image prop "style" removes other unsupported View styles 1`]
         />
         <fecomposite
           in2="SourceAlpha"
-          operator="atop"
+          operator="in"
         />
       </filter>
     </defs>
@@ -410,7 +410,7 @@ exports[`components/Image prop "tintColor" convert to filter 1`] = `
         />
         <fecomposite
           in2="SourceAlpha"
-          operator="atop"
+          operator="in"
         />
       </filter>
     </defs>

--- a/packages/react-native-web/src/exports/Image/index.js
+++ b/packages/react-native-web/src/exports/Image/index.js
@@ -44,7 +44,7 @@ function createTintColorSVG(tintColor, id) {
       <defs>
         <filter id={`tint-${id}`} suppressHydrationWarning={true}>
           <feFlood floodColor={`${tintColor}`} key={tintColor} />
-          <feComposite in2="SourceAlpha" operator="atop" />
+          <feComposite in2="SourceAlpha" operator="in" />
         </filter>
       </defs>
     </svg>


### PR DESCRIPTION
I noticed that when we apply `tintColor` to images using a color with transparency, they seem to blend the color against black before applying it.

I am not deep enough in SVG to /really/ understand what's going on, but I noticed that changing the `feComposite` operator from `atop` to `in` fixes the behaviour. The [operator description for "in" on the MDN page](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/feComposite) doesn't really sound wrong to me either. It works the same, except `atop` also has this:

> The parts of the destination graphic that do not overlap with the source graphic stay untouched.

Isn't the source graphic in this case the flood fill? So there's no way not to overlap. I would expect identical behaviour, and yet, `in` operator has correct transparency behaviour in the browsers I tested.

I made some test screenshots with the following code


```
        <View style={{ backgroundColor: 'blue', padding: 12, flexDirection: 'row' }}>
          <Image tintColor={'rgba(255, 0, 0, 0)'} source={InactiveStar} />
          <Image tintColor={'rgba(255, 0, 0, 0.1)'} source={InactiveStar} />
          <Image tintColor={'rgba(255, 0, 0, 0.5)'} source={InactiveStar} />
          <Image tintColor={'rgba(255, 0, 0, 0.9)'} source={InactiveStar} />
          <Image tintColor={'rgba(255, 0, 0, 1)'} source={InactiveStar} />
        </View>
```

Here are screenshots with `atop` and `in`. From left to right:
iOS native, iOS Safari, macOS Chrome, macOS Firefox


with `atop`:

![Screenshot 2024-06-20 at 13 51 56](https://github.com/necolas/react-native-web/assets/950480/14327951-b0b5-4430-8e2a-25469b41913d)

with `in`

![Screenshot 2024-06-20 at 13 54 29](https://github.com/necolas/react-native-web/assets/950480/27bb11ff-b8ae-421f-b341-f68bfa4e819a)

If you have any ideas what kinds of other scenarios should be tested, or what kind of test info should be attached to the PR, let me know.