### PR TITLE
Make asset registry globally available

### DIFF
--- a/packages/react-native-web/src/modules/AssetRegistry/index.js
+++ b/packages/react-native-web/src/modules/AssetRegistry/index.js
@@ -21,6 +21,8 @@ export type PackagerAsset = {
 
 const assets: Array<PackagerAsset> = [];
 
+globalThis.__react_native_web_assets = assets
+
 export function registerAsset(asset: PackagerAsset): number {
   // `push` returns new array length, so the first asset will
   // get id 1 (not 0) to make the value truthy


### PR DESCRIPTION
## What

Exposes the asset registry array as a global variable so that libraries can access the assets without needing to install `react-native-web`.

## Why

I build many open source libraries for React Native & React Native Web, many of which render an image under the hood.

In particular, I often want to do this in my libraries:

```tsx
<img src={require('./local-image.png')} />
```

However, for libraries using Metro for Web, this doesn't work because ther result of `require` is a `number`.

I'd love to be able to do this:

```tsx
function MyLibrarysComponent({ src }) {
  const asset = typeof src === 'number' ? globalThis.__react_native_web_assets[src] : src
}
```

I am explicitly not interested in importing `Image` from `react-native-web`, because I want to support web-only apps without adding requiring additional dependencies or configuration.

## Workaround

The only way to fix this currently would be to import `resolveAssetSource` from `react-native-web`'s internals. However, this would require adding `react-native-web` as a dependency of the library, just to support Metro Web users.

With this PR, I can confidently pull from the global variable for users which certainly have `react-native-web` installed, without requiring Next.js/Vite/Remix users to install it.

