### PR TITLE
Remove misleading fake http status code.

### DIFF
--- a/packages/react-native-web/src/exports/Image/index.js
+++ b/packages/react-native-web/src/exports/Image/index.js
@@ -298,7 +298,7 @@ const Image: React.AbstractComponent<
           if (onError) {
             onError({
               nativeEvent: {
-                error: `Failed to load resource ${uri} (404)`
+                error: `Failed to load resource ${uri}`
               }
             });
           }


### PR DESCRIPTION
Image load can fail with any http error, not just 404 (Not found), but as in my case it was 401 (Unauthorized).

I guess if we do not know http status we should not make it. But I agree that in 95% it will 404, but not always.

If somebody really need http image status then might use XMLHttpRequest in a separate image load request call.