### PR TITLE
[fix] dont throw if invalid locale

### DIFF
--- a/packages/react-native-web/src/modules/useLocale/isLocaleRTL.js
+++ b/packages/react-native-web/src/modules/useLocale/isLocaleRTL.js
@@ -60,9 +60,16 @@ export function isLocaleRTL(locale: string): boolean {
   let isRTL = false;
   // $FlowFixMe
   if (Intl.Locale) {
-    // $FlowFixMe
-    const script = new Intl.Locale(locale).maximize().script;
-    isRTL = rtlScripts.has(script);
+    try {
+      // $FlowFixMe
+      const script = new Intl.Locale(locale).maximize().script;
+      isRTL = rtlScripts.has(script);
+    } catch {
+      // RangeError: Incorrect locale information provided
+      // Fallback to inferring from language
+      const lang = locale.split('-')[0];
+      isRTL = rtlLangs.has(lang);
+    }
   } else {
     // Fallback to inferring from language
     const lang = locale.split('-')[0];


### PR DESCRIPTION
React native web throws a hard error if the locale is invalid.
This is one of the most common errors according to our error logging.
This hard error seems unnecessary, so try catch and just assume ltr if not supported locale