### PR TITLE
Remove API deprecation warnings

### DIFF
--- a/packages/react-native-web-docs/src/pages/docs/concepts/accessibility.md
+++ b/packages/react-native-web-docs/src/pages/docs/concepts/accessibility.md
@@ -20,7 +20,7 @@ Accessibility in {{ site.name }} combines several separate web APIs into a cohes
 
 ## Accessibility Props API
 
-{{ site.name }} includes APIs for making accessible apps. (Note that the React Native-specific `accessibility*` props are deprecated in favor of `aria-*` props).
+{{ site.name }} includes APIs for making accessible apps. (Note that for compatibility with existing React Native code, the React Native-specific `accessibility*` props are also supported.)
 
 {% call macro.prop('aria-activedescendant', '?string') %}
 Equivalent to [aria-activedescendant](https://www.w3.org/TR/wai-aria-1.2/#aria-activedescendant).

--- a/packages/react-native-web/src/exports/Button/index.js
+++ b/packages/react-native-web/src/exports/Button/index.js
@@ -12,7 +12,7 @@ import * as React from 'react';
 import StyleSheet from '../StyleSheet';
 import TouchableOpacity from '../TouchableOpacity';
 import Text from '../Text';
-import { warnOnce } from '../../modules/warnOnce';
+//import { warnOnce } from '../../modules/warnOnce';
 
 type ButtonProps = {|
   accessibilityLabel?: ?string,
@@ -27,7 +27,7 @@ const Button: React.AbstractComponent<
   ButtonProps,
   React.ElementRef<typeof TouchableOpacity>
 > = React.forwardRef((props, forwardedRef) => {
-  warnOnce('Button', 'Button is deprecated. Please use Pressable.');
+  // warnOnce('Button', 'Button is deprecated. Please use Pressable.');
 
   const { accessibilityLabel, color, disabled, onPress, testID, title } = props;
 

--- a/packages/react-native-web/src/exports/StyleSheet/index.js
+++ b/packages/react-native-web/src/exports/StyleSheet/index.js
@@ -113,9 +113,11 @@ function compose(style1: any, style2: any): any {
       );
     }
     /* eslint-enable prefer-rest-params */
+    /*
     console.warn(
       'StyleSheet.compose(a, b) is deprecated; use array syntax, i.e., [a,b].'
     );
+    */
   }
   return [style1, style2];
 }

--- a/packages/react-native-web/src/exports/StyleSheet/preprocess.js
+++ b/packages/react-native-web/src/exports/StyleSheet/preprocess.js
@@ -186,18 +186,22 @@ export const preprocess = <T: {| [key: string]: any |}>(
       nextStyle[prop] = value.toString();
     } else if (prop === 'fontVariant') {
       if (Array.isArray(value) && value.length > 0) {
+        /*
         warnOnce(
           'fontVariant',
           '"fontVariant" style array value is deprecated. Use space-separated values.'
         );
+        */
         value = value.join(' ');
       }
       nextStyle[prop] = value;
     } else if (prop === 'textAlignVertical') {
+      /*
       warnOnce(
         'textAlignVertical',
         '"textAlignVertical" style is deprecated. Use "verticalAlign".'
       );
+      */
       if (style.verticalAlign == null) {
         nextStyle.verticalAlign = value === 'center' ? 'middle' : value;
       }

--- a/packages/react-native-web/src/exports/Text/index.js
+++ b/packages/react-native-web/src/exports/Text/index.js
@@ -24,7 +24,7 @@ import useResponderEvents from '../../modules/useResponderEvents';
 import StyleSheet from '../StyleSheet';
 import TextAncestorContext from './TextAncestorContext';
 import { useLocaleContext, getLocaleDirection } from '../../modules/useLocale';
-import { warnOnce } from '../../modules/warnOnce';
+//import { warnOnce } from '../../modules/warnOnce';
 
 const forwardPropsList = Object.assign(
   {},
@@ -73,12 +73,14 @@ const Text: React.AbstractComponent<TextProps, HTMLElement & PlatformMethods> =
       ...rest
     } = props;
 
+    /*
     if (selectable != null) {
       warnOnce(
         'selectable',
         'selectable prop is deprecated. Use styles.userSelect.'
       );
     }
+    */
 
     const hasTextAncestor = React.useContext(TextAncestorContext);
     const hostRef = React.useRef(null);

--- a/packages/react-native-web/src/exports/TextInput/index.js
+++ b/packages/react-native-web/src/exports/TextInput/index.js
@@ -25,7 +25,7 @@ import useResponderEvents from '../../modules/useResponderEvents';
 import { getLocaleDirection, useLocaleContext } from '../../modules/useLocale';
 import StyleSheet from '../StyleSheet';
 import TextInputState from '../../modules/TextInputState';
-import { warnOnce } from '../../modules/warnOnce';
+//import { warnOnce } from '../../modules/warnOnce';
 
 /**
  * Determines whether a 'selection' prop differs from a node's existing
@@ -163,7 +163,7 @@ const TextInput: React.AbstractComponent<
       type = 'text';
     }
   } else if (keyboardType != null) {
-    warnOnce('keyboardType', 'keyboardType is deprecated. Use inputMode.');
+    // warnOnce('keyboardType', 'keyboardType is deprecated. Use inputMode.');
     switch (keyboardType) {
       case 'email-address':
         type = 'email';
@@ -394,9 +394,11 @@ const TextInput: React.AbstractComponent<
   supportedProps.autoCorrect = autoCorrect ? 'on' : 'off';
   // 'auto' by default allows browsers to infer writing direction
   supportedProps.dir = dir !== undefined ? dir : 'auto';
+  /*
   if (returnKeyType != null) {
     warnOnce('returnKeyType', 'returnKeyType is deprecated. Use enterKeyHint.');
   }
+  */
   supportedProps.enterKeyHint = enterKeyHint || returnKeyType;
   supportedProps.inputMode = _inputMode;
   supportedProps.onBlur = handleBlur;
@@ -404,16 +406,20 @@ const TextInput: React.AbstractComponent<
   supportedProps.onFocus = handleFocus;
   supportedProps.onKeyDown = handleKeyDown;
   supportedProps.onSelect = handleSelectionChange;
+  /*
   if (editable != null) {
     warnOnce('editable', 'editable is deprecated. Use readOnly.');
   }
+  */
   supportedProps.readOnly = readOnly === true || editable === false;
+  /*
   if (numberOfLines != null) {
     warnOnce(
       'numberOfLines',
       'TextInput numberOfLines is deprecated. Use rows.'
     );
   }
+  */
   supportedProps.rows = multiline ? (rows != null ? rows : numberOfLines) : 1;
   supportedProps.spellCheck = spellCheck != null ? spellCheck : autoCorrect;
   supportedProps.style = [

--- a/packages/react-native-web/src/exports/TouchableHighlight/index.js
+++ b/packages/react-native-web/src/exports/TouchableHighlight/index.js
@@ -20,7 +20,7 @@ import useMergeRefs from '../../modules/useMergeRefs';
 import usePressEvents from '../../modules/usePressEvents';
 import StyleSheet from '../StyleSheet';
 import View from '../View';
-import { warnOnce } from '../../modules/warnOnce';
+//import { warnOnce } from '../../modules/warnOnce';
 
 type ViewStyle = $PropertyType<ViewProps, 'style'>;
 
@@ -71,10 +71,12 @@ function hasPressHandler(props): boolean {
  * If you wish to have several child components, wrap them in a View.
  */
 function TouchableHighlight(props: Props, forwardedRef): React.Node {
+  /*
   warnOnce(
     'TouchableHighlight',
     'TouchableHighlight is deprecated. Please use Pressable.'
   );
+  */
 
   const {
     activeOpacity,

--- a/packages/react-native-web/src/exports/TouchableOpacity/index.js
+++ b/packages/react-native-web/src/exports/TouchableOpacity/index.js
@@ -19,7 +19,7 @@ import useMergeRefs from '../../modules/useMergeRefs';
 import usePressEvents from '../../modules/usePressEvents';
 import StyleSheet from '../StyleSheet';
 import View from '../View';
-import { warnOnce } from '../../modules/warnOnce';
+//import { warnOnce } from '../../modules/warnOnce';
 
 type ViewStyle = $PropertyType<ViewProps, 'style'>;
 
@@ -34,10 +34,12 @@ type Props = $ReadOnly<{|
  * On press down, the opacity of the wrapped view is decreased, dimming it.
  */
 function TouchableOpacity(props: Props, forwardedRef): React.Node {
+  /*
   warnOnce(
     'TouchableOpacity',
     'TouchableOpacity is deprecated. Please use Pressable.'
   );
+  */
 
   const {
     activeOpacity,

--- a/packages/react-native-web/src/modules/createDOMProps/index.js
+++ b/packages/react-native-web/src/modules/createDOMProps/index.js
@@ -153,20 +153,24 @@ const createDOMProps = (elementType, props, options) => {
     ...domProps
   } = props;
 
+  /*
   if (accessibilityDisabled != null) {
     warnOnce('accessibilityDisabled', `accessibilityDisabled is deprecated.`);
   }
+  */
   const disabled = ariaDisabled || accessibilityDisabled;
 
   const role = AccessibilityUtil.propsToAriaRole(props);
 
   // ACCESSIBILITY
+  /*
   if (accessibilityActiveDescendant != null) {
     warnOnce(
       'accessibilityActiveDescendant',
       `accessibilityActiveDescendant is deprecated. Use aria-activedescendant.`
     );
   }
+  */
   const _ariaActiveDescendant =
     ariaActiveDescendant != null
       ? ariaActiveDescendant
@@ -175,129 +179,151 @@ const createDOMProps = (elementType, props, options) => {
     domProps['aria-activedescendant'] = _ariaActiveDescendant;
   }
 
+  /*
   if (accessibilityAtomic != null) {
     warnOnce(
       'accessibilityAtomic',
       `accessibilityAtomic is deprecated. Use aria-atomic.`
     );
   }
+  */
   const _ariaAtomic =
     ariaAtomic != null ? ariaActiveDescendant : accessibilityAtomic;
   if (_ariaAtomic != null) {
     domProps['aria-atomic'] = _ariaAtomic;
   }
 
+  /*
   if (accessibilityAutoComplete != null) {
     warnOnce(
       'accessibilityAutoComplete',
       `accessibilityAutoComplete is deprecated. Use aria-autocomplete.`
     );
   }
+  */
   const _ariaAutoComplete =
     ariaAutoComplete != null ? ariaAutoComplete : accessibilityAutoComplete;
   if (_ariaAutoComplete != null) {
     domProps['aria-autocomplete'] = _ariaAutoComplete;
   }
 
+  /*
   if (accessibilityBusy != null) {
     warnOnce(
       'accessibilityBusy',
       `accessibilityBusy is deprecated. Use aria-busy.`
     );
   }
+  */
   const _ariaBusy = ariaBusy != null ? ariaBusy : accessibilityBusy;
   if (_ariaBusy != null) {
     domProps['aria-busy'] = _ariaBusy;
   }
 
+  /*
   if (accessibilityChecked != null) {
     warnOnce(
       'accessibilityChecked',
       `accessibilityChecked is deprecated. Use aria-checked.`
     );
   }
+  */
   const _ariaChecked = ariaChecked != null ? ariaChecked : accessibilityChecked;
   if (_ariaChecked != null) {
     domProps['aria-checked'] = _ariaChecked;
   }
 
+  /*
   if (accessibilityColumnCount != null) {
     warnOnce(
       'accessibilityColumnCount',
       `accessibilityColumnCount is deprecated. Use aria-colcount.`
     );
   }
+  */
   const _ariaColumnCount =
     ariaColumnCount != null ? ariaColumnCount : accessibilityColumnCount;
   if (_ariaColumnCount != null) {
     domProps['aria-colcount'] = _ariaColumnCount;
   }
 
+  /*
   if (accessibilityColumnIndex != null) {
     warnOnce(
       'accessibilityColumnIndex',
       `accessibilityColumnIndex is deprecated. Use aria-colindex.`
     );
   }
+  */
   const _ariaColumnIndex =
     ariaColumnIndex != null ? ariaColumnIndex : accessibilityColumnIndex;
   if (_ariaColumnIndex != null) {
     domProps['aria-colindex'] = _ariaColumnIndex;
   }
 
+  /*
   if (accessibilityColumnSpan != null) {
     warnOnce(
       'accessibilityColumnSpan',
       `accessibilityColumnSpan is deprecated. Use aria-colspan.`
     );
   }
+  */
   const _ariaColumnSpan =
     ariaColumnSpan != null ? ariaColumnSpan : accessibilityColumnSpan;
   if (_ariaColumnSpan != null) {
     domProps['aria-colspan'] = _ariaColumnSpan;
   }
 
+  /*
   if (accessibilityControls != null) {
     warnOnce(
       'accessibilityControls',
       `accessibilityControls is deprecated. Use aria-controls.`
     );
   }
+  */
   const _ariaControls =
     ariaControls != null ? ariaControls : accessibilityControls;
   if (_ariaControls != null) {
     domProps['aria-controls'] = processIDRefList(_ariaControls);
   }
 
+  /*
   if (accessibilityCurrent != null) {
     warnOnce(
       'accessibilityCurrent',
       `accessibilityCurrent is deprecated. Use aria-current.`
     );
   }
+  */
   const _ariaCurrent = ariaCurrent != null ? ariaCurrent : accessibilityCurrent;
   if (_ariaCurrent != null) {
     domProps['aria-current'] = _ariaCurrent;
   }
 
+  /*
   if (accessibilityDescribedBy != null) {
     warnOnce(
       'accessibilityDescribedBy',
       `accessibilityDescribedBy is deprecated. Use aria-describedby.`
     );
   }
+  */
   const _ariaDescribedBy =
     ariaDescribedBy != null ? ariaDescribedBy : accessibilityDescribedBy;
   if (_ariaDescribedBy != null) {
     domProps['aria-describedby'] = processIDRefList(_ariaDescribedBy);
   }
 
+  /*
   if (accessibilityDetails != null) {
     warnOnce(
       'accessibilityDetails',
       `accessibilityDetails is deprecated. Use aria-details.`
     );
   }
+  */
   const _ariaDetails = ariaDetails != null ? ariaDetails : accessibilityDetails;
   if (_ariaDetails != null) {
     domProps['aria-details'] = _ariaDetails;
@@ -317,161 +343,189 @@ const createDOMProps = (elementType, props, options) => {
     }
   }
 
+  /*
   if (accessibilityErrorMessage != null) {
     warnOnce(
       'accessibilityErrorMessage',
       `accessibilityErrorMessage is deprecated. Use aria-errormessage.`
     );
   }
+  */
   const _ariaErrorMessage =
     ariaErrorMessage != null ? ariaErrorMessage : accessibilityErrorMessage;
   if (_ariaErrorMessage != null) {
     domProps['aria-errormessage'] = _ariaErrorMessage;
   }
 
+  /*
   if (accessibilityExpanded != null) {
     warnOnce(
       'accessibilityExpanded',
       `accessibilityExpanded is deprecated. Use aria-expanded.`
     );
   }
+  */
   const _ariaExpanded =
     ariaExpanded != null ? ariaExpanded : accessibilityExpanded;
   if (_ariaExpanded != null) {
     domProps['aria-expanded'] = _ariaExpanded;
   }
 
+  /*
   if (accessibilityFlowTo != null) {
     warnOnce(
       'accessibilityFlowTo',
       `accessibilityFlowTo is deprecated. Use aria-flowto.`
     );
   }
+  */
   const _ariaFlowTo = ariaFlowTo != null ? ariaFlowTo : accessibilityFlowTo;
   if (_ariaFlowTo != null) {
     domProps['aria-flowto'] = processIDRefList(_ariaFlowTo);
   }
 
+  /*
   if (accessibilityHasPopup != null) {
     warnOnce(
       'accessibilityHasPopup',
       `accessibilityHasPopup is deprecated. Use aria-haspopup.`
     );
   }
+  */
   const _ariaHasPopup =
     ariaHasPopup != null ? ariaHasPopup : accessibilityHasPopup;
   if (_ariaHasPopup != null) {
     domProps['aria-haspopup'] = _ariaHasPopup;
   }
 
+  /*
   if (accessibilityHidden != null) {
     warnOnce(
       'accessibilityHidden',
       `accessibilityHidden is deprecated. Use aria-hidden.`
     );
   }
+  */
   const _ariaHidden = ariaHidden != null ? ariaHidden : accessibilityHidden;
   if (_ariaHidden === true) {
     domProps['aria-hidden'] = _ariaHidden;
   }
 
+  /*
   if (accessibilityInvalid != null) {
     warnOnce(
       'accessibilityInvalid',
       `accessibilityInvalid is deprecated. Use aria-invalid.`
     );
   }
+  */
   const _ariaInvalid = ariaInvalid != null ? ariaInvalid : accessibilityInvalid;
   if (_ariaInvalid != null) {
     domProps['aria-invalid'] = _ariaInvalid;
   }
 
+  /*
   if (accessibilityKeyShortcuts != null) {
     warnOnce(
       'accessibilityKeyShortcuts',
       `accessibilityKeyShortcuts is deprecated. Use aria-keyshortcuts.`
     );
   }
+  */
   const _ariaKeyShortcuts =
     ariaKeyShortcuts != null ? ariaKeyShortcuts : accessibilityKeyShortcuts;
   if (_ariaKeyShortcuts != null) {
     domProps['aria-keyshortcuts'] = processIDRefList(_ariaKeyShortcuts);
   }
 
+  /*
   if (accessibilityLabel != null) {
     warnOnce(
       'accessibilityLabel',
       `accessibilityLabel is deprecated. Use aria-label.`
     );
   }
+  */
   const _ariaLabel = ariaLabel != null ? ariaLabel : accessibilityLabel;
   if (_ariaLabel != null) {
     domProps['aria-label'] = _ariaLabel;
   }
 
+  /*
   if (accessibilityLabelledBy != null) {
     warnOnce(
       'accessibilityLabelledBy',
       `accessibilityLabelledBy is deprecated. Use aria-labelledby.`
     );
   }
+  */
   const _ariaLabelledBy =
     ariaLabelledBy != null ? ariaLabelledBy : accessibilityLabelledBy;
   if (_ariaLabelledBy != null) {
     domProps['aria-labelledby'] = processIDRefList(_ariaLabelledBy);
   }
 
+  /*
   if (accessibilityLevel != null) {
     warnOnce(
       'accessibilityLevel',
       `accessibilityLevel is deprecated. Use aria-level.`
     );
   }
+  */
   const _ariaLevel = ariaLevel != null ? ariaLevel : accessibilityLevel;
   if (_ariaLevel != null) {
     domProps['aria-level'] = _ariaLevel;
   }
 
+  /*
   if (accessibilityLiveRegion != null) {
     warnOnce(
       'accessibilityLiveRegion',
       `accessibilityLiveRegion is deprecated. Use aria-live.`
     );
   }
+  */
   const _ariaLive = ariaLive != null ? ariaLive : accessibilityLiveRegion;
   if (_ariaLive != null) {
     domProps['aria-live'] = _ariaLive === 'none' ? 'off' : _ariaLive;
   }
 
+  /*
   if (accessibilityModal != null) {
     warnOnce(
       'accessibilityModal',
       `accessibilityModal is deprecated. Use aria-modal.`
     );
   }
+  */
   const _ariaModal = ariaModal != null ? ariaModal : accessibilityModal;
   if (_ariaModal != null) {
     domProps['aria-modal'] = _ariaModal;
   }
 
+  /*
   if (accessibilityMultiline != null) {
     warnOnce(
       'accessibilityMultiline',
       `accessibilityMultiline is deprecated. Use aria-multiline.`
     );
   }
+  */
   const _ariaMultiline =
     ariaMultiline != null ? ariaMultiline : accessibilityMultiline;
   if (_ariaMultiline != null) {
     domProps['aria-multiline'] = _ariaMultiline;
   }
 
+  /*
   if (accessibilityMultiSelectable != null) {
     warnOnce(
       'accessibilityMultiSelectable',
       `accessibilityMultiSelectable is deprecated. Use aria-multiselectable.`
     );
   }
+  */
   const _ariaMultiSelectable =
     ariaMultiSelectable != null
       ? ariaMultiSelectable
@@ -480,70 +534,82 @@ const createDOMProps = (elementType, props, options) => {
     domProps['aria-multiselectable'] = _ariaMultiSelectable;
   }
 
+  /*
   if (accessibilityOrientation != null) {
     warnOnce(
       'accessibilityOrientation',
       `accessibilityOrientation is deprecated. Use aria-orientation.`
     );
   }
+  */
   const _ariaOrientation =
     ariaOrientation != null ? ariaOrientation : accessibilityOrientation;
   if (_ariaOrientation != null) {
     domProps['aria-orientation'] = _ariaOrientation;
   }
 
+  /*
   if (accessibilityOwns != null) {
     warnOnce(
       'accessibilityOwns',
       `accessibilityOwns is deprecated. Use aria-owns.`
     );
   }
+  */
   const _ariaOwns = ariaOwns != null ? ariaOwns : accessibilityOwns;
   if (_ariaOwns != null) {
     domProps['aria-owns'] = processIDRefList(_ariaOwns);
   }
 
+  /*
   if (accessibilityPlaceholder != null) {
     warnOnce(
       'accessibilityPlaceholder',
       `accessibilityPlaceholder is deprecated. Use aria-placeholder.`
     );
   }
+  */
   const _ariaPlaceholder =
     ariaPlaceholder != null ? ariaPlaceholder : accessibilityPlaceholder;
   if (_ariaPlaceholder != null) {
     domProps['aria-placeholder'] = _ariaPlaceholder;
   }
 
+  /*
   if (accessibilityPosInSet != null) {
     warnOnce(
       'accessibilityPosInSet',
       `accessibilityPosInSet is deprecated. Use aria-posinset.`
     );
   }
+  */
   const _ariaPosInSet =
     ariaPosInSet != null ? ariaPosInSet : accessibilityPosInSet;
   if (_ariaPosInSet != null) {
     domProps['aria-posinset'] = _ariaPosInSet;
   }
 
+  /*
   if (accessibilityPressed != null) {
     warnOnce(
       'accessibilityPressed',
       `accessibilityPressed is deprecated. Use aria-pressed.`
     );
   }
+  */
   const _ariaPressed = ariaPressed != null ? ariaPressed : accessibilityPressed;
   if (_ariaPressed != null) {
     domProps['aria-pressed'] = _ariaPressed;
   }
 
+  /*
   if (accessibilityReadOnly != null) {
     warnOnce(
       'accessibilityReadOnly',
       `accessibilityReadOnly is deprecated. Use aria-readonly.`
     );
   }
+  */
   const _ariaReadOnly =
     ariaReadOnly != null ? ariaReadOnly : accessibilityReadOnly;
   if (_ariaReadOnly != null) {
@@ -558,12 +624,14 @@ const createDOMProps = (elementType, props, options) => {
     }
   }
 
+  /*
   if (accessibilityRequired != null) {
     warnOnce(
       'accessibilityRequired',
       `accessibilityRequired is deprecated. Use aria-required.`
     );
   }
+  */
   const _ariaRequired =
     ariaRequired != null ? ariaRequired : accessibilityRequired;
   if (_ariaRequired != null) {
@@ -578,20 +646,24 @@ const createDOMProps = (elementType, props, options) => {
     }
   }
 
+  /*
   if (accessibilityRole != null) {
     warnOnce('accessibilityRole', `accessibilityRole is deprecated. Use role.`);
   }
+  */
   if (role != null) {
     // 'presentation' synonym has wider browser support
     domProps['role'] = role === 'none' ? 'presentation' : role;
   }
 
+  /*
   if (accessibilityRoleDescription != null) {
     warnOnce(
       'accessibilityRoleDescription',
       `accessibilityRoleDescription is deprecated. Use aria-roledescription.`
     );
   }
+  */
   const _ariaRoleDescription =
     ariaRoleDescription != null
       ? ariaRoleDescription
@@ -600,117 +672,137 @@ const createDOMProps = (elementType, props, options) => {
     domProps['aria-roledescription'] = _ariaRoleDescription;
   }
 
+  /*
   if (accessibilityRowCount != null) {
     warnOnce(
       'accessibilityRowCount',
       `accessibilityRowCount is deprecated. Use aria-rowcount.`
     );
   }
+  */
   const _ariaRowCount =
     ariaRowCount != null ? ariaRowCount : accessibilityRowCount;
   if (_ariaRowCount != null) {
     domProps['aria-rowcount'] = _ariaRowCount;
   }
 
+  /*
   if (accessibilityRowIndex != null) {
     warnOnce(
       'accessibilityRowIndex',
       `accessibilityRowIndex is deprecated. Use aria-rowindex.`
     );
   }
+  */
   const _ariaRowIndex =
     ariaRowIndex != null ? ariaRowIndex : accessibilityRowIndex;
   if (_ariaRowIndex != null) {
     domProps['aria-rowindex'] = _ariaRowIndex;
   }
 
+  /*
   if (accessibilityRowSpan != null) {
     warnOnce(
       'accessibilityRowSpan',
       `accessibilityRowSpan is deprecated. Use aria-rowspan.`
     );
   }
+  */
   const _ariaRowSpan = ariaRowSpan != null ? ariaRowSpan : accessibilityRowSpan;
   if (_ariaRowSpan != null) {
     domProps['aria-rowspan'] = _ariaRowSpan;
   }
 
+  /*
   if (accessibilitySelected != null) {
     warnOnce(
       'accessibilitySelected',
       `accessibilitySelected is deprecated. Use aria-selected.`
     );
   }
+  */
   const _ariaSelected =
     ariaSelected != null ? ariaSelected : accessibilitySelected;
   if (_ariaSelected != null) {
     domProps['aria-selected'] = _ariaSelected;
   }
 
+  /*
   if (accessibilitySetSize != null) {
     warnOnce(
       'accessibilitySetSize',
       `accessibilitySetSize is deprecated. Use aria-setsize.`
     );
   }
+  */
   const _ariaSetSize = ariaSetSize != null ? ariaSetSize : accessibilitySetSize;
   if (_ariaSetSize != null) {
     domProps['aria-setsize'] = _ariaSetSize;
   }
 
+  /*
   if (accessibilitySort != null) {
     warnOnce(
       'accessibilitySort',
       `accessibilitySort is deprecated. Use aria-sort.`
     );
   }
+  */
   const _ariaSort = ariaSort != null ? ariaSort : accessibilitySort;
   if (_ariaSort != null) {
     domProps['aria-sort'] = _ariaSort;
   }
 
+  /*
   if (accessibilityValueMax != null) {
     warnOnce(
       'accessibilityValueMax',
       `accessibilityValueMax is deprecated. Use aria-valuemax.`
     );
   }
+  */
   const _ariaValueMax =
     ariaValueMax != null ? ariaValueMax : accessibilityValueMax;
   if (_ariaValueMax != null) {
     domProps['aria-valuemax'] = _ariaValueMax;
   }
 
+  /*
   if (accessibilityValueMin != null) {
     warnOnce(
       'accessibilityValueMin',
       `accessibilityValueMin is deprecated. Use aria-valuemin.`
     );
   }
+  */
   const _ariaValueMin =
     ariaValueMin != null ? ariaValueMin : accessibilityValueMin;
   if (_ariaValueMin != null) {
     domProps['aria-valuemin'] = _ariaValueMin;
   }
 
+  /*
   if (accessibilityValueNow != null) {
     warnOnce(
       'accessibilityValueNow',
       `accessibilityValueNow is deprecated. Use aria-valuenow.`
     );
   }
+  */
   const _ariaValueNow =
     ariaValueNow != null ? ariaValueNow : accessibilityValueNow;
   if (_ariaValueNow != null) {
     domProps['aria-valuenow'] = _ariaValueNow;
   }
 
+  /*
   if (accessibilityValueText != null) {
     warnOnce(
       'accessibilityValueText',
       `accessibilityValueText is deprecated. Use aria-valuetext.`
     );
   }
+  */
   const _ariaValueText =
     ariaValueText != null ? ariaValueText : accessibilityValueText;
   if (_ariaValueText != null) {
@@ -739,9 +831,11 @@ const createDOMProps = (elementType, props, options) => {
   ) {
     domProps.tabIndex = tabIndex;
   } else {
+    /*
     if (focusable != null) {
       warnOnce('focusable', `focusable is deprecated.`);
     }
+    */
 
     // "focusable" indicates that an element may be a keyboard tab-stop.
     if (focusable === false) {
@@ -801,9 +895,11 @@ const createDOMProps = (elementType, props, options) => {
 
   // OTHER
   // Native element ID
+  /*
   if (nativeID != null) {
     warnOnce('nativeID', `nativeID is deprecated. Use id.`);
   }
+  */
   const _id = id != null ? id : nativeID;
   if (_id != null) {
     domProps.id = _id;


### PR DESCRIPTION
Removes warnings for non-standard APIs in React Native, given there has been no upstream interest in deprecating them. And the standards-based approach to cross-platform React is instead being built into React Strict DOM.

cc @EvanBacon for Expo approval