### PR TITLE
refactor(deps): removing fbjs dependency by creating a local module for invariant and warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16569,7 +16569,6 @@
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "@react-native/normalize-colors": "^0.74.1",
-        "fbjs": "^3.0.4",
         "inline-style-prefixer": "^6.0.1",
         "memoize-one": "^6.0.0",
         "nullthrows": "^1.1.1",
@@ -25639,7 +25638,6 @@
       "requires": {
         "@babel/runtime": "^7.18.6",
         "@react-native/normalize-colors": "^0.74.1",
-        "fbjs": "^3.0.4",
         "inline-style-prefixer": "^6.0.1",
         "memoize-one": "^6.0.0",
         "nullthrows": "^1.1.1",

--- a/packages/react-native-web/package.json
+++ b/packages/react-native-web/package.json
@@ -24,7 +24,6 @@
   "dependencies": {
     "@babel/runtime": "^7.18.6",
     "@react-native/normalize-colors": "^0.74.1",
-    "fbjs": "^3.0.4",
     "inline-style-prefixer": "^6.0.1",
     "memoize-one": "^6.0.0",
     "nullthrows": "^1.1.1",

--- a/packages/react-native-web/src/exports/AppRegistry/index.js
+++ b/packages/react-native-web/src/exports/AppRegistry/index.js
@@ -13,7 +13,7 @@
 import type { Application } from './renderApplication';
 import type { ComponentType, Node } from 'react';
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from '../../modules/invariant';
 import unmountComponentAtNode from '../unmountComponentAtNode';
 import renderApplication, { getApplication } from './renderApplication';
 

--- a/packages/react-native-web/src/exports/AppRegistry/renderApplication.js
+++ b/packages/react-native-web/src/exports/AppRegistry/renderApplication.js
@@ -11,7 +11,7 @@
 import type { ComponentType, Node } from 'react';
 
 import AppContainer from './AppContainer';
-import invariant from 'fbjs/lib/invariant';
+import invariant from '../../modules/invariant';
 import renderLegacy, { hydrateLegacy, render, hydrate } from '../render';
 import StyleSheet from '../StyleSheet';
 import React from 'react';

--- a/packages/react-native-web/src/exports/AppState/index.js
+++ b/packages/react-native-web/src/exports/AppState/index.js
@@ -10,7 +10,7 @@
 
 'use client';
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from '../../modules/invariant';
 import EventEmitter from '../../vendor/react-native/vendor/emitter/EventEmitter';
 import canUseDOM from '../../modules/canUseDom';
 

--- a/packages/react-native-web/src/exports/Dimensions/index.js
+++ b/packages/react-native-web/src/exports/Dimensions/index.js
@@ -11,7 +11,7 @@
 'use client';
 
 import type { EventSubscription } from '../../vendor/react-native/vendor/emitter/EventEmitter';
-import invariant from 'fbjs/lib/invariant';
+import invariant from '../../modules/invariant';
 import canUseDOM from '../../modules/canUseDom';
 
 export type DisplayMetrics = {|

--- a/packages/react-native-web/src/exports/InteractionManager/TaskQueue.js
+++ b/packages/react-native-web/src/exports/InteractionManager/TaskQueue.js
@@ -8,7 +8,7 @@
  * @flow
  */
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from '../../modules/invariant';
 
 type SimpleTask = {|
   name: string,

--- a/packages/react-native-web/src/exports/InteractionManager/index.js
+++ b/packages/react-native-web/src/exports/InteractionManager/index.js
@@ -8,7 +8,7 @@
  * @flow
  */
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from '../../modules/invariant';
 import type { Task } from './TaskQueue';
 import TaskQueue from './TaskQueue';
 import type { EventSubscription } from '../../vendor/react-native/vendor/emitter/EventEmitter';

--- a/packages/react-native-web/src/exports/Linking/index.js
+++ b/packages/react-native-web/src/exports/Linking/index.js
@@ -8,7 +8,7 @@
  * @flow
  */
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from '../../modules/invariant';
 import canUseDOM from '../../modules/canUseDom';
 
 const initialURL = canUseDOM ? window.location.href : '';

--- a/packages/react-native-web/src/exports/ScrollView/index.js
+++ b/packages/react-native-web/src/exports/ScrollView/index.js
@@ -14,7 +14,7 @@ import type { ViewProps, ViewStyle } from '../View/types';
 
 import Dimensions from '../Dimensions';
 import dismissKeyboard from '../../modules/dismissKeyboard';
-import invariant from 'fbjs/lib/invariant';
+import invariant from '../../modules/invariant';
 import mergeRefs from '../../modules/mergeRefs';
 import Platform from '../Platform';
 import ScrollViewBase from './ScrollViewBase';

--- a/packages/react-native-web/src/exports/ScrollView/index.js
+++ b/packages/react-native-web/src/exports/ScrollView/index.js
@@ -23,7 +23,7 @@ import TextInputState from '../../modules/TextInputState';
 import UIManager from '../UIManager';
 import View from '../View';
 import React from 'react';
-import warning from 'fbjs/lib/warning';
+import warning from '../../modules/warning';
 
 type ScrollViewProps = {
   ...ViewProps,

--- a/packages/react-native-web/src/exports/Share/index.js
+++ b/packages/react-native-web/src/exports/Share/index.js
@@ -8,7 +8,7 @@
  * @flow
  */
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from '../../modules/invariant';
 
 type Content =
   | { title?: string, message?: string, url: string }

--- a/packages/react-native-web/src/exports/Touchable/ensurePositiveDelayProps.js
+++ b/packages/react-native-web/src/exports/Touchable/ensurePositiveDelayProps.js
@@ -7,7 +7,7 @@
  * @flow
  */
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from '../../modules/invariant';
 
 const ensurePositiveDelayProps = (props: any) => {
   invariant(

--- a/packages/react-native-web/src/modules/emptyFunction/index.js
+++ b/packages/react-native-web/src/modules/emptyFunction/index.js
@@ -1,0 +1,30 @@
+/* eslint-disable */
+'use strict';
+
+function makeEmptyFunction(arg) {
+  return function () {
+    return arg;
+  };
+}
+/**
+ * This function accepts and discards inputs; it has no side effects. This is
+ * primarily useful idiomatically for overridable function endpoints which
+ * always need to be callable, since JS lacks a null-call idiom ala Cocoa.
+ */
+
+var emptyFunction = function emptyFunction() {};
+
+emptyFunction.thatReturns = makeEmptyFunction;
+emptyFunction.thatReturnsFalse = makeEmptyFunction(false);
+emptyFunction.thatReturnsTrue = makeEmptyFunction(true);
+emptyFunction.thatReturnsNull = makeEmptyFunction(null);
+
+emptyFunction.thatReturnsThis = function () {
+  return this;
+};
+
+emptyFunction.thatReturnsArgument = function (arg) {
+  return arg;
+};
+
+export default emptyFunction;

--- a/packages/react-native-web/src/modules/invariant/index.js
+++ b/packages/react-native-web/src/modules/invariant/index.js
@@ -1,0 +1,50 @@
+/* eslint-disable */
+'use strict';
+
+var validateFormat =
+  process.env.NODE_ENV !== 'production'
+    ? function (format) {
+        if (format === undefined) {
+          throw new Error('invariant(...): Second argument must be a string.');
+        }
+      }
+    : function (format) {};
+
+function invariant(condition, format) {
+  for (
+    var _len = arguments.length,
+      args = new Array(_len > 2 ? _len - 2 : 0),
+      _key = 2;
+    _key < _len;
+    _key++
+  ) {
+    args[_key - 2] = arguments[_key];
+  }
+
+  validateFormat(format);
+
+  if (!condition) {
+    var error;
+
+    if (format === undefined) {
+      error = new Error(
+        'Minified exception occurred; use the non-minified dev environment ' +
+          'for the full error message and additional helpful warnings.'
+      );
+    } else {
+      var argIndex = 0;
+      error = new Error(
+        format.replace(/%s/g, function () {
+          return String(args[argIndex++]);
+        })
+      );
+      error.name = 'Invariant Violation';
+    }
+
+    error.framesToPop = 1; // Skip invariant's own stack frame.
+
+    throw error;
+  }
+}
+
+export default invariant;

--- a/packages/react-native-web/src/modules/warning/index.js
+++ b/packages/react-native-web/src/modules/warning/index.js
@@ -1,0 +1,68 @@
+/* eslint-disable */
+'use strict';
+
+import emptyFunction from '../emptyFunction';
+/**
+ * Similar to invariant but only logs a warning if the condition is not met.
+ * This can be used to log issues in development environments in critical
+ * paths. Removing the logging code for production environments will keep the
+ * same logic and follow the same code paths.
+ */
+
+function printWarning(format) {
+  for (
+    var _len = arguments.length,
+      args = new Array(_len > 1 ? _len - 1 : 0),
+      _key = 1;
+    _key < _len;
+    _key++
+  ) {
+    args[_key - 1] = arguments[_key];
+  }
+
+  var argIndex = 0;
+  var message =
+    'Warning: ' +
+    format.replace(/%s/g, function () {
+      return args[argIndex++];
+    });
+
+  if (typeof console !== 'undefined') {
+    console.error(message);
+  }
+
+  try {
+    // --- Welcome to debugging React ---
+    // This error was thrown as a convenience so that you can use this stack
+    // to find the callsite that caused this warning to fire.
+    throw new Error(message);
+  } catch (x) {}
+}
+
+var warning =
+  process.env.NODE_ENV !== 'production'
+    ? function (condition, format) {
+        if (format === undefined) {
+          throw new Error(
+            '`warning(condition, format, ...args)` requires a warning ' +
+              'message argument'
+          );
+        }
+
+        if (!condition) {
+          for (
+            var _len2 = arguments.length,
+              args = new Array(_len2 > 2 ? _len2 - 2 : 0),
+              _key2 = 2;
+            _key2 < _len2;
+            _key2++
+          ) {
+            args[_key2 - 2] = arguments[_key2];
+          }
+
+          printWarning.apply(void 0, [format].concat(args));
+        }
+      }
+    : emptyFunction;
+
+export default warning;

--- a/packages/react-native-web/src/vendor/react-native/Animated/AnimatedEvent.js
+++ b/packages/react-native-web/src/vendor/react-native/Animated/AnimatedEvent.js
@@ -13,7 +13,7 @@
 import AnimatedValue from './nodes/AnimatedValue';
 import NativeAnimatedHelper from './NativeAnimatedHelper';
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from '../../../modules/invariant';
 
 import {shouldUseNativeDriver}from  './NativeAnimatedHelper';
 

--- a/packages/react-native-web/src/vendor/react-native/Animated/NativeAnimatedHelper.js
+++ b/packages/react-native-web/src/vendor/react-native/Animated/NativeAnimatedHelper.js
@@ -21,7 +21,7 @@ import type {
 import type {AnimationConfig, EndCallback} from './animations/Animation';
 import type {InterpolationConfigType} from './nodes/AnimatedInterpolation';
 import ReactNativeFeatureFlags from '../ReactNative/ReactNativeFeatureFlags';
-import invariant from 'fbjs/lib/invariant';
+import invariant from '../../../modules/invariant';
 import RCTDeviceEventEmitter from '../EventEmitter/RCTDeviceEventEmitter';
 import type {EventSubscription} from '../vendor/emitter/EventEmitter';
 

--- a/packages/react-native-web/src/vendor/react-native/Animated/animations/SpringAnimation.js
+++ b/packages/react-native-web/src/vendor/react-native/Animated/animations/SpringAnimation.js
@@ -17,7 +17,7 @@ import type AnimatedInterpolation from '../nodes/AnimatedInterpolation';
 import Animation from './Animation';
 import SpringConfig from '../SpringConfig';
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from '../../../../modules/invariant';
 
 import {shouldUseNativeDriver} from '../NativeAnimatedHelper';
 

--- a/packages/react-native-web/src/vendor/react-native/Animated/nodes/AnimatedInterpolation.js
+++ b/packages/react-native-web/src/vendor/react-native/Animated/nodes/AnimatedInterpolation.js
@@ -17,7 +17,7 @@ import type AnimatedNode from './AnimatedNode';
 import AnimatedWithChildren from './AnimatedWithChildren';
 import NativeAnimatedHelper from '../NativeAnimatedHelper';
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from '../../../../modules/invariant';
 import normalizeColor from '@react-native/normalize-colors';
 
 import type {PlatformConfig} from '../AnimatedPlatformConfig';

--- a/packages/react-native-web/src/vendor/react-native/Animated/nodes/AnimatedNode.js
+++ b/packages/react-native-web/src/vendor/react-native/Animated/nodes/AnimatedNode.js
@@ -13,7 +13,7 @@
 import NativeAnimatedHelper from '../NativeAnimatedHelper';
 
 const NativeAnimatedAPI = NativeAnimatedHelper.API;
-import invariant from 'fbjs/lib/invariant';
+import invariant from '../../../../modules/invariant';
 
 import type {PlatformConfig} from '../AnimatedPlatformConfig';
 

--- a/packages/react-native-web/src/vendor/react-native/Animated/nodes/AnimatedProps.js
+++ b/packages/react-native-web/src/vendor/react-native/Animated/nodes/AnimatedProps.js
@@ -15,7 +15,7 @@ import AnimatedNode from './AnimatedNode';
 import AnimatedStyle from './AnimatedStyle';
 import NativeAnimatedHelper from '../NativeAnimatedHelper';
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from '../../../../modules/invariant';
 
 class AnimatedProps extends AnimatedNode {
   _props: Object;

--- a/packages/react-native-web/src/vendor/react-native/Animated/nodes/AnimatedValueXY.js
+++ b/packages/react-native-web/src/vendor/react-native/Animated/nodes/AnimatedValueXY.js
@@ -13,7 +13,7 @@
 import AnimatedValue from './AnimatedValue';
 import AnimatedWithChildren from './AnimatedWithChildren';
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from '../../../../modules/invariant';
 
 type ValueXYListenerCallback = (value: {
   x: number,

--- a/packages/react-native-web/src/vendor/react-native/EventEmitter/NativeEventEmitter.js
+++ b/packages/react-native-web/src/vendor/react-native/EventEmitter/NativeEventEmitter.js
@@ -16,7 +16,7 @@ import {
 } from '../vendor/emitter/EventEmitter';
 import Platform from '../../../exports/Platform';
 import RCTDeviceEventEmitter from './RCTDeviceEventEmitter';
-import invariant from 'fbjs/lib/invariant';
+import invariant from '../../../modules/invariant';
 
 type NativeModule = $ReadOnly<{
   addListener: (eventType: string) => void,

--- a/packages/react-native-web/src/vendor/react-native/FlatList/index.js
+++ b/packages/react-native-web/src/vendor/react-native/FlatList/index.js
@@ -12,7 +12,7 @@ import View, { type ViewProps } from '../../../exports/View';
 import StyleSheet from '../../../exports/StyleSheet';
 import deepDiffer from '../deepDiffer';
 import Platform from '../../../exports/Platform';
-import invariant from 'fbjs/lib/invariant';
+import invariant from '../../../modules/invariant';
 import * as React from 'react';
 
 type ScrollViewNativeComponent = any;

--- a/packages/react-native-web/src/vendor/react-native/PooledClass/index.js
+++ b/packages/react-native-web/src/vendor/react-native/PooledClass/index.js
@@ -9,8 +9,6 @@
  * From React 16.0.0
  */
 
-import invariant from 'fbjs/lib/invariant';
-
 var twoArgumentPooler = function(a1, a2) {
   var Klass = this;
   if (Klass.instancePool.length) {

--- a/packages/react-native-web/src/vendor/react-native/TurboModule/TurboModuleRegistry.js
+++ b/packages/react-native-web/src/vendor/react-native/TurboModule/TurboModuleRegistry.js
@@ -11,7 +11,7 @@
 'use strict';
 
 import type {TurboModule} from './RCTExport';
-import invariant from 'fbjs/lib/invariant';
+import invariant from '../../../modules/invariant';
 
 export function get<T: TurboModule>(name: string): ?T {
   return null;

--- a/packages/react-native-web/src/vendor/react-native/ViewabilityHelper/index.js
+++ b/packages/react-native-web/src/vendor/react-native/ViewabilityHelper/index.js
@@ -12,7 +12,7 @@
 
 import type {FrameMetricProps} from '../VirtualizedList/VirtualizedListProps';
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from '../../../modules/invariant';
 
 export type ViewToken = {
   item: any,

--- a/packages/react-native-web/src/vendor/react-native/VirtualizedList/CellRenderMask.js
+++ b/packages/react-native-web/src/vendor/react-native/VirtualizedList/CellRenderMask.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from '../../../modules/invariant';
 
 export type CellRegion = {
   first: number,

--- a/packages/react-native-web/src/vendor/react-native/VirtualizedList/ChildListCollection.js
+++ b/packages/react-native-web/src/vendor/react-native/VirtualizedList/ChildListCollection.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from '../../../modules/invariant';
 
 export default class ChildListCollection<TList> {
   _cellKeyToChildren: Map<string, Set<TList>> = new Map();

--- a/packages/react-native-web/src/vendor/react-native/VirtualizedList/StateSafePureComponent.js
+++ b/packages/react-native-web/src/vendor/react-native/VirtualizedList/StateSafePureComponent.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-import invariant from 'fbjs/lib/invariant';
+import invariant from '../../../modules/invariant';
 import * as React from 'react';
 
 /**

--- a/packages/react-native-web/src/vendor/react-native/VirtualizedList/VirtualizedListCellRenderer.js
+++ b/packages/react-native-web/src/vendor/react-native/VirtualizedList/VirtualizedListCellRenderer.js
@@ -17,7 +17,7 @@ import type {CellRendererProps, RenderItemType} from './VirtualizedListProps';
 import View, { type ViewProps } from '../../../exports/View';
 import StyleSheet from '../../../exports/StyleSheet';
 import {VirtualizedListCellContextProvider} from './VirtualizedListContext.js';
-import invariant from 'fbjs/lib/invariant';
+import invariant from '../../../modules/invariant';
 import * as React from 'react';
 
 type ViewStyleProp = $PropertyType<ViewProps, 'style'>;

--- a/packages/react-native-web/src/vendor/react-native/VirtualizedList/index.js
+++ b/packages/react-native-web/src/vendor/react-native/VirtualizedList/index.js
@@ -46,7 +46,7 @@ import {
   computeWindowedRenderLimits,
   keyExtractor as defaultKeyExtractor,
 } from '../VirtualizeUtils';
-import invariant from 'fbjs/lib/invariant';
+import invariant from '../../../modules/invariant';
 import nullthrows from 'nullthrows';
 import * as React from 'react';
 

--- a/packages/react-native-web/src/vendor/react-native/VirtualizedSectionList/index.js
+++ b/packages/react-native-web/src/vendor/react-native/VirtualizedSectionList/index.js
@@ -12,7 +12,7 @@ import type {ViewToken} from '../ViewabilityHelper';
 import View from '../../../exports/View';
 import VirtualizedList from '../VirtualizedList';
 import {keyExtractor as defaultKeyExtractor} from '../VirtualizeUtils';
-import invariant from 'fbjs/lib/invariant';
+import invariant from '../../../modules/invariant';
 import * as React from 'react';
 
 type Item = any;


### PR DESCRIPTION
As part of https://github.com/necolas/react-native-web/issues/2333, `invariant` and `warning` are the last two dependencies in the project used from `fbjs`.

In this PR:
- Local module for `invariant` and replacing the imports
- Local module for `warning` which had another dependency of `emptyFunction` hence it has been added as well.
- `fbjs` dependency has been removed from `packages/react-native-web/package.json`.

I can still see `fbjs` in the main `package-lock.json` as there are other packages within the repo that have `react-native-web` installed as a dependency, hence it might potentially be removed once that dependency is upgraded as well.

Ps: I did the removal of warning in the same PR as it was fairly small, but happy to split this up in another PR if needed.