### PR TITLE
Add Image.resolveAssetSource

### DIFF
--- a/packages/react-native-web/src/exports/Image/index.js
+++ b/packages/react-native-web/src/exports/Image/index.js
@@ -167,6 +167,12 @@ interface ImageStatics {
     failure: () => void
   ) => void;
   prefetch: (uri: string) => Promise<void>;
+  resolveAssetSource: (source: $PropertyType<ImageProps, 'source'>) => {
+    height: ?number,
+    width: ?number,
+    scale: number,
+    uri: string
+  };
   queryCache: (
     uris: Array<string>
   ) => Promise<{| [uri: string]: 'disk/memory' |}>;
@@ -373,6 +379,30 @@ ImageWithStatics.prefetch = function (uri) {
 
 ImageWithStatics.queryCache = function (uris) {
   return ImageLoader.queryCache(uris);
+};
+
+ImageWithStatics.resolveAssetSource = function (source) {
+  if (typeof source !== 'number') {
+    throw new Error(
+      'May only call Image.resolveAssetSource with images included in the asset registry'
+    );
+  }
+
+  const asset = getAssetByID(source);
+  const uri = resolveAssetUri(source);
+
+  if (!asset || !uri) {
+    throw new Error(
+      'Unable to find requested resource in asset registry - ' + source
+    );
+  }
+
+  return {
+    height: asset.height,
+    width: asset.width,
+    uri,
+    scale: asset.scales[0]
+  };
 };
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
Add a web shim for Image.resolveAssetSource, as documented here https://reactnative.dev/docs/image#resolveassetsource

I was unable to get tests to run locally on my machine, but ran prettier and made sure that eslint and flow are happy. 