### PR TITLE
fix: fix weakmap error when create stylesheet

### DIFF
--- a/packages/react-native-web/src/exports/StyleSheet/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/StyleSheet/__tests__/index-test.js
@@ -133,6 +133,19 @@ describe('StyleSheet', () => {
       expect(() => StyleSheet.flatten([null, false, undefined])).not.toThrow();
     });
 
+    test('should not fail on single flatten style object', () => {
+      const style = StyleSheet.create({
+        opacity: 1,
+        position: 'absolute'
+      });
+      expect(style).toMatchInlineSnapshot(`
+        {
+          "opacity": 1,
+          "position": "absolute",
+        }
+      `);
+    });
+
     test('should recursively flatten arrays', () => {
       const style = StyleSheet.flatten([
         null,

--- a/packages/react-native-web/src/exports/StyleSheet/index.js
+++ b/packages/react-native-web/src/exports/StyleSheet/index.js
@@ -80,7 +80,7 @@ function create<T: Object>(styles: T): $ReadOnly<T> {
   Object.keys(styles).forEach((key) => {
     const styleObj = styles[key];
     // Only compile at runtime if the style is not already compiled
-    if (styleObj != null && styleObj.$$css !== true) {
+    if (styleObj != null && styleObj.$$css !== true && typeof(styleObj) === 'object') {
       let compiledStyles;
       if (key.indexOf('$raw') > -1) {
         compiledStyles = compileAndInsertReset(styleObj, key.split('$raw')[0]);


### PR DESCRIPTION
`react-native-web` use `WeakMap` in creating `StyleSheet`. Since keys of `WeakMap` must be objects, it raise an error when input style is a one level object. Fix this error by skip the non-object value.