### PR TITLE
Add ...children rest parameter to unstable_createElement

### DIFF
--- a/packages/react-native-web/src/exports/createElement/index.js
+++ b/packages/react-native-web/src/exports/createElement/index.js
@@ -14,7 +14,7 @@ import createDOMProps from '../../modules/createDOMProps';
 import React from 'react';
 import { LocaleProvider } from '../../modules/useLocale';
 
-const createElement = (component, props, options) => {
+const createElement = (component, props, options, ...children) => {
   // Use equivalent platform elements where possible.
   let accessibilityComponent;
   if (component && component.constructor === String) {
@@ -24,7 +24,7 @@ const createElement = (component, props, options) => {
   const Component = accessibilityComponent || component;
   const domProps = createDOMProps(Component, props, options);
 
-  const element = React.createElement(Component, domProps);
+  const element = React.createElement(Component, domProps, ...children);
 
   // Update locale context if element's writing direction prop changes
   const elementWithLocaleProvider = domProps.dir ? (


### PR DESCRIPTION
Mirror `React.createElement(component, props, ...children)` as close as possible without breaking current implementation of `unstable_createElement`.

This provides a way forward for passing children via the rest parameter, which allows a variable number of a children without warning about missing `key` prop.