### PR TITLE
inline-style-prefixer version bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "gen-flow-files": "^0.4.11",
         "glob": "^8.0.3",
         "husky": "^8.0.0",
-        "inline-style-prefixer": "^6.0.0",
+        "inline-style-prefixer": "^7.0.1",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "lint-staged": "^13.0.3",
@@ -7368,7 +7368,8 @@
     "node_modules/fast-loops": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/fast-loops/-/fast-loops-1.1.4.tgz",
-      "integrity": "sha512-8dbd3XWoKCTms18ize6JmQF1SFnnfj5s0B7rRry22EofgMu7B6LKHVh+XfFqFGsqnbH54xgeO83PzpKI+ODhlg=="
+      "integrity": "sha512-8dbd3XWoKCTms18ize6JmQF1SFnnfj5s0B7rRry22EofgMu7B6LKHVh+XfFqFGsqnbH54xgeO83PzpKI+ODhlg==",
+      "license": "MIT"
     },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
@@ -8374,11 +8375,13 @@
       "license": "ISC"
     },
     "node_modules/inline-style-prefixer": {
-      "version": "6.0.4",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-7.0.1.tgz",
+      "integrity": "sha512-lhYo5qNTQp3EvSSp3sRvXMbVQTLrvGV6DycRMJ5dm2BLMiJ30wpXKdDdgX+GmJZ5uQMucwRKHamXSst3Sj/Giw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "css-in-js-utils": "^3.1.0",
-        "fast-loops": "^1.1.3"
+        "css-in-js-utils": "^3.1.0"
       }
     },
     "node_modules/internal-slot": {
@@ -16541,6 +16544,16 @@
       "integrity": "sha512-2UiwS6G7XKJvpo0X5OFkzGjHGFuNx9J+DgEG8TEmm+X5S0z6EB59W11RDEZghdKzsQzVbs1jB+2VHBuVgjMTiw==",
       "dev": true
     },
+    "packages/benchmarks/node_modules/inline-style-prefixer": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-6.0.4.tgz",
+      "integrity": "sha512-FwXmZC2zbeeS7NzGjJ6pAiqRhXR0ugUShSNb6GApMl6da0/XGc4MOJsoWAywia52EEWbXNSy0pzkwz/+Y+swSg==",
+      "license": "MIT",
+      "dependencies": {
+        "css-in-js-utils": "^3.1.0",
+        "fast-loops": "^1.1.3"
+      }
+    },
     "packages/benchmarks/node_modules/react-native-web": {
       "version": "0.18.10",
       "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.18.10.tgz",
@@ -16615,6 +16628,16 @@
       "devDependencies": {
         "@babel/core": "^7.18.6",
         "@babel/preset-flow": "^7.18.6"
+      }
+    },
+    "packages/react-native-web/node_modules/inline-style-prefixer": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-6.0.4.tgz",
+      "integrity": "sha512-FwXmZC2zbeeS7NzGjJ6pAiqRhXR0ugUShSNb6GApMl6da0/XGc4MOJsoWAywia52EEWbXNSy0pzkwz/+Y+swSg==",
+      "license": "MIT",
+      "dependencies": {
+        "css-in-js-utils": "^3.1.0",
+        "fast-loops": "^1.1.3"
       }
     }
   },
@@ -19678,6 +19701,15 @@
           "integrity": "sha512-2UiwS6G7XKJvpo0X5OFkzGjHGFuNx9J+DgEG8TEmm+X5S0z6EB59W11RDEZghdKzsQzVbs1jB+2VHBuVgjMTiw==",
           "dev": true
         },
+        "inline-style-prefixer": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-6.0.4.tgz",
+          "integrity": "sha512-FwXmZC2zbeeS7NzGjJ6pAiqRhXR0ugUShSNb6GApMl6da0/XGc4MOJsoWAywia52EEWbXNSy0pzkwz/+Y+swSg==",
+          "requires": {
+            "css-in-js-utils": "^3.1.0",
+            "fast-loops": "^1.1.3"
+          }
+        },
         "react-native-web": {
           "version": "0.18.10",
           "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.18.10.tgz",
@@ -22100,10 +22132,12 @@
       "dev": true
     },
     "inline-style-prefixer": {
-      "version": "6.0.4",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-7.0.1.tgz",
+      "integrity": "sha512-lhYo5qNTQp3EvSSp3sRvXMbVQTLrvGV6DycRMJ5dm2BLMiJ30wpXKdDdgX+GmJZ5uQMucwRKHamXSst3Sj/Giw==",
+      "dev": true,
       "requires": {
-        "css-in-js-utils": "^3.1.0",
-        "fast-loops": "^1.1.3"
+        "css-in-js-utils": "^3.1.0"
       }
     },
     "internal-slot": {
@@ -25645,6 +25679,17 @@
         "nullthrows": "^1.1.1",
         "postcss-value-parser": "^4.2.0",
         "styleq": "^0.1.3"
+      },
+      "dependencies": {
+        "inline-style-prefixer": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-6.0.4.tgz",
+          "integrity": "sha512-FwXmZC2zbeeS7NzGjJ6pAiqRhXR0ugUShSNb6GApMl6da0/XGc4MOJsoWAywia52EEWbXNSy0pzkwz/+Y+swSg==",
+          "requires": {
+            "css-in-js-utils": "^3.1.0",
+            "fast-loops": "^1.1.3"
+          }
+        }
       }
     },
     "react-native-web-docs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8378,7 +8378,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-7.0.1.tgz",
       "integrity": "sha512-lhYo5qNTQp3EvSSp3sRvXMbVQTLrvGV6DycRMJ5dm2BLMiJ30wpXKdDdgX+GmJZ5uQMucwRKHamXSst3Sj/Giw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "css-in-js-utils": "^3.1.0"
@@ -22125,7 +22124,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-7.0.1.tgz",
       "integrity": "sha512-lhYo5qNTQp3EvSSp3sRvXMbVQTLrvGV6DycRMJ5dm2BLMiJ30wpXKdDdgX+GmJZ5uQMucwRKHamXSst3Sj/Giw==",
-      "dev": true,
       "requires": {
         "css-in-js-utils": "^3.1.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16583,7 +16583,7 @@
         "@babel/runtime": "^7.18.6",
         "@react-native/normalize-colors": "^0.74.1",
         "fbjs": "^3.0.4",
-        "inline-style-prefixer": "^6.0.1",
+        "inline-style-prefixer": "^7.0.1",
         "memoize-one": "^6.0.0",
         "nullthrows": "^1.1.1",
         "postcss-value-parser": "^4.2.0",
@@ -16628,16 +16628,6 @@
       "devDependencies": {
         "@babel/core": "^7.18.6",
         "@babel/preset-flow": "^7.18.6"
-      }
-    },
-    "packages/react-native-web/node_modules/inline-style-prefixer": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-6.0.4.tgz",
-      "integrity": "sha512-FwXmZC2zbeeS7NzGjJ6pAiqRhXR0ugUShSNb6GApMl6da0/XGc4MOJsoWAywia52EEWbXNSy0pzkwz/+Y+swSg==",
-      "license": "MIT",
-      "dependencies": {
-        "css-in-js-utils": "^3.1.0",
-        "fast-loops": "^1.1.3"
       }
     }
   },
@@ -25674,22 +25664,11 @@
         "@babel/runtime": "^7.18.6",
         "@react-native/normalize-colors": "^0.74.1",
         "fbjs": "^3.0.4",
-        "inline-style-prefixer": "^6.0.1",
+        "inline-style-prefixer": "^7.0.1",
         "memoize-one": "^6.0.0",
         "nullthrows": "^1.1.1",
         "postcss-value-parser": "^4.2.0",
         "styleq": "^0.1.3"
-      },
-      "dependencies": {
-        "inline-style-prefixer": {
-          "version": "6.0.4",
-          "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-6.0.4.tgz",
-          "integrity": "sha512-FwXmZC2zbeeS7NzGjJ6pAiqRhXR0ugUShSNb6GApMl6da0/XGc4MOJsoWAywia52EEWbXNSy0pzkwz/+Y+swSg==",
-          "requires": {
-            "css-in-js-utils": "^3.1.0",
-            "fast-loops": "^1.1.3"
-          }
-        }
       }
     },
     "react-native-web-docs": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "gen-flow-files": "^0.4.11",
     "glob": "^8.0.3",
     "husky": "^8.0.0",
-    "inline-style-prefixer": "^6.0.0",
+    "inline-style-prefixer": "^7.0.1",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "lint-staged": "^13.0.3",

--- a/packages/react-native-web/package.json
+++ b/packages/react-native-web/package.json
@@ -25,7 +25,7 @@
     "@babel/runtime": "^7.18.6",
     "@react-native/normalize-colors": "^0.74.1",
     "fbjs": "^3.0.4",
-    "inline-style-prefixer": "^6.0.1",
+    "inline-style-prefixer": "^7.0.1",
     "memoize-one": "^6.0.0",
     "nullthrows": "^1.1.1",
     "postcss-value-parser": "^4.2.0",

--- a/packages/react-native-web/src/modules/prefixStyles/static.js
+++ b/packages/react-native-web/src/modules/prefixStyles/static.js
@@ -1,4 +1,3 @@
-import backgroundClip from 'inline-style-prefixer/lib/plugins/backgroundClip';
 import crossFade from 'inline-style-prefixer/lib/plugins/crossFade';
 import cursor from 'inline-style-prefixer/lib/plugins/cursor';
 import filter from 'inline-style-prefixer/lib/plugins/filter';
@@ -15,7 +14,6 @@ const wmms = ['Webkit', 'Moz', 'ms'];
 
 export default {
   plugins: [
-    backgroundClip,
     crossFade,
     cursor,
     filter,


### PR DESCRIPTION
react-native-web is polluted by https://github.com/robinweser/fast-loops/issues/18

It can be easily fixed by upgrading the inline-style-prefixer to the 7.0.1 version, which deletes redundant fast-loops dependency, that is causing the pollution. Relevant [issue](https://github.com/robinweser/inline-style-prefixer/issues/233)

I deleted backgroundClip import as it has been deleted from the inline-style-prefixer package. Relevant [PR](https://github.com/robinweser/inline-style-prefixer/pull/221)