### PR TITLE
fix: `Animated.loop` and `Animated.sequence` crash if `resetBeforeIteration` is `false`, original author asyler (from PR 44031 on RN repo)

### DIFF
--- a/packages/react-native-web/src/vendor/react-native/Animated/AnimatedImplementation.js
+++ b/packages/react-native-web/src/vendor/react-native/Animated/AnimatedImplementation.js
@@ -318,6 +318,8 @@ const sequence = function (
         current++;
 
         if (current === animations.length) {
+          // if the start is called, even without a reset, it should start from the beginning
+          current = 0;
           callback && callback(result);
           return;
         }


### PR DESCRIPTION
Summary
---

This PR fixes `Animated.loop` and `Animated.sequence` combination usage crash if `resetBeforeIteration` param for `loop` is `false`:
```js
TypeError: can't access property "start", animations[current] is undefined
```

original author of fix [asyler](https://github.com/asyler) (from PR [44031](https://github.com/facebook/react-native/pull/44031) of RN repo)

tests are included with fix

Related issues
---

https://github.com/facebook/react-native/issues/43120
https://github.com/facebook/react-native/issues/37611
