### PR TITLE
ModalPortal - Update for new react-dom export

### DIFF
--- a/packages/react-native-web/src/exports/Modal/ModalPortal.js
+++ b/packages/react-native-web/src/exports/Modal/ModalPortal.js
@@ -9,7 +9,7 @@
  */
 
 import * as React from 'react';
-import ReactDOM from 'react-dom';
+import {createPortal} from "react-dom";
 import canUseDOM from '../../modules/canUseDom';
 
 export type ModalPortalProps = {|
@@ -41,7 +41,7 @@ function ModalPortal(props: ModalPortalProps): React.Node {
   }, []);
 
   return elementRef.current && canUseDOM
-    ? ReactDOM.createPortal(children, elementRef.current)
+    ? createPortal(children, elementRef.current)
     : null;
 }
 


### PR DESCRIPTION
In our repo we needed to make this change in order for the Modal component to continue working with React/ReactDOM 19.1.

This pull request changes the `ModalPortal` implementation in `packages/react-native-web/src/exports/Modal/ModalPortal.js` by replacing the `ReactDOM` import with `createPortal` directly from `react-dom`. This change streamlines the code and ensures consistency in how portals are created.

Code simplification:

* [`packages/react-native-web/src/exports/Modal/ModalPortal.js`](diffhunk://#diff-01fcebb5018e1aca7afdd9e60c9e7a83fcade58e4d5d25982782ffad917f8dc5L12-R12): Replaced the `ReactDOM` import with `createPortal` from `react-dom` and updated the portal creation logic to use `createPortal` directly. [[1]](diffhunk://#diff-01fcebb5018e1aca7afdd9e60c9e7a83fcade58e4d5d25982782ffad917f8dc5L12-R12) [[2]](diffhunk://#diff-01fcebb5018e1aca7afdd9e60c9e7a83fcade58e4d5d25982782ffad917f8dc5L44-R44)