### PR TITLE
Fix memory leak with Animated API

### DIFF
--- a/packages/react-native-web/src/vendor/react-native/Animated/nodes/AnimatedProps.js
+++ b/packages/react-native-web/src/vendor/react-native/Animated/nodes/AnimatedProps.js
@@ -78,6 +78,7 @@ class AnimatedProps extends AnimatedNode {
     if (this.__isNative && this._animatedView) {
       this.__disconnectAnimatedView();
     }
+    this._animatedView = null;
     for (const key in this._props) {
       const value = this._props[key];
       if (value instanceof AnimatedNode) {


### PR DESCRIPTION
### Summary
While working with `@react-navigation` package I noticed a leak that was leaving multiple `Detached <div>` instances in the memory while using `Animated API` on web. They were never garbage collected.

After a [week-long investigation](https://github.com/react-navigation/react-navigation/issues/12702) I finally found the root cause for the problem. It turned out that `_animatedView` instance was never set to `null`, even after detaching the element. It turned out that this problem [has already been solved](https://github.com/facebook/react-native/blob/ce8fe490db7556421736bdaf8c01dba98fb53e36/packages/react-native/Libraries/Animated/nodes/AnimatedProps.js#L170) in the `react-native` repository. But since `react-native-web` uses an older version of React Native it was not reflected in the `vendor` directory.

My suggestion is to `cherry-pick` this solution also to some other versions of `react-native-web` (to v19 and v20), since I noticed it there, too.