### PR TITLE
[feat] Support title property for all elements

### DIFF
--- a/packages/react-native-web/src/exports/Pressable/__tests__/index-test.js
+++ b/packages/react-native-web/src/exports/Pressable/__tests__/index-test.js
@@ -342,4 +342,11 @@ describe('components/Pressable', () => {
       expect(container.firstChild).toMatchSnapshot();
     });
   });
+
+  describe('prop "title"', () => {
+    test('value is set', () => {
+      const { container } = render(<Pressable title="123" />);
+      expect(container.firstChild).toHaveProperty('title', '123');
+    });
+  });
 });

--- a/packages/react-native-web/src/modules/forwardedProps/index.js
+++ b/packages/react-native-web/src/modules/forwardedProps/index.js
@@ -16,6 +16,7 @@ export const defaultProps = {
   suppressHydrationWarning: true,
   tabIndex: true,
   testID: true,
+  title: true,
   // @deprecated
   focusable: true,
   nativeID: true


### PR DESCRIPTION
the `title` property is used in web for describing `<button />` without text (for example only icons), that is used additionally to the `aria-label`. This is because the `aria-label` is only available for the screen readers but not for the regular user, the title will also appear for the regular user.