### PR TITLE
Modal: Significantly improve animation

### DIFF
--- a/packages/react-native-web/src/exports/Modal/ModalAnimation.js
+++ b/packages/react-native-web/src/exports/Modal/ModalAnimation.js
@@ -12,7 +12,7 @@ import * as React from 'react';
 import StyleSheet from '../StyleSheet';
 import createElement from '../createElement';
 
-const ANIMATION_DURATION = 300;
+const ANIMATION_DURATION = 250;
 
 function getAnimationStyle(animationType, visible) {
   if (animationType === 'slide') {
@@ -100,12 +100,12 @@ const styles = StyleSheet.create({
   },
   animatedIn: {
     animationDuration: `${ANIMATION_DURATION}ms`,
-    animationTimingFunction: 'ease-in'
+    animationTimingFunction: 'cubic-bezier(0.215, 0.61, 0.355, 1)'
   },
   animatedOut: {
     pointerEvents: 'none',
     animationDuration: `${ANIMATION_DURATION}ms`,
-    animationTimingFunction: 'ease-out'
+    animationTimingFunction: 'cubic-bezier(0.47, 0, 0.745, 0.715)'
   },
   fadeIn: {
     opacity: 1,


### PR DESCRIPTION
`ease-in` and `ease-out` were mixed up, making the animation jarring, as it would accelerate faster towards the destination.

The defined `cubic-bezier` animations now used are approximately equivalent to using `Easing.out(Easing.cubic)` for the animation in and `Easing.in(Easing.sin)` for the animation out.

Before:

https://github.com/user-attachments/assets/ab5c6bee-c1f6-4849-988e-8dbe78666f85

After:

https://github.com/user-attachments/assets/181f1a39-b745-4713-ba92-f23287d20165